### PR TITLE
Encapsulate device map

### DIFF
--- a/include/edgex/devsdk.h
+++ b/include/edgex/devsdk.h
@@ -339,18 +339,11 @@ void edgex_device_update_device
 );
 
 /**
- * @brief Obtain a list of devices known to the system. This function calls
- *        core-metadata to retrieve all devices associated with this device
- *        service.
+ * @brief Obtain a list of devices known to the system.
  * @param svc The device service.
- * @param err Nonzero reason codes will be set here in the event of errors.
  */
 
-edgex_device * edgex_device_devices
-(
-  edgex_device_service *svc,
-  edgex_error *err
-);
+edgex_device * edgex_device_devices (edgex_device_service *svc);
 
 /**
  * @brief Retrieve device information.
@@ -382,16 +375,23 @@ void edgex_device_free_device (edgex_device *e);
 /**
  * @brief Retrieve the device profiles currently known in the SDK.
  * @param svc The device service.
- * @param count Is set to the number of profiles returned.
  * @param profiles Is set to an array of device profiles. This should be
- *        free()d after use.
+ *        freed using edgex_deviceprofile_free_array() after use.
+ * @returns the size of the returned array.
  */
 
-void edgex_device_service_getprofiles
+uint32_t edgex_device_service_getprofiles
 (
   edgex_device_service *svc,
-  uint32_t *count,
   edgex_deviceprofile **profiles
 );
+
+/**
+ * @brief Free an array of device profiles.
+ * @param e The array.
+ * @param count The number of elements in the array.
+ */
+
+void edgex_deviceprofile_free_array (edgex_deviceprofile *e, unsigned count);
 
 #endif

--- a/include/edgex/edgex.h
+++ b/include/edgex/edgex.h
@@ -187,6 +187,7 @@ typedef struct edgex_device
   edgex_deviceservice *service;
   edgex_deviceprofile *profile;
   struct edgex_device *next;
+  atomic_uint_fast32_t refs;
 } edgex_device;
 
 #endif

--- a/include/edgex/os.h
+++ b/include/edgex/os.h
@@ -18,5 +18,6 @@
 #include <pthread.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdatomic.h>
 
 #endif

--- a/src/c/config.c
+++ b/src/c/config.c
@@ -832,7 +832,7 @@ void edgex_device_process_configured_devices
     edgex_device *existing;
     char *profile_name;
     char *description;
-    edgex_protocols *protocols = NULL;
+    edgex_protocols *protocols;
     edgex_strings *labels;
     edgex_strings *newlabel;
     toml_table_t *table;
@@ -857,6 +857,7 @@ void edgex_device_process_configured_devices
         if (pptable)
         {
           const char *key;
+          protocols = NULL;
           for (int i = 0; 0 != (key = toml_key_in (pptable, i)); i++)
           {
             toml_table_t *pprops = toml_table_in (pptable, key);

--- a/src/c/config.c
+++ b/src/c/config.c
@@ -829,7 +829,7 @@ void edgex_device_process_configured_devices
   {
     char *devname;
     const char *raw;
-    char **existing;
+    edgex_device *existing;
     char *profile_name;
     char *description;
     edgex_protocols *protocols = NULL;
@@ -844,10 +844,12 @@ void edgex_device_process_configured_devices
     {
       raw = toml_raw_in (table, "Name");
       toml_rtos2 (raw, &devname);
-      pthread_rwlock_rdlock (&svc->deviceslock);
-      existing = edgex_map_get (&svc->name_to_id, devname);
-      pthread_rwlock_unlock (&svc->deviceslock);
-      if (existing == NULL)
+      existing = edgex_devmap_device_byname (svc->devices, devname);
+      if (existing)
+      {
+        edgex_device_release (existing);
+      }
+      else
       {
         /* Protocols */
 

--- a/src/c/device.h
+++ b/src/c/device.h
@@ -10,6 +10,7 @@
 #define _EDGEX_DEVICE_DEVICE_H_ 1
 
 #include "edgex/devsdk.h"
+#include "edgex/edgex.h"
 #include "rest_server.h"
 
 extern int edgex_device_handler_device
@@ -30,5 +31,8 @@ extern char *edgex_value_tostring
   edgex_propertyvalue *props,
   edgex_nvpairs *mappings
 );
+
+extern const struct edgex_cmdinfo *edgex_deviceprofile_findcommand
+  (const char *name, edgex_deviceprofile *prof, bool forGet);
 
 #endif

--- a/src/c/devmap.c
+++ b/src/c/devmap.c
@@ -41,6 +41,7 @@ edgex_devmap_t *edgex_devmap_alloc ()
 
   edgex_devmap_t *res = malloc (sizeof (edgex_devmap_t));
   pthread_rwlock_init (&res->lock, &rwatt);
+  pthread_rwlockattr_destroy (&rwatt);
   edgex_map_init (&res->devices);
   edgex_map_init (&res->name_to_id);
   edgex_map_init (&res->profiles);
@@ -49,7 +50,6 @@ edgex_devmap_t *edgex_devmap_alloc ()
 
 void edgex_devmap_free (edgex_devmap_t *map)
 {
-  pthread_rwlock_wrlock (&map->lock);
   edgex_map_deinit (&map->name_to_id);
   edgex_map_iter i = edgex_map_iter (map->devices);
   const char *key;
@@ -66,7 +66,7 @@ void edgex_devmap_free (edgex_devmap_t *map)
     edgex_deviceprofile_free (*p);
   }
   edgex_map_deinit (&map->profiles);
-  pthread_rwlock_unlock (&map->lock);
+  pthread_rwlock_destroy (&map->lock);
   free (map);
 }
 

--- a/src/c/devmap.c
+++ b/src/c/devmap.c
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2019
+ * IoTech Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+/* Device / profile map implementation. We maintain 3 maps: device by id,
+ * device id by name and profile by name. The devices in the device map
+ * reference profiles in the profile map by pointer.
+ */
+
+#include "devmap.h"
+#include "map.h"
+#include "edgex_rest.h"
+#include "device.h"
+
+typedef edgex_map(edgex_device *) edgex_map_device;
+typedef edgex_map(edgex_deviceprofile *) edgex_map_profile;
+
+struct edgex_devmap_t
+{
+  pthread_rwlock_t lock;
+  edgex_map_device devices;
+  edgex_map_string name_to_id;
+  edgex_map_profile profiles;
+};
+
+edgex_devmap_t *edgex_devmap_alloc ()
+{
+  pthread_rwlockattr_t rwatt;
+  pthread_rwlockattr_init (&rwatt);
+#ifdef  __GLIBC_PREREQ
+#if __GLIBC_PREREQ(2, 1)
+  /* Avoid heavy readlock use (eg spammed "all" commands) blocking updates */
+  pthread_rwlockattr_setkind_np
+    (&rwatt, PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP);
+#endif
+#endif
+
+  edgex_devmap_t *res = malloc (sizeof (edgex_devmap_t));
+  pthread_rwlock_init (&res->lock, &rwatt);
+  edgex_map_init (&res->devices);
+  edgex_map_init (&res->name_to_id);
+  edgex_map_init (&res->profiles);
+  return res;
+}
+
+void edgex_devmap_free (edgex_devmap_t *map)
+{
+  pthread_rwlock_wrlock (&map->lock);
+  edgex_map_deinit (&map->name_to_id);
+  edgex_map_iter i = edgex_map_iter (map->devices);
+  const char *key;
+  while ((key = edgex_map_next (&map->devices, &i)))
+  {
+    edgex_device **e = edgex_map_get (&map->devices, key);
+    edgex_device_release (*e);
+  }
+  edgex_map_deinit (&map->devices);
+  i = edgex_map_iter (map->profiles);
+  while ((key = edgex_map_next (&map->profiles, &i)))
+  {
+    edgex_deviceprofile **p = edgex_map_get (&map->profiles, key);
+    edgex_deviceprofile_free (*p);
+  }
+  edgex_map_deinit (&map->profiles);
+  pthread_rwlock_unlock (&map->lock);
+  free (map);
+}
+
+static void add_locked (edgex_devmap_t *map, const edgex_device *newdev)
+{
+  edgex_device *dup = edgex_device_dup (newdev);
+  atomic_store (&dup->refs, 1);
+  edgex_deviceprofile **pp = edgex_map_get (&map->profiles, dup->profile->name);
+  if (pp)
+  {
+    edgex_deviceprofile_free (dup->profile);
+    dup->profile = *pp;
+  }
+  else
+  {
+    edgex_map_set (&map->profiles, dup->profile->name, dup->profile);
+  }
+  edgex_map_set (&map->devices, dup->id, dup);
+  edgex_map_set (&map->name_to_id, dup->name, dup->id);
+}
+
+void edgex_devmap_populate_devices
+  (edgex_devmap_t *map, const edgex_device *devs)
+{
+  pthread_rwlock_wrlock (&map->lock);
+  for (const edgex_device *d = devs; d; d = d->next)
+  {
+    if (edgex_map_get (&map->name_to_id, d->name) == NULL)
+    {
+      add_locked (map, d);
+    }
+  }
+  pthread_rwlock_unlock (&map->lock);
+}
+
+edgex_device *edgex_devmap_copydevices (edgex_devmap_t *map)
+{
+  edgex_device *result = NULL;
+  edgex_device *dup;
+  const char *key;
+
+  pthread_rwlock_rdlock (&map->lock);
+  edgex_map_iter iter = edgex_map_iter (map->devices);
+  while ((key = edgex_map_next (&map->devices, &iter)))
+  {
+    dup = edgex_device_dup (*edgex_map_get (&map->devices, key));
+    dup->next = result;
+    result = dup;
+  }
+  pthread_rwlock_unlock (&map->lock);
+  return result;
+}
+
+uint32_t edgex_devmap_copyprofiles
+  (edgex_devmap_t *map, edgex_deviceprofile **profiles)
+{
+  edgex_deviceprofile *arr;
+  const char *key;
+  uint32_t count = 0;
+
+  pthread_rwlock_rdlock (&map->lock);
+  edgex_map_iter iter = edgex_map_iter (map->profiles);
+  while (edgex_map_next (&map->profiles, &iter))
+  {
+    count++;
+  }
+  arr = malloc (count * sizeof (edgex_deviceprofile));
+
+  iter = edgex_map_iter (map->profiles);
+  for (uint32_t i = 0; i < count; i++)
+  {
+    key = edgex_map_next (&map->profiles, &iter);
+    edgex_deviceprofile_cpy (arr + i, *edgex_map_get (&map->profiles, key));
+  }
+  pthread_rwlock_unlock (&map->lock);
+
+  *profiles = arr;
+  return count;
+}
+
+const edgex_deviceprofile *edgex_devmap_profile
+  (edgex_devmap_t *map, const char *name)
+{
+  edgex_deviceprofile **dpp;
+  pthread_rwlock_rdlock (&map->lock);
+  dpp = edgex_map_get (&map->profiles, name);
+  pthread_rwlock_unlock (&map->lock);
+  return dpp ? *dpp : NULL;
+}
+
+static void remove_locked (edgex_devmap_t *map, edgex_device *olddev)
+{
+  edgex_map_remove (&map->name_to_id, olddev->name);
+  edgex_map_remove (&map->devices, olddev->id);
+  edgex_device_release (olddev);
+}
+
+void edgex_devmap_replace_device (edgex_devmap_t *map, const edgex_device *dev)
+{
+  edgex_device **olddev;
+
+  pthread_rwlock_wrlock (&map->lock);
+  olddev = edgex_map_get (&map->devices, dev->id);
+  if (olddev)
+  {
+    remove_locked (map, *olddev);
+  }
+  add_locked (map, dev);
+  pthread_rwlock_unlock (&map->lock);
+}
+
+edgex_device *edgex_devmap_device_byid (edgex_devmap_t *map, const char *id)
+{
+  edgex_device **dev;
+  edgex_device *result = NULL;
+
+  pthread_rwlock_rdlock (&map->lock);
+  dev = edgex_map_get (&map->devices, id);
+  if (dev)
+  {
+    result = *dev;
+    atomic_fetch_add (&result->refs, 1);
+  }
+  pthread_rwlock_unlock (&map->lock);
+  return result;
+}
+
+edgex_device *edgex_devmap_device_byname (edgex_devmap_t *map, const char *name)
+{
+  char **id;
+  edgex_device *result = NULL;
+
+  pthread_rwlock_rdlock (&map->lock);
+  id = edgex_map_get (&map->name_to_id, name);
+  if (id)
+  {
+    result = *edgex_map_get (&map->devices, *id);
+    atomic_fetch_add (&result->refs, 1);
+  }
+  pthread_rwlock_unlock (&map->lock);
+  return result;
+}
+
+void edgex_devmap_removedevice_byname (edgex_devmap_t *map, const char *name)
+{
+  edgex_device **olddev;
+  char **id;
+
+  pthread_rwlock_wrlock (&map->lock);
+  id = edgex_map_get (&map->name_to_id, name);
+  if (id)
+  {
+    olddev = edgex_map_get (&map->devices, *id);
+    remove_locked (map, *olddev);
+  }
+  pthread_rwlock_unlock (&map->lock);
+}
+
+void edgex_devmap_removedevice_byid (edgex_devmap_t *map, const char *id)
+{
+  edgex_device **olddev;
+  pthread_rwlock_wrlock (&map->lock);
+  olddev = edgex_map_get (&map->devices, id);
+  remove_locked (map, *olddev);
+  pthread_rwlock_unlock (&map->lock);
+}
+
+void edgex_devmap_add_profile (edgex_devmap_t *map, edgex_deviceprofile *dp)
+{
+  pthread_rwlock_wrlock (&map->lock);
+  edgex_map_set (&map->profiles, dp->name, dp);
+  pthread_rwlock_unlock (&map->lock);
+}
+
+edgex_cmdqueue_t *edgex_devmap_device_forcmd
+  (edgex_devmap_t *map, const char *cmd, bool forGet)
+{
+  edgex_device *dev;
+  const char *key;
+  const struct edgex_cmdinfo *command;
+  edgex_cmdqueue_t *result = NULL;
+  edgex_cmdqueue_t *q;
+
+  pthread_rwlock_rdlock (&map->lock);
+  edgex_map_iter iter = edgex_map_iter (map->devices);
+  while ((key = edgex_map_next (&map->devices, &iter)))
+  {
+    dev = *edgex_map_get (&map->devices, key);
+    if (dev->operatingState == ENABLED && dev->adminState == UNLOCKED)
+    {
+      command = edgex_deviceprofile_findcommand (cmd, dev->profile, forGet);
+      if (command)
+      {
+        q = malloc (sizeof (edgex_cmdqueue_t));
+        q->dev = dev;
+        q->cmd = command;
+        q->next = result;
+        result = q;
+        atomic_fetch_add (&dev->refs, 1);
+      }
+    }
+  }
+  pthread_rwlock_unlock (&map->lock);
+  return result;
+}
+
+void edgex_device_release (edgex_device *dev)
+{
+  if (atomic_fetch_add (&dev->refs, -1) == 1)
+  {
+    dev->profile = NULL;
+    edgex_device_free (dev);
+  }
+}
+

--- a/src/c/devmap.h
+++ b/src/c/devmap.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2019
+ * IoTech Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#ifndef _EDGEX_DEVICE_DEVMAP_H_
+#define _EDGEX_DEVICE_DEVMAP_H_ 1
+
+/* Maintains the device / profile map for the SDK. */
+
+#include "edgex/edgex.h"
+
+struct edgex_devmap_t;
+typedef struct edgex_devmap_t edgex_devmap_t;
+
+/*
+ * A list of devices matching a command.
+ */
+
+typedef struct edgex_cmdqueue_t
+{
+   edgex_device *dev;
+   const struct edgex_cmdinfo *cmd;
+   struct edgex_cmdqueue_t *next;
+} edgex_cmdqueue_t;
+
+/*
+ * Device[Profile] map lifecycle.
+ */
+
+extern edgex_devmap_t *edgex_devmap_alloc (void);
+extern void edgex_devmap_free (edgex_devmap_t *map);
+
+/*
+ * These functions copy devices and profiles in and out.
+ */
+
+extern void edgex_devmap_populate_devices
+  (edgex_devmap_t *map, const edgex_device *devs);
+extern edgex_device *edgex_devmap_copydevices (edgex_devmap_t *map);
+extern uint32_t edgex_devmap_copyprofiles
+  (edgex_devmap_t *map, edgex_deviceprofile **profiles);
+extern void edgex_devmap_replace_device
+  (edgex_devmap_t *map, const edgex_device *dev);
+
+/*
+ * These functions return pointers to the devices held in the implementation.
+ * They must be released after use by calling edgex_device_release().
+ */
+
+extern edgex_device *edgex_devmap_device_byid
+  (edgex_devmap_t *map, const char *id);
+extern edgex_device *edgex_devmap_device_byname
+  (edgex_devmap_t *map, const char *name);
+extern edgex_cmdqueue_t *edgex_devmap_device_forcmd
+  (edgex_devmap_t *map, const char *cmd, bool forGet);
+
+/*
+ * Release function. The device is freed when its reference count hits zero.
+ */
+
+extern void edgex_device_release (edgex_device *dev);
+
+/*
+ * Device removal.
+ */
+
+extern void edgex_devmap_removedevice_byid
+  (edgex_devmap_t *map, const char *id);
+extern void edgex_devmap_removedevice_byname
+  (edgex_devmap_t *map, const char *name);
+
+/*
+ * Add and retrieve profiles. We take ownership on add, and return pointers
+ * to the profiles held in the implementation. Unlike devices these are not
+ * refcounted and do not need to be released or freed.
+ */
+
+extern void edgex_devmap_add_profile
+  (edgex_devmap_t *map, edgex_deviceprofile *dp);
+extern const edgex_deviceprofile *edgex_devmap_profile
+  (edgex_devmap_t *map, const char *name);
+
+#endif

--- a/src/c/edgex_rest.h
+++ b/src/c/edgex_rest.h
@@ -15,7 +15,7 @@
 
 edgex_strings *edgex_strings_dup (const edgex_strings *strs);
 void edgex_strings_free (edgex_strings *strs);
-edgex_nvpairs *edgex_nvpairs_dup (edgex_nvpairs *p);
+edgex_nvpairs *edgex_nvpairs_dup (const edgex_nvpairs *p);
 void edgex_nvpairs_free (edgex_nvpairs *p);
 const char *edgex_propertytype_tostring (edgex_propertytype pt);
 bool edgex_propertytype_fromstring (edgex_propertytype *res, const char *str);
@@ -23,7 +23,8 @@ edgex_protocols *edgex_protocols_dup (const edgex_protocols *e);
 void edgex_protocols_free (edgex_protocols *e);
 edgex_deviceprofile *edgex_deviceprofile_read (iot_logging_client *lc, const char *json);
 char *edgex_deviceprofile_write (const edgex_deviceprofile *e, bool create);
-edgex_deviceprofile *edgex_deviceprofile_dup (edgex_deviceprofile *e);
+edgex_deviceprofile *edgex_deviceprofile_dup (const edgex_deviceprofile *e);
+void edgex_deviceprofile_cpy (edgex_deviceprofile *dest, const edgex_deviceprofile *src);
 void edgex_deviceprofile_free (edgex_deviceprofile *e);
 edgex_deviceservice *edgex_deviceservice_read (const char *json);
 char *edgex_deviceservice_write (const edgex_deviceservice *e, bool create);
@@ -37,7 +38,7 @@ void edgex_device_free (edgex_device *e);
 edgex_device *edgex_devices_read (iot_logging_client *lc, const char *json);
 edgex_addressable *edgex_addressable_read (const char *json);
 char *edgex_addressable_write (const edgex_addressable *e, bool create);
-edgex_addressable *edgex_addressable_dup (edgex_addressable *e);
+edgex_addressable *edgex_addressable_dup (const edgex_addressable *e);
 void edgex_addressable_free (edgex_addressable *e);
 edgex_valuedescriptor *edgex_valuedescriptor_read (const char *json);
 char *edgex_valuedescriptor_write (const edgex_valuedescriptor *e);

--- a/src/c/rest_server.c
+++ b/src/c/rest_server.c
@@ -268,14 +268,12 @@ void edgex_rest_server_destroy (edgex_rest_server *svr)
   {
     MHD_stop_daemon (svr->daemon);
   }
-  pthread_mutex_lock (&svr->lock);
   while (svr->handlers)
   {
     tmp = svr->handlers->next;
     free (svr->handlers);
     svr->handlers = tmp;
   }
-  pthread_mutex_unlock (&svr->lock);
   pthread_mutex_destroy (&svr->lock);
   free (svr);
 }

--- a/src/c/service.h
+++ b/src/c/service.h
@@ -12,13 +12,10 @@
 #include "edgex/devsdk.h"
 #include "edgex/edgex_logging.h"
 #include "config.h"
-#include "map.h"
+#include "devmap.h"
 #include "rest_server.h"
 #include "thpool.h"
 #include "iot/scheduler.h"
-
-typedef edgex_map(edgex_device *) edgex_map_device;
-typedef edgex_map(edgex_deviceprofile *) edgex_map_profile;
 
 struct edgex_device_service_job;
 
@@ -34,13 +31,7 @@ struct edgex_device_service
   edgex_device_operatingstate opstate;
   edgex_device_adminstate adminstate;
 
-  edgex_map_device devices;
-  edgex_map_string name_to_id;
-  pthread_rwlock_t deviceslock;
-
-  edgex_map_profile profiles;
-  pthread_mutex_t profileslock;
-
+  edgex_devmap_t *devices;
   threadpool thpool;
   iot_scheduler scheduler;
   struct edgex_device_service_job *sjobs;


### PR DESCRIPTION
Bring the device and device profile datastructures together in their own class, for better maintainability.
Refcount devices so that we can handle a delete while an operation is in progress.