### PR TITLE
Refactor: split out device management API into a seperate header

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,8 @@ differs as follows:
 
 Changes for 1.0.0:
 
+- The API for managing devices and profiles is split out into a seperate header
+  edgex/device-mgmt.h
 - The device name is passed to the Get and Set handlers. The commandrequest
   structure is simplified.
 - Example implementation includes setting service name and registry location

--- a/include/edgex/device-mgmt.h
+++ b/include/edgex/device-mgmt.h
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2019
+ * IoTech Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#ifndef _EDGEX_DEVICE_MGMT_H_
+#define _EDGEX_DEVICE_MGMT_H_ 1
+
+/**
+ * @file
+ * @brief This file defines the functions for device and profile management
+ *        provided by the SDK.
+ */
+
+#include "edgex/devsdk.h"
+#include "edgex/edgex.h"
+#include "edgex/error.h"
+
+/**
+ * @brief Add a device to the EdgeX system. This will generally be called in
+ *        response to a request for device discovery.
+ * @param svc The device service.
+ * @param name The name of the new device.
+ * @param description Optional description of the new device.
+ * @param labels Optional labels for the new device.
+ * @param profile_name Name of the device profile to be used with this device.
+ * @param address Addressable for this device. The addressable will be created
+ *        in metadata. The address' name and origin timestamp will be generated
+ *        if not set.
+ * @param err Nonzero reason codes will be set here in the event of errors.
+ * @returns The id of the newly created or existing device, or NULL if an error
+ *          occurred.
+ */
+
+char * edgex_device_add_device
+(
+  edgex_device_service *svc,
+  const char *name,
+  const char *description,
+  const edgex_strings *labels,
+  const char *profile_name,
+  edgex_protocols *protocols,
+  edgex_error *err
+);
+
+/**
+ * @brief Remove a device from EdgeX. The device will be deleted from the
+ *        device service and from core-metadata.
+ * @param svc The device service.
+ * @param id The id of the device to be removed.
+ * @param err Nonzero reason codes will be set here in the event of errors.
+ */
+
+void edgex_device_remove_device
+  (edgex_device_service *svc, const char *id, edgex_error *err);
+
+/**
+ * @brief Remove a device from EdgeX. The device will be deleted from the
+ *        device service and from core-metadata.
+ * @param svc The device service.
+ * @param name The name of the device to be removed.
+ * @param err Nonzero reason codes will be set here in the event of errors.
+ */
+
+void edgex_device_remove_device_byname
+  (edgex_device_service *svc, const char *name, edgex_error *err);
+
+/**
+ * @brief Update a device's details.
+ * @param svc The device service.
+ * @param id The id of the device to update. If this is unset, the device will
+ *           be located by name.
+ * @param name If id is unset, this parameter must be set to the name of the
+ *             devce to be updated. Otherwise, it is optional and if set,
+ *             specifies a new name for the device.
+ * @param description If set, a new description for the device.
+ * @param labels If set, a new set of labels for the device.
+ * @param profilename If set, a new device profile for the device.
+ * @param err Nonzero reason codes will be set here in the event of errors.
+ */
+
+void edgex_device_update_device
+(
+  edgex_device_service *svc,
+  const char *id,
+  const char *name,
+  const char *description,
+  const edgex_strings *labels,
+  const char *profilename,
+  edgex_error *err
+);
+
+/**
+ * @brief Obtain a list of devices known to the system.
+ * @param svc The device service.
+ */
+
+edgex_device * edgex_device_devices (edgex_device_service *svc);
+
+/**
+ * @brief Retrieve device information.
+ * @param svc The device service.
+ * @param id The device id.
+ * @returns The requested device metadata or null if the device was not found.
+ */
+
+edgex_device * edgex_device_get_device
+  (edgex_device_service *svc, const char *id);
+
+/**
+ * @brief Retrieve device information.
+ * @param svc The device service.
+ * @param name The device name.
+ * @returns The requested device metadata or null if the device was not found.
+ */
+
+edgex_device * edgex_device_get_device_byname
+  (edgex_device_service *svc, const char *name);
+
+/**
+ * @brief Free a device structure or list of device structures.
+ * @param The device or the first device in the list.
+ */
+
+void edgex_device_free_device (edgex_device *e);
+
+/**
+ * @brief Retrieve the device profiles currently known in the SDK.
+ * @param svc The device service.
+ * @param profiles Is set to an array of device profiles. This should be
+ *        freed using edgex_deviceprofile_free_array() after use.
+ * @returns the size of the returned array.
+ */
+
+uint32_t edgex_device_service_getprofiles
+(
+  edgex_device_service *svc,
+  edgex_deviceprofile **profiles
+);
+
+/**
+ * @brief Free an array of device profiles.
+ * @param e The array.
+ * @param count The number of elements in the array.
+ */
+
+void edgex_deviceprofile_free_array (edgex_deviceprofile *e, unsigned count);
+
+#endif

--- a/include/edgex/edgex-base.h
+++ b/include/edgex/edgex-base.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2019
+ * IoTech Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#ifndef _EDGEX_EDGEX_BASE_H_
+#define _EDGEX_EDGEX_BASE_H_
+
+#include "edgex/os.h"
+
+typedef struct edgex_strings
+{
+  char *str;
+  struct edgex_strings *next;
+} edgex_strings;
+
+typedef struct edgex_nvpairs
+{
+  char *name;
+  char *value;
+  struct edgex_nvpairs *next;
+} edgex_nvpairs;
+
+typedef struct edgex_blob
+{
+  size_t size;
+  uint8_t *bytes;
+} edgex_blob;
+
+typedef enum
+{
+  Bool,
+  String,
+  Binary,
+  Uint8, Uint16, Uint32, Uint64,
+  Int8, Int16, Int32, Int64,
+  Float32, Float64
+} edgex_propertytype;
+
+typedef union edgex_device_resultvalue
+{
+  bool bool_result;
+  char *string_result;
+  uint8_t ui8_result;
+  uint16_t ui16_result;
+  uint32_t ui32_result;
+  uint64_t ui64_result;
+  int8_t i8_result;
+  int16_t i16_result;
+  int32_t i32_result;
+  int64_t i64_result;
+  float f32_result;
+  double f64_result;
+  edgex_blob binary_result;
+} edgex_device_resultvalue;
+
+typedef struct edgex_protocols
+{
+  char *name;
+  edgex_nvpairs *properties;
+  struct edgex_protocols *next;
+} edgex_protocols;
+
+#endif

--- a/include/edgex/edgex.h
+++ b/include/edgex/edgex.h
@@ -9,34 +9,11 @@
 #ifndef _EDGEX_EDGEX_H_
 #define _EDGEX_EDGEX_H_
 
-#include "edgex/os.h"
-
-typedef enum
-{
-  Bool,
-  String,
-  Binary,
-  Uint8, Uint16, Uint32, Uint64,
-  Int8, Int16, Int32, Int64,
-  Float32, Float64
-} edgex_propertytype;
+#include "edgex/edgex-base.h"
 
 typedef enum { LOCKED, UNLOCKED } edgex_device_adminstate;
 
 typedef enum { ENABLED, DISABLED } edgex_device_operatingstate;
-
-typedef struct edgex_nvpairs
-{
-  char *name;
-  char *value;
-  struct edgex_nvpairs *next;
-} edgex_nvpairs;
-
-typedef struct edgex_strings
-{
-  char *str;
-  struct edgex_strings *next;
-} edgex_strings;
 
 typedef struct
 {
@@ -65,13 +42,6 @@ typedef struct
   char *topic;
   char *user;
 } edgex_addressable;
-
-typedef struct edgex_protocols
-{
-  char *name;
-  edgex_nvpairs *properties;
-  struct edgex_protocols *next;
-} edgex_protocols;
 
 typedef struct
 {

--- a/include/edgex/registry.h
+++ b/include/edgex/registry.h
@@ -15,7 +15,7 @@
  *        pluggable registries.
  */
 
-#include "edgex/edgex.h"
+#include "edgex/edgex-base.h"
 #include "edgex/error.h"
 #include "edgex/edgex_logging.h"
 

--- a/src/c/config.c
+++ b/src/c/config.c
@@ -10,6 +10,7 @@
 #include "service.h"
 #include "errorlist.h"
 #include "edgex_rest.h"
+#include "edgex/device-mgmt.h"
 
 #include <microhttpd.h>
 

--- a/src/c/devman.c
+++ b/src/c/devman.c
@@ -12,6 +12,7 @@
 #include "edgex_rest.h"
 #include "errorlist.h"
 #include "edgex_time.h"
+#include "edgex/device-mgmt.h"
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/c/discovery.c
+++ b/src/c/discovery.c
@@ -30,6 +30,11 @@ int edgex_device_handler_discovery
 {
   edgex_device_service *svc = (edgex_device_service *) ctx;
 
+  if (svc->userfns.discover == NULL)
+  {
+    return MHD_HTTP_NOT_IMPLEMENTED;
+  }
+
   if (svc->adminstate == LOCKED || svc->opstate == DISABLED)
   {
     return MHD_HTTP_LOCKED;

--- a/src/c/edgex_rest.c
+++ b/src/c/edgex_rest.c
@@ -7,6 +7,7 @@
  */
 
 #include "edgex_rest.h"
+#include "edgex/device-mgmt.h"
 #include "cmdinfo.h"
 #include "parson.h"
 #include <string.h>

--- a/src/c/examples/template.c
+++ b/src/c/examples/template.c
@@ -181,7 +181,7 @@ static bool template_put_handler
 
 /* ---- Disconnect ---- */
 /* Disconnect handles protocol-specific cleanup when a device is removed. */
-static bool template_disconnect (void *impl, edgex_addressable *device)
+static bool template_disconnect (void *impl, edgex_protocols *device)
 {
   return true;
 }

--- a/src/c/profiles.c
+++ b/src/c/profiles.c
@@ -6,6 +6,7 @@
  *
  */
 
+#include "edgex/device-mgmt.h"
 #include "profiles.h"
 #include "service.h"
 #include "metadata.h"

--- a/src/c/service.c
+++ b/src/c/service.c
@@ -20,6 +20,7 @@
 #include "edgex_rest.h"
 #include "edgex_time.h"
 #include "edgex/csdk-defs.h"
+#include "edgex/registry.h"
 
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
+ Fix leftover reference to edgex_addressable relating to a device
+ Make discovery callback optional

Signed-off-by: Iain Anderson <iain@iotechsys.com>