### PR TITLE
F 25 branch

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,7 @@ differs as follows:
 
 Changes for 1.0.0:
 
+- Initial support for binary data, marshalled as base64 strings.
 - Assertions on data readings are implemented.
 - Some parts of the edgex model are now held in appropriate types rather
   than strings.

--- a/TODO
+++ b/TODO
@@ -1,8 +1,7 @@
 TODO
 ====
 
-Readings:  Binary encodings. base64 encoding of floating point numbers. Mask
-and shift transforms.
+Readings:  base64 encoding of floating point numbers. Mask and shift transforms.
 
 Discovery endpoint - Only enable new devices which match a provisionwatcher.
 These to be dynamically created according to configuration.

--- a/docs/deviceprofiles.md
+++ b/docs/deviceprofiles.md
@@ -75,7 +75,7 @@ each logical value is given two properties, named value and units. The
 following fields are available in a property:
 
 * type - Required. The data type of the value. Supported types are Bool,
-Int8 - Int64, Uint8 - Uint64, Float32, Float64 and String. Note that the
+Int8 - Int64, Uint8 - Uint64, Float32, Float64, Binary and String. Note that the
 undifferentiated Integer and Float types are deprecated in EdgeX and not
 supported by the SDK.
 * readWrite - "R", "RW", or "W" indicating whether the value is readable or

--- a/docs/servicewritersguide.md
+++ b/docs/servicewritersguide.md
@@ -29,7 +29,7 @@ The Get handler deals with incoming requests to get data from a device. The foll
 * edgex_addressable *devaddr - This provides information about the endpoint that this get request is seeking to access. Typically this is mapped to a device-specific client/connection etc.
 * uint32_t nreadings - The following requests and reading parameters are arrays of size nreadings.
 * edgex_device_commandrequest *requests - The deviceobject and resourceoperation supplied are pointers into the lists of such objects held in the relevant device profile. As such, each contains a "next" pointer. This should be ignored - each edgex_device_commandrequest describes only one operation. Here a device service would typically drill down to the attributes used to describe device resources, it would use these attributes to understand how to query the device for the requested data.
-* edgex_device_coommandresult * readings - Once a reading has been taken from a device, the resulting value is placed into the readings. This is used by the SDK to return the result to EdgeX.
+* edgex_device_coommandresult * readings - Once a reading has been taken from a device, the resulting value is placed into the readings. This is used by the SDK to return the result to EdgeX. If a reading is of String or Binary type, memory ownership is taken by the SDK.
 
 In general the GET handler should implement a translation between a GET request from edgex and a read/get via the protocol-specific mechanism. Multiple sources of metadata are provided to allow the device-service to identify what it should query on receipt of the callback.
 

--- a/include/edgex/devsdk.h
+++ b/include/edgex/devsdk.h
@@ -18,6 +18,12 @@
 #include "edgex/error.h"
 #include "edgex/edgex_logging.h"
 
+typedef struct edgex_blob
+{
+  size_t size;
+  uint8_t *bytes;
+} edgex_blob;
+
 typedef union edgex_device_resultvalue
 {
   bool bool_result;
@@ -32,6 +38,7 @@ typedef union edgex_device_resultvalue
   int64_t i64_result;
   float f32_result;
   double f64_result;
+  edgex_blob binary_result;
 } edgex_device_resultvalue;
 
 /**

--- a/include/edgex/devsdk.h
+++ b/include/edgex/devsdk.h
@@ -233,7 +233,9 @@ void edgex_device_service_start
  * @param sources An array specifying the resources from which the readings
  *        have been taken.
  * @param values An array of readings. These will be combined into an Event
- *        and submitted to core-data.
+ *        and submitted to core-data. For readings of String or Binary type,
+ *        the SDK takes ownership of the memory containing the string or
+ *        byte array.
  */
 
 void edgex_device_post_readings

--- a/include/edgex/edgex.h
+++ b/include/edgex/edgex.h
@@ -15,6 +15,7 @@ typedef enum
 {
   Bool,
   String,
+  Binary,
   Uint8, Uint16, Uint32, Uint64,
   Int8, Int16, Int32, Int64,
   Float32, Float64
@@ -66,14 +67,6 @@ typedef struct
     double dval;
   } value;
 } edgex_transformArg;
-
-typedef struct
-{
-  char *id;
-  int64_t created;
-  int64_t modified;
-  int64_t origin;
-} edgex_baseobject;
 
 typedef struct
 {

--- a/src/c/data.h
+++ b/src/c/data.h
@@ -15,13 +15,13 @@
 
 typedef struct edgex_service_endpoints edgex_service_endpoints;
 
-edgex_event *edgex_data_client_add_event
+void edgex_data_client_add_event
 (
   iot_logging_client *lc,
   edgex_service_endpoints *endpoints,
-  const char *device,
+  char *device,
   uint64_t origin,
-  const edgex_reading *readings,
+  edgex_reading *readings,
   edgex_error *err
 );
 

--- a/src/c/edgex_rest.c
+++ b/src/c/edgex_rest.c
@@ -122,7 +122,7 @@ void edgex_nvpairs_free (edgex_nvpairs *p)
 
 static const char *proptypes[] =
 {
-  "Bool", "String", "Uint8", "Uint16", "Uint32", "Uint64",
+  "Bool", "String", "Binary", "Uint8", "Uint16", "Uint32", "Uint64",
   "Int8", "Int16", "Int32", "Int64", "Float32", "Float64"
 };
 

--- a/src/c/parson.c
+++ b/src/c/parson.c
@@ -1012,7 +1012,7 @@ static int json_serialize_string(const char *string, char *buf) {
         switch (c) {
             case '\"': APPEND_STRING("\\\""); break;
             case '\\': APPEND_STRING("\\\\"); break;
-            case '/':  APPEND_STRING("\\/"); break; /* to make json embeddable in xml\/html */
+/*            case '/':  APPEND_STRING("\\/"); break;  to make json embeddable in xml\/html */
             case '\b': APPEND_STRING("\\b"); break;
             case '\f': APPEND_STRING("\\f"); break;
             case '\n': APPEND_STRING("\\n"); break;

--- a/src/c/service.c
+++ b/src/c/service.c
@@ -38,8 +38,9 @@
 typedef struct postparams
 {
   edgex_device_service *svc;
-  const char *name;
+  char *name;
   uint64_t origin;
+  uint32_t nreadings;
   edgex_reading *readings;
 } postparams;
 
@@ -705,7 +706,13 @@ static void doPost (void *p)
     pp->readings,
     &err
   );
+
+  for (uint32_t i = 0; i < pp->nreadings; i++)
+  {
+    free (pp->readings[i].value);
+  }
   free (pp->readings);
+  free (pp->name);
   free (pp);
 }
 
@@ -739,9 +746,10 @@ void edgex_device_post_readings
   }
   postparams *pp = malloc (sizeof (postparams));
   pp->svc = svc;
-  pp->name = device_name;
+  pp->name = strdup (device_name);
   pp->origin = timenow;
   pp->readings = rdgs;
+  pp->nreadings = nreadings;
   thpool_add_work (svc->thpool, doPost, pp);
 }
 


### PR DESCRIPTION
Add support for Binary types and clean up some of the memory usage. In particular for types that are likely to have dynamically allocated memory (ie Binary and String) the memory is free'd in the SDK.