### PR TITLE
F-88 enable base64 encode/decode for floats

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,8 @@ differs as follows:
 
 Changes for 1.0.0:
 
+- Float data is marshalled as base64 unless specified otherwise in the
+  floatEncoding field of the device profile.
 - Schedules and ScheduleEvents are removed.
 - The get and set handlers now take an edgex_protocols object rather than an
   edgex_addressable.

--- a/TODO
+++ b/TODO
@@ -1,7 +1,7 @@
 TODO
 ====
 
-Readings:  base64 encoding of floating point numbers. Mask and shift transforms.
+Readings - Mask and shift transforms.
 
 Discovery endpoint - Only enable new devices which match a provisionwatcher.
 These to be dynamically created according to configuration.

--- a/include/edgex/edgex.h
+++ b/include/edgex/edgex.h
@@ -118,6 +118,7 @@ typedef struct
   edgex_transformArg base;
   char *assertion;
   char *precision;
+  bool floatAsBinary;
 } edgex_propertyvalue;
 
 typedef struct

--- a/src/c/edgex_rest.c
+++ b/src/c/edgex_rest.c
@@ -278,6 +278,7 @@ static bool get_transformArg
 static edgex_propertyvalue *propertyvalue_read
   (iot_logging_client *lc, const JSON_Object *obj)
 {
+  const char *fe;
   edgex_propertytype pt;
   edgex_propertyvalue *result = NULL;
   const char *tstr = json_object_get_string (obj, "type");
@@ -322,6 +323,12 @@ static edgex_propertyvalue *propertyvalue_read
     result->lsb = get_string (obj, "lsb");
     result->assertion = get_string (obj, "assertion");
     result->precision = get_string (obj, "precision");
+    fe = get_string (obj, "floatEncoding");
+#ifdef LEGIBLE_FLOATS
+    result->floatAsBinary = (strcmp (fe, "base64") == 0);
+#else
+    result->floatAsBinary = (strcmp (fe, "eNotation") != 0);
+#endif
   }
   else
   {
@@ -371,6 +378,8 @@ static JSON_Value *propertyvalue_write (const edgex_propertyvalue *e)
   set_arg (obj, "base", e->base, e->type);
   json_object_set_string (obj, "assertion", e->assertion);
   json_object_set_string (obj, "precision", e->precision);
+  json_object_set_string
+    (obj, "floatEncoding", e->floatAsBinary ? "base64" : "eNotation");
   return result;
 }
 
@@ -394,6 +403,7 @@ static edgex_propertyvalue *propertyvalue_dup (edgex_propertyvalue *pv)
     result->base = pv->base;
     result->assertion = strdup (pv->assertion);
     result->precision = strdup (pv->precision);
+    result->floatAsBinary = pv->floatAsBinary;
   }
   return result;
 }


### PR DESCRIPTION
Addresses #88 
Inbound float data is autodetected as base64 or decimal regardless of settings