### PR TITLE
Header redundancy

### DIFF
--- a/include/edgex/edgex.h
+++ b/include/edgex/edgex.h
@@ -21,26 +21,6 @@ typedef enum
   Float32, Float64
 } edgex_propertytype;
 
-typedef enum
-{
-  GET = 1,
-  POST = 2,
-  PUT = 4,
-  PATCH = 8,
-  DELETE = 16,
-  UNKNOWN = 1024
-} edgex_http_method;
-
-typedef enum
-{
-  HTTP = 0,
-  TCP = 1,
-  MAC = 2,
-  ZMQ = 3,
-  OTHER = 4,
-  SSL = 5
-} edgex_protocol;
-
 typedef enum { LOCKED, UNLOCKED } edgex_device_adminstate;
 
 typedef enum { ENABLED, DISABLED } edgex_device_operatingstate;
@@ -101,23 +81,6 @@ typedef struct
   edgex_device_operatingstate operatingState;
   uint64_t origin;
 } edgex_deviceservice;
-
-typedef struct
-{
-  uint64_t created;
-  char *defaultValue;
-  char *description;
-  char *formatting;
-  char *id;
-  edgex_strings *labels;
-  char *max;
-  char *min;
-  uint64_t modified;
-  char *name;
-  uint64_t origin;
-  char *type;
-  char *uomLabel;
-} edgex_valuedescriptor;
 
 typedef struct edgex_response
 {
@@ -247,29 +210,5 @@ typedef struct edgex_device
   edgex_deviceprofile *profile;
   struct edgex_device *next;
 } edgex_device;
-
-typedef struct edgex_reading
-{
-  uint64_t created;
-  char *id;
-  uint64_t modified;
-  char *name;
-  uint64_t origin;
-  uint64_t pushed;
-  char *value;
-  struct edgex_reading *next;
-} edgex_reading;
-
-typedef struct edgex_event
-{
-  uint64_t created;
-  char *device;
-  char *id;
-  uint64_t modified;
-  uint64_t origin;
-  uint64_t pushed;
-  edgex_reading *readings;
-  struct edgex_event *next;
-} edgex_event;
 
 #endif

--- a/src/c/callback.h
+++ b/src/c/callback.h
@@ -9,7 +9,7 @@
 #ifndef _EDGEX_DEVICE_CALLBACK_H_
 #define _EDGEX_DEVICE_CALLBACK_H_ 1
 
-#include "edgex/devsdk.h"
+#include "rest_server.h"
 
 extern int edgex_device_handler_callback
 (

--- a/src/c/data.h
+++ b/src/c/data.h
@@ -13,6 +13,47 @@
 #include "edgex/edgex_logging.h"
 #include "edgex/error.h"
 
+typedef struct edgex_reading
+{
+  uint64_t created;
+  char *id;
+  uint64_t modified;
+  char *name;
+  uint64_t origin;
+  uint64_t pushed;
+  char *value;
+  struct edgex_reading *next;
+} edgex_reading;
+
+typedef struct edgex_event
+{
+  uint64_t created;
+  char *device;
+  char *id;
+  uint64_t modified;
+  uint64_t origin;
+  uint64_t pushed;
+  edgex_reading *readings;
+  struct edgex_event *next;
+} edgex_event;
+
+typedef struct
+{
+  uint64_t created;
+  char *defaultValue;
+  char *description;
+  char *formatting;
+  char *id;
+  edgex_strings *labels;
+  char *max;
+  char *min;
+  uint64_t modified;
+  char *name;
+  uint64_t origin;
+  char *type;
+  char *uomLabel;
+} edgex_valuedescriptor;
+
 typedef struct edgex_service_endpoints edgex_service_endpoints;
 
 void edgex_data_client_add_event

--- a/src/c/device.c
+++ b/src/c/device.c
@@ -223,28 +223,28 @@ char *edgex_value_tostring
       res = strdup (value.bool_result ? "true" : "false");
       break;
     case Uint8:
-      sprintf (res, "%u", value.ui8_result);
+      sprintf (res, "%" PRIu8, value.ui8_result);
       break;
     case Uint16:
-      sprintf (res, "%u", value.ui16_result);
+      sprintf (res, "%" PRIu16, value.ui16_result);
       break;
     case Uint32:
-      sprintf (res, "%u", value.ui32_result);
+      sprintf (res, "%" PRIu32, value.ui32_result);
       break;
     case Uint64:
-      sprintf (res, "%lu", value.ui64_result);
+      sprintf (res, "%" PRIu64, value.ui64_result);
       break;
     case Int8:
-      sprintf (res, "%d", value.i8_result);
+      sprintf (res, "%" PRIi8, value.i8_result);
       break;
     case Int16:
-      sprintf (res, "%d", value.i16_result);
+      sprintf (res, "%" PRIi16, value.i16_result);
       break;
     case Int32:
-      sprintf (res, "%d", value.i32_result);
+      sprintf (res, "%" PRIi32, value.i32_result);
       break;
     case Int64:
-      sprintf (res, "%ld", value.i64_result);
+      sprintf (res, "%" PRIi64, value.i64_result);
       break;
     case Float32:
       sprintf (res, "%.8e", value.f32_result);

--- a/src/c/device.h
+++ b/src/c/device.h
@@ -10,6 +10,7 @@
 #define _EDGEX_DEVICE_DEVICE_H_ 1
 
 #include "edgex/devsdk.h"
+#include "rest_server.h"
 
 extern int edgex_device_handler_device
 (

--- a/src/c/discovery.h
+++ b/src/c/discovery.h
@@ -9,7 +9,7 @@
 #ifndef _EDGEX_DEVICE_DISCOVERY_H_
 #define _EDGEX_DEVICE_DISCOVERY_H_ 1
 
-#include "edgex/devsdk.h"
+#include "rest_server.h"
 
 #include <stddef.h>
 

--- a/src/c/edgex_rest.c
+++ b/src/c/edgex_rest.c
@@ -153,14 +153,7 @@ static const char *edgex_adminstate_tostring (edgex_device_adminstate ad)
 
 static edgex_device_adminstate edgex_adminstate_fromstring (const char *str)
 {
-  if (strcmp (str, adstatetypes[LOCKED]) == 0)
-  {
-    return LOCKED;
-  }
-  else
-  {
-    return UNLOCKED;
-  }
+  return (strcmp (str, adstatetypes[LOCKED]) == 0) ? LOCKED : UNLOCKED;
 }
 
 static const char *opstatetypes[] = { "ENABLED", "DISABLED" };
@@ -174,14 +167,7 @@ static const char *edgex_operatingstate_tostring
 static edgex_device_operatingstate edgex_operatingstate_fromstring
   (const char *str)
 {
-  if (strcmp (str, opstatetypes[DISABLED]) == 0)
-  {
-    return DISABLED;
-  }
-  else
-  {
-    return ENABLED;
-  }
+  return (strcmp (str, opstatetypes[DISABLED]) == 0) ? DISABLED : ENABLED;
 }
 
 static bool get_transformArg

--- a/src/c/edgex_rest.h
+++ b/src/c/edgex_rest.h
@@ -12,6 +12,7 @@
 #include "edgex/edgex.h"
 #include "iot/logging.h"
 #include "schedules.h"
+#include "data.h"
 
 edgex_strings *edgex_strings_dup (const edgex_strings *strs);
 void edgex_strings_free (edgex_strings *strs);

--- a/src/c/rest_server.h
+++ b/src/c/rest_server.h
@@ -16,6 +16,16 @@
 struct edgex_rest_server;
 typedef struct edgex_rest_server edgex_rest_server;
 
+typedef enum
+{
+  GET = 1,
+  POST = 2,
+  PUT = 4,
+  PATCH = 8,
+  DELETE = 16,
+  UNKNOWN = 1024
+} edgex_http_method;
+
 typedef int (*http_method_handler_fn)
 (
   void *context,


### PR DESCRIPTION
Various parts of the EdgeX model defined in edgex/edgex.h are not needed by device service developers - move them into the "internal" header files.
Also two minor fixes for portability and brevity.