### PR TITLE
Leave unset origin fields on readings alone, avoid overflow on timest…

### DIFF
--- a/src/c/device.c
+++ b/src/c/device.c
@@ -12,6 +12,7 @@
 #include "parson.h"
 #include "data.h"
 #include "edgex_rest.h"
+#include "edgex_time.h"
 
 #include <inttypes.h>
 #include <string.h>
@@ -480,7 +481,7 @@ static int runOneGet
   )
   {
     edgex_error err = EDGEX_OK;
-    uint64_t timenow = (uint64_t)time (NULL) * 1000;
+    uint64_t timenow = edgex_device_millitime ();
     edgex_reading *rdgs = malloc (nops * sizeof (edgex_reading));
     *reply = json_value_init_object ();
     JSON_Object *jobj = json_value_get_object (*reply);

--- a/src/c/device.c
+++ b/src/c/device.c
@@ -480,9 +480,7 @@ static int runOneGet
   )
   {
     edgex_error err = EDGEX_OK;
-    uint64_t timenow = time (NULL) * 1000UL;
-    uint64_t origin =
-      (nops == 1 && results[0].origin) ? results[0].origin : timenow;
+    uint64_t timenow = (uint64_t)time (NULL) * 1000;
     edgex_reading *rdgs = malloc (nops * sizeof (edgex_reading));
     *reply = json_value_init_object ();
     JSON_Object *jobj = json_value_get_object (*reply);
@@ -501,13 +499,13 @@ static int runOneGet
         requests[i].devobj->properties->value,
         requests[i].ro->mappings
       );
-      rdgs[i].origin = results[i].origin ? results[i].origin : timenow;
+      rdgs[i].origin = results[i].origin;
       rdgs[i].next = (i == nops - 1) ? NULL : rdgs + i + 1;
       json_object_set_string (jobj, rdgs[i].name, rdgs[i].value);
     }
     edgex_event_free (edgex_data_client_add_event
-                        (svc->logger, &svc->config.endpoints, dev->name, origin,
-                         rdgs, &err));
+                        (svc->logger, &svc->config.endpoints, dev->name,
+                         timenow, rdgs, &err));
 
     for (uint32_t i = 0; i < nops; i++)
     {

--- a/src/c/devman.c
+++ b/src/c/devman.c
@@ -10,6 +10,7 @@
 #include "profiles.h"
 #include "metadata.h"
 #include "edgex_rest.h"
+#include "edgex_time.h"
 
 #include <string.h>
 #include <stdlib.h>
@@ -65,7 +66,7 @@ char * edgex_device_add_device
   {
     if (newaddr->origin == 0)
     {
-      newaddr->origin = (uint64_t)time (NULL) * 1000;
+      newaddr->origin = edgex_device_millitime ();
     }
     newaddr->id = edgex_metadata_client_create_addressable
       (svc->logger, &svc->config.endpoints, newaddr, err);

--- a/src/c/devman.c
+++ b/src/c/devman.c
@@ -65,7 +65,7 @@ char * edgex_device_add_device
   {
     if (newaddr->origin == 0)
     {
-      newaddr->origin = time (NULL) * 1000UL;
+      newaddr->origin = (uint64_t)time (NULL) * 1000;
     }
     newaddr->id = edgex_metadata_client_create_addressable
       (svc->logger, &svc->config.endpoints, newaddr, err);

--- a/src/c/edgex_time.c
+++ b/src/c/edgex_time.c
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2018
+ * IoTech Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#include <time.h>
+#include "edgex_time.h"
+
+uint64_t edgex_device_millitime()
+{
+  return (uint64_t)time (NULL) * EDGEX_MILLIS;
+}

--- a/src/c/edgex_time.h
+++ b/src/c/edgex_time.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2018
+ * IoTech Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#ifndef _EDGEX_DEVICE_EX_TIME_H_
+#define _EDGEX_DEVICE_EX_TIME_H_ 1
+
+#include <inttypes.h>
+
+#define EDGEX_MILLIS 1000
+
+extern uint64_t edgex_device_millitime(void);
+
+#endif

--- a/src/c/profiles.c
+++ b/src/c/profiles.c
@@ -11,6 +11,7 @@
 #include "metadata.h"
 #include "data.h"
 #include "edgex_rest.h"
+#include "edgex_time.h"
 #include "errorlist.h"
 
 #include <dirent.h>
@@ -32,7 +33,7 @@ static void generate_value_descriptors
   const edgex_deviceprofile *dp
 )
 {
-  uint64_t timenow = (uint64_t)time (NULL) * 1000;
+  uint64_t timenow = edgex_device_millitime ();
 
   for (edgex_deviceobject *res = dp->device_resources; res; res = res->next)
   {

--- a/src/c/profiles.c
+++ b/src/c/profiles.c
@@ -32,7 +32,7 @@ static void generate_value_descriptors
   const edgex_deviceprofile *dp
 )
 {
-  uint64_t timenow = time (NULL) * 1000UL;
+  uint64_t timenow = (uint64_t)time (NULL) * 1000;
 
   for (edgex_deviceobject *res = dp->device_resources; res; res = res->next)
   {

--- a/src/c/service.c
+++ b/src/c/service.c
@@ -262,7 +262,7 @@ void edgex_device_service_start
 
   if (ds == NULL)
   {
-    uint64_t millis = time (NULL) * 1000;
+    uint64_t millis = (uint64_t)time (NULL) * 1000;
     edgex_addressable *addr = edgex_metadata_client_get_addressable
       (svc->logger, &svc->config.endpoints, svc->name, err);
     if (err->code)
@@ -629,9 +629,7 @@ void edgex_device_post_readings
   const edgex_device_commandresult *values
 )
 {
-  uint64_t timenow = time (NULL) * 1000UL;
-  uint64_t origin =
-    (nreadings == 1 && values[0].origin) ? values[0].origin : timenow;
+  uint64_t timenow = (uint64_t)time (NULL) * 1000;
   edgex_reading *rdgs = malloc (nreadings * sizeof (edgex_reading));
   for (uint32_t i = 0; i < nreadings; i++)
   {
@@ -647,13 +645,13 @@ void edgex_device_post_readings
       sources[i].devobj->properties->value,
       sources[i].ro->mappings
     );
-    rdgs[i].origin = values[i].origin ? values[i].origin : timenow;
+    rdgs[i].origin = values[i].origin;
     rdgs[i].next = (i == nreadings - 1) ? NULL : rdgs + i + 1;
   }
   postparams *pp = malloc (sizeof (postparams));
   pp->svc = svc;
   pp->name = device_name;
-  pp->origin = origin;
+  pp->origin = timenow;
   pp->readings = rdgs;
   thpool_add_work (svc->thpool, doPost, pp);
 }

--- a/src/c/service.c
+++ b/src/c/service.c
@@ -18,6 +18,7 @@
 #include "data.h"
 #include "rest.h"
 #include "edgex_rest.h"
+#include "edgex_time.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -262,7 +263,7 @@ void edgex_device_service_start
 
   if (ds == NULL)
   {
-    uint64_t millis = (uint64_t)time (NULL) * 1000;
+    uint64_t millis = edgex_device_millitime ();
     edgex_addressable *addr = edgex_metadata_client_get_addressable
       (svc->logger, &svc->config.endpoints, svc->name, err);
     if (err->code)
@@ -629,7 +630,7 @@ void edgex_device_post_readings
   const edgex_device_commandresult *values
 )
 {
-  uint64_t timenow = (uint64_t)time (NULL) * 1000;
+  uint64_t timenow = edgex_device_millitime ();
   edgex_reading *rdgs = malloc (nreadings * sizeof (edgex_reading));
   for (uint32_t i = 0; i < nreadings; i++)
   {


### PR DESCRIPTION
…amps

1) We should not be setting the origin field in the SDK. Either the device sets this or it doesn't. We have the created timestamp to indicate when data arrived in EdgeX.
2) Previous code was causing overflow errors on systems where time_t is 32 bits.

Signed-off-by: Iain Anderson <iain@iotechsys.com>