### PR TITLE
Dynamic configuration support

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@ differs as follows:
 
 Changes for 1.0.0:
 
+- Initial support for configuration changes without restarting.
 - Support Correlation IDs. This introduces a requirement for libUUID.
 - The API for Event generation other than via device GET requests is split out
   into a seperate header edgex/eventgen.h
@@ -26,8 +27,6 @@ Changes for 1.0.0:
   edgex_addressable.
 - The device endpoint can be used to access either resources or deviceResources.
   The commands section of a device profile is not used.
-  - *** This results in the possibility that NULL resourceoperations are passed
-        to the set or get handlers ***
 - Endpoints for other EdgeX microservices are obtained from the registry (if
   enabled) rather than configuration.
 - Metadata for individual devices can be obtained in the device management API.

--- a/TODO
+++ b/TODO
@@ -8,5 +8,3 @@ Discovery - Implement ProvisionWatchers.
 Threadpool - Configure number of threads.
 
 Provide device profile management API.
-
-Allow configuration changes without restart (when using registry).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,6 +56,7 @@ Option | Type | Notes
 :--- | :--- | :---
 RemoteURL | String | If this option is set, logs will be submitted to a logging service at the specified URL.
 File | String | If this option is set, logs will be written to the named file. Setting a value of "-" causes logs to be written to standard output.
+LogLevel | String | Sets the logging level. Available settings in order of increasing severity are: TRACE, DEBUG, INFO, WARNING, ERROR.
 
 ## Driver section
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,7 +6,7 @@ DOCGEN=false
 
 IOTECH=IOTechSystems
 CUTILNAME=iotech-c-utils
-CUTILREF=1a0be9f
+CUTILREF=fc39644
 CUTILDIR=$IOTECH-$CUTILNAME-$CUTILREF
 
 # Process arguments

--- a/src/c/config.h
+++ b/src/c/config.h
@@ -56,6 +56,7 @@ typedef struct edgex_device_logginginfo
 {
   char *file;
   char *remoteurl;
+  iot_loglevel_t level;
 } edgex_device_logginginfo;
 
 typedef struct edgex_device_watcherinfo
@@ -91,6 +92,8 @@ void edgex_device_populateConfig
 
 void edgex_device_populateConfigNV
   (edgex_device_service *svc, const edgex_nvpairs *config, edgex_error *err);
+
+void edgex_device_updateConf (void *svc, const edgex_nvpairs *config);
 
 void edgex_device_validateConfig (edgex_device_service *svc, edgex_error *err);
 

--- a/src/c/consul.h
+++ b/src/c/consul.h
@@ -11,6 +11,7 @@
 
 #include "edgex/edgex.h"
 #include "edgex/edgex_logging.h"
+#include "edgex/registry.h"
 #include "edgex/error.h"
 
 bool edgex_consul_client_ping
@@ -23,9 +24,13 @@ bool edgex_consul_client_ping
 edgex_nvpairs *edgex_consul_client_get_config
 (
   iot_logger_t *lc,
+  iot_threadpool_t *thpool,
   void *location,
   const char *servicename,
   const char *profile,
+  edgex_registry_updatefn updater,
+  void *updatectx,
+  atomic_bool *updatedone,
   edgex_error *err
 );
 

--- a/src/c/errorlist.h
+++ b/src/c/errorlist.h
@@ -19,10 +19,7 @@
 #define EDGEX_NO_DEVICE_VERSION (edgex_error){ .code = 7, .reason = "No Device version was specified" }
 #define EDGEX_NO_CTX (edgex_error){ .code = 8, .reason = "No connection context supplied" }
 #define EDGEX_INVALID_ARG (edgex_error){ .code = 9, .reason = "Invalid argument" }
-#define EDGEX_HTTP_GET_ERROR (edgex_error){ .code = 10, .reason = "HTTP GET failed" }
-#define EDGEX_HTTP_POST_ERROR (edgex_error){ .code = 11, .reason = "HTTP POST failed" }
-#define EDGEX_HTTP_POSTFILE_ERROR (edgex_error){ .code = 12, .reason = "HTTP POST failed" }
-#define EDGEX_HTTP_PUT_ERROR (edgex_error){ .code = 13, .reason = "HTTP PUT failed" }
+// errors 10..13 superceded by EDGEX_HTTP_ERROR
 #define EDGEX_DRIVER_UNSTART (edgex_error){ .code = 14, .reason = "Protocol driver initialization failed" }
 #define EDGEX_REMOTE_SERVER_DOWN (edgex_error){ .code = 15, .reason = "Remote server unresponsive" }
 #define EDGEX_PROFILE_PARSE_ERROR (edgex_error){ .code = 16, .reason = "Error while parsing device profile" }
@@ -30,4 +27,5 @@
 #define EDGEX_CONSUL_RESPONSE (edgex_error){ .code = 18, .reason = "Unable to process response from consul" }
 #define EDGEX_PROFILES_DIRECTORY (edgex_error){ .code = 19, .reason = "Problem scanning profiles directory" }
 #define EDGEX_ASSERT_FAIL (edgex_error){ .code = 20, .reason = "A reading did not match a specified assertion string" }
+#define EDGEX_HTTP_ERROR (edgex_error){ .code = 21, .reason = "HTTP request failed" }
 #endif

--- a/src/c/examples/res/configuration.toml
+++ b/src/c/examples/res/configuration.toml
@@ -31,6 +31,7 @@
 [Logging]
   RemoteURL = ""
   File = "-"
+  LogLevel = "DEBUG"
 
 [[DeviceList]]
   Name = "TemplateDevice"

--- a/src/c/rest.c
+++ b/src/c/rest.c
@@ -32,75 +32,91 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #define USE_CURL_MIME
 #endif
 
-#define HTTP_UNAUTH 401
-
 #define MAX_TOKEN_LEN 600
+#define EDGEX_AUTH_HDR "Authorization: Bearer "
+
+/* Add a request header to the list */
+
+static struct curl_slist *edgex_add_hdr (struct curl_slist *slist, const char *name, const char *value)
+{
+  char *bearer = malloc (strlen (name) + strlen (value) + 3);
+  strcpy (bearer, name);
+  strcat (bearer, ": ");
+  strcat (bearer, value);
+  slist = curl_slist_append (slist, bearer);
+  free (bearer);
+  return slist;
+}
+
+/* Add a header for correlation ID if we have one */
 
 static struct curl_slist *edgex_add_crlid_hdr (struct curl_slist *slist)
 {
   const char *id = edgex_device_get_crlid ();
-  if (id)
-  {
-    char *bearer = malloc (sizeof (EDGEX_CRLID_HDR) + strlen (id) + 2);
-    strcpy (bearer, EDGEX_CRLID_HDR);
-    strcat (bearer, ": ");
-    strcat (bearer, id);
-    slist = curl_slist_append (slist, bearer);
-    free (bearer);
-  }
-  return slist;
+  return id ? edgex_add_hdr (slist, EDGEX_CRLID_HDR, id) : slist;
 }
 
-static struct curl_slist *edgex_add_auth_hdr
-  (iot_logger_t *lc, edgex_ctx *ctx, struct curl_slist *slist)
-{
-  int bearer_size;
-  char *bearer;
+/* Populate request headers from a list */
 
-  /*
-   * Create the Authorization header if needed
-   */
+static struct curl_slist *edgex_add_other_hdrs (struct curl_slist *slist, const edgex_nvpairs *hdrs)
+{
+  struct curl_slist *s = slist;
+  for (const edgex_nvpairs *h = hdrs; h; h = h->next)
+  {
+    s = edgex_add_hdr (s, h->name, h->value);
+  }
+  return s;
+}
+
+/* Create the Authorization header if needed */
+
+static struct curl_slist *edgex_add_auth_hdr (edgex_ctx *ctx, struct curl_slist *slist)
+{
   if (ctx->jwt_token)
   {
-    bearer_size = strnlen (ctx->jwt_token, MAX_TOKEN_LEN) + 23;
-    bearer = calloc (1, bearer_size);
-    if (!bearer)
-    {
-      iot_log_error (lc, "unable to allocate memory.");
-      return slist;
-    }
-    snprintf
-      (bearer, bearer_size + 1, "Authorization: Bearer %s", ctx->jwt_token);
+    char *bearer = malloc (sizeof (EDGEX_AUTH_HDR) + strnlen (ctx->jwt_token, MAX_TOKEN_LEN));
+    strcpy (bearer, EDGEX_AUTH_HDR);
+    strncat (bearer, ctx->jwt_token, MAX_TOKEN_LEN);
     slist = curl_slist_append (slist, bearer);
     free (bearer);
   }
   return slist;
 }
 
+/* Callback: inspect a returned header to see if it matches any that we want */
 
-static void edgex_log_peer_cert
-  (iot_logger_t *lc, edgex_ctx *ctx, CURL *hnd)
+static size_t edgex_check_rsp_hdr (char *buffer, size_t size, size_t nitems, void *v)
 {
-  int rv;
-  union
+  char *end = buffer + size * nitems - 1;
+  for (edgex_nvpairs *i = (edgex_nvpairs *)v; i; i = i->next)
   {
-    struct curl_slist *to_info;
-    struct curl_certinfo *to_certinfo;
-  } ptr;
-  int i;
-  struct curl_slist *slist;
-
-  ptr.to_info = NULL;
-
-  rv = curl_easy_getinfo(hnd, CURLINFO_CERTINFO, &ptr.to_info);
-
-  if (!rv && ptr.to_info)
-  {
-    iot_log_info (lc, "TLS peer presented the following %d certificates...",
-                  ptr.to_certinfo->num_of_certs);
-    for (i = 0; i < ptr.to_certinfo->num_of_certs; i++)
+    int len = strlen (i->name);
+    if ((end - buffer > len) && (strncmp (buffer, i->name, len) == 0) && (buffer[len] == ':'))
     {
-      for (slist = ptr.to_certinfo->certinfo[i]; slist; slist = slist->next)
+      char *start = buffer + len + 1;
+      while (start < end && *start == ' ') start++;
+      while (end > start && (*end == '\n' || *end == ' ' || *end == '\r' )) end--;
+      i->value = strndup (start, end - start + 1);
+    }
+  }
+  return size * nitems;
+}
+
+/* Inspect returned certificates and log their contents */
+
+static void edgex_log_peer_cert (iot_logger_t *lc, edgex_ctx *ctx, CURL *hnd)
+{
+  struct curl_slist *slist;
+  struct curl_certinfo *certs = NULL;
+
+  int rv = curl_easy_getinfo (hnd, CURLINFO_CERTINFO, &certs);
+
+  if (!rv && certs)
+  {
+    iot_log_info (lc, "TLS peer presented the following %d certificates...", certs->num_of_certs);
+    for (int i = 0; i < certs->num_of_certs; i++)
+    {
+      for (slist = certs->certinfo[i]; slist; slist = slist->next)
       {
         iot_log_info (lc, "%s", slist->data);
       }
@@ -108,8 +124,9 @@ static void edgex_log_peer_cert
   }
 }
 
-size_t edgex_http_write_cb
-  (void *contents, size_t size, size_t nmemb, void *userp)
+/* Append a chunk of returned data to the buffer */
+
+size_t edgex_http_write_cb (void *contents, size_t size, size_t nmemb, void *userp)
 {
   edgex_ctx *ctx = (edgex_ctx *) userp;
   size *= nmemb;
@@ -121,297 +138,45 @@ size_t edgex_http_write_cb
   return size;
 }
 
-/*
- * This function uses libcurl to send a simple HTTP GET
- * request with no Content-Type header.
- * TLS peer verification is enabled, but not HTTP authentication.
- * The parameters are:
- *
- * ctx: Ptr to edgex_ctx, which contains the server name
- * url: URL to use for the GET request
- * writefunc: Function pointer to handle writing the data
- *            from the HTTP body received from the server.
- *
- * Return value is the HTTP status value from the server
- *	    (e.g. 200 for HTTP OK)
- */
-long edgex_http_get (iot_logger_t *lc, edgex_ctx *ctx, const char *url,
-                     void *writefunc, edgex_error *err)
+/* Kill an ongoing request if our flag becomes set */
+
+static int abort_callback (void *clientp, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow)
 {
-  long http_code = 0;
-  CURL *hnd;
-  struct curl_slist *slist;
-  CURLcode rc;
-
-  slist = NULL;
-  /*
-   * Create the Authorization header if needed
-   */
-  slist = edgex_add_auth_hdr (lc, ctx, slist);
-  slist = edgex_add_crlid_hdr (slist);
-  ctx->buff = malloc (1);
-  ctx->size = 0;
-
-  /*
-   * Setup Curl
-   */
-  hnd = curl_easy_init ();
-  curl_easy_setopt(hnd, CURLOPT_URL, url);
-  curl_easy_setopt(hnd, CURLOPT_NOPROGRESS, 1L);
-  curl_easy_setopt(hnd, CURLOPT_USERAGENT, "edgex");
-  if (slist)
-  {
-    curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, slist);
-  }
-  if (ctx->verify_peer && ctx->cacerts_file)
-  {
-    curl_easy_setopt(hnd, CURLOPT_CAINFO, ctx->cacerts_file);
-    curl_easy_setopt(hnd, CURLOPT_SSL_VERIFYPEER, 1L);
-    curl_easy_setopt(hnd, CURLOPT_CERTINFO, 1L);
-  }
-  else
-  {
-    curl_easy_setopt(hnd, CURLOPT_SSL_VERIFYPEER, 0L);
-  }
-  curl_easy_setopt(hnd, CURLOPT_TCP_KEEPALIVE, 1L);
-  if (ctx->tls_cert && ctx->tls_key)
-  {
-    curl_easy_setopt(hnd, CURLOPT_SSLCERTTYPE, "PEM");
-    curl_easy_setopt(hnd, CURLOPT_SSLCERT, ctx->tls_cert);
-    curl_easy_setopt(hnd, CURLOPT_SSLKEYTYPE, "PEM");
-    curl_easy_setopt(hnd, CURLOPT_SSLKEY, ctx->tls_key);
-  }
-  /*
-   * If the caller wants the HTTP data from the server
-   * set the callback function
-   */
-  if (writefunc)
-  {
-    curl_easy_setopt(hnd, CURLOPT_WRITEDATA, ctx);
-    curl_easy_setopt(hnd, CURLOPT_WRITEFUNCTION, writefunc);
-  }
-
-  /*
-   * Send the HTTP GET request
-   */
-  rc = curl_easy_perform (hnd);
-  if (rc != CURLE_OK)
-  {
-    iot_log_error (lc, "curl_easy_perform returned: %d", (int) rc);
-    *err = EDGEX_HTTP_GET_ERROR;
-    return 0;
-  }
-
-  /*
-   * Get the cert info from the TLS peer
-   */
-  if (ctx->verify_peer)
-  {
-    edgex_log_peer_cert (lc, ctx, hnd);
-  }
-
-  /*
-   * Get the HTTP reponse status code from the server
-   */
-  curl_easy_getinfo(hnd, CURLINFO_RESPONSE_CODE, &http_code);
-
-  if (http_code < 200 || http_code >= 300)
-  {
-    iot_log_info (lc, "HTTP response: %d", (int) http_code);
-    *err = EDGEX_HTTP_GET_ERROR;
-  }
-  else
-  {
-    *err = EDGEX_OK;
-  }
-
-  curl_easy_cleanup (hnd);
-  hnd = NULL;
-  if (slist)
-  {
-    curl_slist_free_all (slist);
-    slist = NULL;
-  }
-
-  return http_code;
+  atomic_bool *flag = (atomic_bool *)clientp;
+  return (*flag) ? 1 : 0;
 }
 
 /*
- * This function uses libcurl to send a simple HTTP DELETE
- * request with no Content-Type header.
- * TLS peer verification is enabled, but not HTTP authentication.
- * The parameters are:
- *
- * ctx: Ptr to edgex_ctx, which contains the server name
- * url: URL to use for the DELETE request
- * writefunc: Function pointer to handle writing the data
- *            from the HTTP body received from the server.
- *
- * Return value is the HTTP status value from the server
- *	    (e.g. 200 for HTTP OK)
+ * Set up common curl options and headers, perform the http request, process the results and clean up.
+ * Additional options may be set by calling curl_easy_setopt before this.
+ * Extra headers may be added by passing non-null slist_in.
  */
-long edgex_http_delete (iot_logger_t *lc, edgex_ctx *ctx, const char *url,
-                        void *writefunc, edgex_error *err)
-{
-  long http_code = 0;
-  CURL *hnd;
-  struct curl_slist *slist;
-  CURLcode rc;
 
-  slist = NULL;
-  /*
-   * Create the Authorization header if needed
-   */
-  slist = edgex_add_auth_hdr (lc, ctx, slist);
-  slist = edgex_add_crlid_hdr (slist);
-
-  ctx->buff = malloc (1);
-  ctx->size = 0;
-
-  /*
-   * Setup Curl
-   */
-  hnd = curl_easy_init ();
-  curl_easy_setopt(hnd, CURLOPT_URL, url);
-  curl_easy_setopt(hnd, CURLOPT_NOPROGRESS, 1L);
-  curl_easy_setopt(hnd, CURLOPT_USERAGENT, "edgex");
-  curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "DELETE");
-  if (slist)
-  {
-    curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, slist);
-  }
-  if (ctx->verify_peer && ctx->cacerts_file)
-  {
-    curl_easy_setopt(hnd, CURLOPT_CAINFO, ctx->cacerts_file);
-    curl_easy_setopt(hnd, CURLOPT_SSL_VERIFYPEER, 1L);
-    curl_easy_setopt(hnd, CURLOPT_CERTINFO, 1L);
-  }
-  else
-  {
-    curl_easy_setopt(hnd, CURLOPT_SSL_VERIFYPEER, 0L);
-  }
-  curl_easy_setopt(hnd, CURLOPT_TCP_KEEPALIVE, 1L);
-  if (ctx->tls_cert && ctx->tls_key)
-  {
-    curl_easy_setopt(hnd, CURLOPT_SSLCERTTYPE, "PEM");
-    curl_easy_setopt(hnd, CURLOPT_SSLCERT, ctx->tls_cert);
-    curl_easy_setopt(hnd, CURLOPT_SSLKEYTYPE, "PEM");
-    curl_easy_setopt(hnd, CURLOPT_SSLKEY, ctx->tls_key);
-  }
-  /*
-   * If the caller wants the HTTP data from the server
-   * set the callback function
-   */
-  if (writefunc)
-  {
-    curl_easy_setopt(hnd, CURLOPT_WRITEDATA, ctx);
-    curl_easy_setopt(hnd, CURLOPT_WRITEFUNCTION, writefunc);
-  }
-
-  /*
-   * Send the HTTP DELETE request
-   */
-  rc = curl_easy_perform (hnd);
-  if (rc != CURLE_OK)
-  {
-    iot_log_error (lc, "curl_easy_perform returned: %d", (int) rc);
-    *err = EDGEX_HTTP_GET_ERROR;
-    return 0;
-  }
-
-  /*
-   * Get the cert info from the TLS peer
-   */
-  if (ctx->verify_peer)
-  {
-    edgex_log_peer_cert (lc, ctx, hnd);
-  }
-
-  /*
-   * Get the HTTP reponse status code from the server
-   */
-  curl_easy_getinfo(hnd, CURLINFO_RESPONSE_CODE, &http_code);
-
-  if (http_code < 200 || http_code >= 300)
-  {
-    iot_log_info (lc, "HTTP response: %d", (int) http_code);
-    *err = EDGEX_HTTP_GET_ERROR;
-  }
-  else
-  {
-    *err = EDGEX_OK;
-  }
-
-  curl_easy_cleanup (hnd);
-  hnd = NULL;
-  if (slist)
-  {
-    curl_slist_free_all (slist);
-    slist = NULL;
-  }
-
-  return http_code;
-}
-
-/*
- * This function uses libcurl to send a simple HTTP POST
- * request with JSON data.
- * TLS peer verification is enabled, but not HTTP authentication.
- * The parameters are:
- *
- * ctx: Ptr to edgex_ctx, which contains the server name
- * url: URL to use for the GET request
- * data: data to POST to the server
- * writefunc: Function pointer to handle writing the data
- *            from the HTTP body received from the server.
- *
- * Return value is the HTTP status value from the server
- *	    (e.g. 200 for HTTP OK)
- */
-long edgex_http_post
+static long edgex_run_curl
 (
   iot_logger_t *lc,
   edgex_ctx *ctx,
+  CURL *hnd,
   const char *url,
-  const char *data,
   void *writefunc,
+  struct curl_slist *slist_in,
   edgex_error *err
 )
 {
-  long http_code = 0;
-  CURL *hnd;
-  CURLcode crv;
   struct curl_slist *slist;
+  CURLcode rc;
+  long http_code = 0;
 
-  /*
-   * Set the Content-Type header in the HTTP request
-   */
-  slist = NULL;
-  slist = curl_slist_append (slist, "Content-Type:application/json");
-
-  /*
-   * Create the Authorization header if needed
-   */
-  slist = edgex_add_auth_hdr (lc, ctx, slist);
-  slist = edgex_add_crlid_hdr (slist);
-
-  ctx->buff = malloc (1);
+  /* Init buffer */
+  ctx->buff = NULL;
   ctx->size = 0;
 
-  /*
-   * Setup Curl
-   */
-  hnd = curl_easy_init ();
+  /* Setup Curl */
   curl_easy_setopt(hnd, CURLOPT_URL, url);
-  curl_easy_setopt(hnd, CURLOPT_NOPROGRESS, 1L);
   curl_easy_setopt(hnd, CURLOPT_USERAGENT, "edgex");
-  curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, slist);
-  curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "POST");
-  curl_easy_setopt(hnd, CURLOPT_POST, 1L);
-  curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, data);
-  curl_easy_setopt
-    (hnd, CURLOPT_POSTFIELDSIZE_LARGE, (curl_off_t) strlen (data));
-  //FIXME: we should always to TLS peer auth
+  curl_easy_setopt(hnd, CURLOPT_TCP_KEEPALIVE, 1L);
+
+  /* TLS options */
   if (ctx->verify_peer && ctx->cacerts_file)
   {
     curl_easy_setopt(hnd, CURLOPT_CAINFO, ctx->cacerts_file);
@@ -422,7 +187,6 @@ long edgex_http_post
   {
     curl_easy_setopt(hnd, CURLOPT_SSL_VERIFYPEER, 0L);
   }
-  curl_easy_setopt(hnd, CURLOPT_TCP_KEEPALIVE, 1L);
   if (ctx->tls_cert && ctx->tls_key)
   {
     curl_easy_setopt(hnd, CURLOPT_SSLCERTTYPE, "PEM");
@@ -431,87 +195,120 @@ long edgex_http_post
     curl_easy_setopt(hnd, CURLOPT_SSLKEY, ctx->tls_key);
   }
 
-  /*
-   * If the caller wants the HTTP data from the server
-   * set the callback function
-   */
+  /* Setup for response header processing */
+  if (ctx->rsphdrs)
+  {
+    curl_easy_setopt(hnd, CURLOPT_HEADERFUNCTION, edgex_check_rsp_hdr);
+    curl_easy_setopt(hnd, CURLOPT_HEADERDATA, ctx->rsphdrs);
+  }
+
+  /* Use the progress callback to abort a request on demand */
+  if (ctx->aborter)
+  {
+    curl_easy_setopt(hnd, CURLOPT_NOPROGRESS, 0L);
+    curl_easy_setopt(hnd, CURLOPT_XFERINFOFUNCTION, abort_callback);
+    curl_easy_setopt(hnd, CURLOPT_XFERINFODATA, ctx->aborter);
+  }
+  else
+  {
+    curl_easy_setopt(hnd, CURLOPT_NOPROGRESS, 1L);
+  }
+
+  /* If the caller wants the HTTP data from the server set the callback function */
   if (writefunc)
   {
     curl_easy_setopt(hnd, CURLOPT_WRITEDATA, ctx);
     curl_easy_setopt(hnd, CURLOPT_WRITEFUNCTION, writefunc);
   }
 
-  /*
-   * Send the HTTP POST request
-   */
-  crv = curl_easy_perform (hnd);
-  if (crv != CURLE_OK)
+  /* Setup header list */
+  slist = edgex_add_auth_hdr (ctx, slist_in);
+  slist = edgex_add_crlid_hdr (slist);
+  slist = edgex_add_other_hdrs (slist, ctx->reqhdrs);
+  if (slist)
   {
-    iot_log_error
-      (lc, "Curl failed with code %d (%s)", crv, curl_easy_strerror (crv));
-    *err = EDGEX_HTTP_POST_ERROR;
-    return 0;
+    curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, slist);
   }
 
-  /*
-   * Get the cert info from the TLS peer
-   */
-  if (ctx->verify_peer)
-  {
-    edgex_log_peer_cert (lc, ctx, hnd);
-  }
+  /* Make the call */
+  rc = curl_easy_perform (hnd);
 
-  /*
-   * Get the HTTP reponse status code from the server
-   */
-  curl_easy_getinfo(hnd, CURLINFO_RESPONSE_CODE, &http_code);
+  if (rc == CURLE_OK)
+  {
+    /* Get the cert info from the TLS peer */
+    if (ctx->verify_peer)
+    {
+      edgex_log_peer_cert (lc, ctx, hnd);
+    }
 
-  if (http_code == 409)
-  {
-    iot_log_info (lc, "HTTP response 409 - Conflict");
-    *err = EDGEX_HTTP_CONFLICT;
+    /* Get the HTTP reponse status code from the server */
+    curl_easy_getinfo (hnd, CURLINFO_RESPONSE_CODE, &http_code);
+
+    if (http_code == 409)
+    {
+      iot_log_info (lc, "HTTP response 409 - Conflict");
+      *err = EDGEX_HTTP_CONFLICT;
+    }
+    else if (http_code < 200 || http_code >= 300)
+    {
+      iot_log_info (lc, "HTTP response: %d", (int)http_code);
+      *err = EDGEX_HTTP_ERROR;
+    }
+    else
+    {
+      *err = EDGEX_OK;
+    }
   }
-  else if (http_code < 200 || http_code >= 300)
+  else if (rc == CURLE_ABORTED_BY_CALLBACK)
   {
-    iot_log_error (lc, "HTTP response: %d", (int) http_code);
-    *err = EDGEX_HTTP_POST_ERROR;
+    iot_log_debug (lc, "HTTP operation aborted via callback");
+    *err = EDGEX_OK;
   }
   else
   {
-    *err = EDGEX_OK;
+    iot_log_error (lc, "Curl failed with code %d (%s)", rc, curl_easy_strerror (rc));
+    *err = EDGEX_HTTP_ERROR;
   }
 
   curl_easy_cleanup (hnd);
-  hnd = NULL;
   curl_slist_free_all (slist);
-  slist = NULL;
-
   return http_code;
 }
 
-/*
- * This function uses libcurl to send a HTTP POST
- * request with a form-based file upload
- * TLS peer verification is enabled, but not HTTP authentication.
- * The parameters are:
- *
- * ctx: Ptr to edgex_ctx, which contains the server name
- * url: URL to use for the GET request
- * fname: name of file to POST to the server
- * writefunc: Function pointer to handle writing the data
- *            from the HTTP body received from the server.
- *
- * Return value is the HTTP status value from the server
- *	    (e.g. 200 for HTTP OK)
- */
-long
-edgex_http_postfile (iot_logger_t *lc, edgex_ctx *ctx, const char *url,
-                     const char *fname, void *writefunc, edgex_error *err)
+long edgex_http_get (iot_logger_t *lc, edgex_ctx *ctx, const char *url, void *writefunc, edgex_error *err)
+{
+  CURL *hnd = curl_easy_init ();
+  return edgex_run_curl (lc, ctx, hnd, url, writefunc, NULL, err);
+}
+
+long edgex_http_delete (iot_logger_t *lc, edgex_ctx *ctx, const char *url, void *writefunc, edgex_error *err)
+{
+  CURL *hnd = curl_easy_init ();
+  curl_easy_setopt (hnd, CURLOPT_CUSTOMREQUEST, "DELETE");
+
+  return edgex_run_curl (lc, ctx, hnd, url, writefunc, NULL, err);
+}
+
+long edgex_http_post
+  (iot_logger_t *lc, edgex_ctx *ctx, const char *url, const char *data, void *writefunc, edgex_error *err)
+{
+  struct curl_slist *slist;
+  CURL *hnd = curl_easy_init ();
+
+  curl_easy_setopt (hnd, CURLOPT_CUSTOMREQUEST, "POST");
+  curl_easy_setopt (hnd, CURLOPT_POST, 1L);
+  curl_easy_setopt (hnd, CURLOPT_POSTFIELDS, data);
+  curl_easy_setopt (hnd, CURLOPT_POSTFIELDSIZE_LARGE, (curl_off_t) strlen (data));
+
+  slist = edgex_add_hdr (NULL, "Content-Type", "application/json");
+  return edgex_run_curl (lc, ctx, hnd, url, writefunc, slist, err);
+}
+
+long edgex_http_postfile
+  (iot_logger_t *lc, edgex_ctx *ctx, const char *url, const char *fname, void *writefunc, edgex_error *err)
 {
   long http_code = 0;
   CURL *hnd;
-  CURLcode crv;
-  struct curl_slist *slist;
 #ifdef USE_CURL_MIME
   curl_mime *form = NULL;
   curl_mimepart *field = NULL;
@@ -520,19 +317,6 @@ edgex_http_postfile (iot_logger_t *lc, edgex_ctx *ctx, const char *url,
   struct curl_httppost *lastptr = NULL;
 #endif
 
-  /*
-   * Create the Authorization header if needed
-   */
-  slist = NULL;
-  slist = edgex_add_auth_hdr (lc, ctx, slist);
-  slist = edgex_add_crlid_hdr (slist);
-
-  ctx->buff = malloc (1);
-  ctx->size = 0;
-
-  /*
-   * Setup Curl
-   */
   hnd = curl_easy_init ();
 
 #ifdef USE_CURL_MIME
@@ -548,104 +332,19 @@ edgex_http_postfile (iot_logger_t *lc, edgex_ctx *ctx, const char *url,
   curl_mime_data (field, "send", CURL_ZERO_TERMINATED);
   curl_easy_setopt(hnd, CURLOPT_MIMEPOST, form);
 #else
-  curl_formadd
-  (
-    &form, &lastptr,
-    CURLFORM_COPYNAME, "file", CURLFORM_FILE, fname, CURLFORM_END
-  );
-  curl_formadd
-  (
-    &form, &lastptr,
-    CURLFORM_COPYNAME, "filename", CURLFORM_COPYCONTENTS, fname, CURLFORM_END
-  );
-  curl_formadd
-  (
-    &form, &lastptr,
-    CURLFORM_COPYNAME, "submit", CURLFORM_COPYCONTENTS, "send", CURLFORM_END
-  );
+  curl_formadd (&form, &lastptr, CURLFORM_COPYNAME, "file", CURLFORM_FILE, fname, CURLFORM_END);
+  curl_formadd (&form, &lastptr, CURLFORM_COPYNAME, "filename", CURLFORM_COPYCONTENTS, fname, CURLFORM_END);
+  curl_formadd (&form, &lastptr, CURLFORM_COPYNAME, "submit", CURLFORM_COPYCONTENTS, "send", CURLFORM_END);
   curl_easy_setopt(hnd, CURLOPT_HTTPPOST, form);
 #endif
 
-  curl_easy_setopt(hnd, CURLOPT_URL, url);
-  curl_easy_setopt(hnd, CURLOPT_NOPROGRESS, 1L);
-  curl_easy_setopt(hnd, CURLOPT_USERAGENT, "edgex");
-  curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, slist);
-  //FIXME: we should always to TLS peer auth
-  if (ctx->verify_peer && ctx->cacerts_file)
-  {
-    curl_easy_setopt(hnd, CURLOPT_CAINFO, ctx->cacerts_file);
-    curl_easy_setopt(hnd, CURLOPT_SSL_VERIFYPEER, 1L);
-    curl_easy_setopt(hnd, CURLOPT_CERTINFO, 1L);
-  }
-  else
-  {
-    curl_easy_setopt(hnd, CURLOPT_SSL_VERIFYPEER, 0L);
-  }
-  curl_easy_setopt(hnd, CURLOPT_TCP_KEEPALIVE, 1L);
-  if (ctx->tls_cert && ctx->tls_key)
-  {
-    curl_easy_setopt(hnd, CURLOPT_SSLCERTTYPE, "PEM");
-    curl_easy_setopt(hnd, CURLOPT_SSLCERT, ctx->tls_cert);
-    curl_easy_setopt(hnd, CURLOPT_SSLKEYTYPE, "PEM");
-    curl_easy_setopt(hnd, CURLOPT_SSLKEY, ctx->tls_key);
-  }
+  http_code = edgex_run_curl (lc, ctx, hnd, url, writefunc, NULL, err);
 
-  /*
-   * If the caller wants the HTTP data from the server
-   * set the callback function
-   */
-  if (writefunc)
-  {
-    curl_easy_setopt(hnd, CURLOPT_WRITEDATA, ctx);
-    curl_easy_setopt(hnd, CURLOPT_WRITEFUNCTION, writefunc);
-  }
-
-  /*
-   * Send the HTTP POST request
-   */
-  crv = curl_easy_perform (hnd);
-  if (crv != CURLE_OK)
-  {
-    iot_log_error
-      (lc, "Curl failed with code %d (%s)", crv, curl_easy_strerror (crv));
-    *err = EDGEX_HTTP_POSTFILE_ERROR;
-    http_code = 0;
-  }
-  else
-  {
-    /*
-     * Get the cert info from the TLS peer
-     */
-    if (ctx->verify_peer)
-    {
-      edgex_log_peer_cert (lc, ctx, hnd);
-    }
-
-    /*
-     * Get the HTTP reponse status code from the server
-     */
-    curl_easy_getinfo(hnd, CURLINFO_RESPONSE_CODE, &http_code);
-
-    if (http_code < 200 || http_code >= 300)
-    {
-      iot_log_error (lc, "HTTP response: %d", (int) http_code);
-      *err = EDGEX_HTTP_POSTFILE_ERROR;
-    }
-    else
-    {
-      *err = EDGEX_OK;
-    }
-  }
-
-  curl_easy_cleanup (hnd);
-  hnd = NULL;
 #ifdef USE_CURL_MIME
   curl_mime_free (form);
 #else
   curl_formfree(form);
 #endif
-  curl_slist_free_all (slist);
-  slist = NULL;
 
   return http_code;
 }
@@ -657,8 +356,7 @@ struct put_data
   size_t remaining;
 };
 
-static size_t read_callback
-  (char *buffer, size_t size, size_t nitems, void *userdata)
+static size_t read_callback (char *buffer, size_t size, size_t nitems, void *userdata)
 {
   struct put_data *pd = (struct put_data *) userdata;
   size_t max_size = size * nitems;
@@ -675,44 +373,12 @@ static size_t read_callback
 }
 
 long edgex_http_put
-(
-  iot_logger_t *lc,
-  edgex_ctx *ctx,
-  const char *url,
-  const char *data,
-  void *writefunc,
-  edgex_error *err
-)
+  (iot_logger_t *lc, edgex_ctx *ctx, const char *url, const char *data, void *writefunc, edgex_error *err)
 {
-  long http_code = 0;
-  CURL *hnd;
-  CURLcode crv;
   struct curl_slist *slist;
   struct put_data cb_data;
+  CURL *hnd = curl_easy_init ();
 
-  /*
-   * Set the Content-Type header in the HTTP request
-   */
-  slist = NULL;
-  slist = curl_slist_append (slist, "Content-Type:application/json");
-
-  /*
-   * Create the Authorization header if needed
-   */
-  slist = edgex_add_auth_hdr (lc, ctx, slist);
-  slist = edgex_add_crlid_hdr (slist);
-
-  ctx->buff = malloc (1);
-  ctx->size = 0;
-
-  /*
-   * Setup Curl
-   */
-  hnd = curl_easy_init ();
-  curl_easy_setopt(hnd, CURLOPT_URL, url);
-  curl_easy_setopt(hnd, CURLOPT_NOPROGRESS, 1L);
-  curl_easy_setopt(hnd, CURLOPT_USERAGENT, "edgex");
-  curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, slist);
   curl_easy_setopt(hnd, CURLOPT_UPLOAD, 1L);
 
   if (data)
@@ -720,80 +386,11 @@ long edgex_http_put
     cb_data.data = data;
     cb_data.offset = 0;
     cb_data.remaining = strlen (data);
-    curl_easy_setopt(hnd, CURLOPT_READFUNCTION, read_callback);
-    curl_easy_setopt(hnd, CURLOPT_READDATA, &cb_data);
-    curl_easy_setopt(hnd, CURLOPT_INFILESIZE, cb_data.remaining);
+    curl_easy_setopt (hnd, CURLOPT_READFUNCTION, read_callback);
+    curl_easy_setopt (hnd, CURLOPT_READDATA, &cb_data);
+    curl_easy_setopt (hnd, CURLOPT_INFILESIZE, cb_data.remaining);
   }
 
-  //FIXME: we should always to TLS peer auth
-  if (ctx->verify_peer && ctx->cacerts_file)
-  {
-    curl_easy_setopt(hnd, CURLOPT_CAINFO, ctx->cacerts_file);
-    curl_easy_setopt(hnd, CURLOPT_SSL_VERIFYPEER, 1L);
-    curl_easy_setopt(hnd, CURLOPT_CERTINFO, 1L);
-  }
-  else
-  {
-    curl_easy_setopt(hnd, CURLOPT_SSL_VERIFYPEER, 0L);
-  }
-  curl_easy_setopt(hnd, CURLOPT_TCP_KEEPALIVE, 1L);
-  if (ctx->tls_cert && ctx->tls_key)
-  {
-    curl_easy_setopt(hnd, CURLOPT_SSLCERTTYPE, "PEM");
-    curl_easy_setopt(hnd, CURLOPT_SSLCERT, ctx->tls_cert);
-    curl_easy_setopt(hnd, CURLOPT_SSLKEYTYPE, "PEM");
-    curl_easy_setopt(hnd, CURLOPT_SSLKEY, ctx->tls_key);
-  }
-
-  /*
-   * If the caller wants the HTTP data from the server
-   * set the callback function
-   */
-  if (writefunc)
-  {
-    curl_easy_setopt(hnd, CURLOPT_WRITEDATA, ctx);
-    curl_easy_setopt(hnd, CURLOPT_WRITEFUNCTION, writefunc);
-  }
-
-  /*
-   * Send the HTTP PUT request
-   */
-  crv = curl_easy_perform (hnd);
-  if (crv != CURLE_OK)
-  {
-    iot_log_error (lc, "Curl failed with code %d (%s)", crv,
-                   curl_easy_strerror (crv));
-    *err = EDGEX_HTTP_PUT_ERROR;
-    return 0;
-  }
-
-  /*
-   * Get the cert info from the TLS peer
-   */
-  if (ctx->verify_peer)
-  {
-    edgex_log_peer_cert (lc, ctx, hnd);
-  }
-
-  /*
-   * Get the HTTP reponse status code from the server
-   */
-  curl_easy_getinfo(hnd, CURLINFO_RESPONSE_CODE, &http_code);
-
-  if (http_code < 200 || http_code >= 300)
-  {
-    iot_log_error (lc, "HTTP response: %d", (int) http_code);
-    *err = EDGEX_HTTP_PUT_ERROR;
-  }
-  else
-  {
-    *err = EDGEX_OK;
-  }
-
-  curl_easy_cleanup (hnd);
-  hnd = NULL;
-  curl_slist_free_all (slist);
-  slist = NULL;
-
-  return http_code;
+  slist = edgex_add_hdr (NULL, "Content-Type", "application/json");
+  return edgex_run_curl (lc, ctx, hnd, url, writefunc, slist, err);
 }

--- a/src/c/rest.h
+++ b/src/c/rest.h
@@ -10,66 +10,62 @@
 #define _EDGEX_DEVICE_REST_H_ 1
 
 #include "edgex/edgex_logging.h"
+#include "edgex/edgex-base.h"
 #include "edgex/error.h"
 
 typedef struct edgex_ctx
 {
-  char *cacerts_file;   // Location of CA certificates Curl will use to verify peer
-  int verify_peer;      // enables TLS peer verification via Curl
-  char *tls_cert;       // Location of PEM encoded X509 cert to use for TLS client auth
-  char *tls_key;        // Location of PEM encoded priv key to use for TLS client auth
-  char *jwt_token;      // access_token provided by server for authenticating REST calls
-  char *buff;           // used during curl processing
-  size_t size;
+  char *cacerts_file;     // Location of CA certificates Curl will use to verify peer
+  int verify_peer;        // enables TLS peer verification via Curl
+  char *tls_cert;         // Location of PEM encoded X509 cert to use for TLS client auth
+  char *tls_key;          // Location of PEM encoded priv key to use for TLS client auth
+  char *jwt_token;        // access_token provided by server for authenticating REST calls
+  edgex_nvpairs *reqhdrs; // headers to be sent with request
+  edgex_nvpairs *rsphdrs; // headers to be retrieved from response
+  atomic_bool *aborter;   // if non-null, can kill a request by setting to true
+  char *buff;             // data returned from the request
+  size_t size;            // current buffer size
 } edgex_ctx;
 
 #define URL_BUF_SIZE 512
 
-size_t edgex_http_write_cb
-  (void *contents, size_t size, size_t nmemb, void *userp);
+/*
+ * If this function is specified as the writefunc to a request, the returned data will be copied
+ * to the buffer in the edgex_ctx
+ */
+size_t edgex_http_write_cb (void *contents, size_t size, size_t nmemb, void *userp);
+
+/*
+ * These functions use libcurl to send http get/post/put/delete requests.
+ * TLS peer verification is enabled, but not HTTP authentication.
+ * The POST and PUT functions assume JSON data and set the request Content-Type accordingly.
+ * The common parameters are:
+ *
+ * lc: Logs will be written to this logging client.
+ * ctx: Ptr to edgex_ctx, which contains various processing parameters as detailed above.
+ * url: URL to use for the request.
+ * writefunc: Function pointer to handle writing the data from the HTTP body received from the server.
+ * err: Used to return error codes to the caller.
+ *
+ * The post and put functions take in addition a data parameter, this is the content that will be sent to the server.
+ * edgex_http_postfile performs a post operation which uploads a file, this is specified by filename.
+ *
+ * Return value is the HTTP status value from the server (e.g. 200 for HTTP OK)
+ */
 
 long edgex_http_get
-(
-  iot_logger_t *lc,
-  edgex_ctx *ctx,
-  const char *url,
-  void *writefunc,
-  edgex_error *err
-);
+  (iot_logger_t *lc, edgex_ctx *ctx, const char *url, void *writefunc, edgex_error *err);
+
 long edgex_http_delete
-(
-  iot_logger_t *lc,
-  edgex_ctx *ctx,
-  const char *url,
-  void *writefunc,
-  edgex_error *err
-);
+  (iot_logger_t *lc, edgex_ctx *ctx, const char *url, void *writefunc, edgex_error *err);
+
 long edgex_http_post
-(
-  iot_logger_t *lc,
-  edgex_ctx *ctx,
-  const char *url,
-  const char *data,
-  void *writefunc,
-  edgex_error *err
-);
+  (iot_logger_t *lc, edgex_ctx *ctx, const char *url, const char *data, void *writefunc, edgex_error *err);
+
 long edgex_http_postfile
-(
-  iot_logger_t *lc,
-  edgex_ctx *ctx,
-  const char *url,
-  const char *fname,
-  void *writefunc,
-  edgex_error *err
-);
+  (iot_logger_t *lc, edgex_ctx *ctx, const char *url, const char *filename, void *writefunc, edgex_error *err);
+
 long edgex_http_put
-(
-  iot_logger_t *lc,
-  edgex_ctx *ctx,
-  const char *url,
-  const char *data,
-  void *writefunc,
-  edgex_error *err
-);
+  (iot_logger_t *lc, edgex_ctx *ctx, const char *url, const char *data, void *writefunc, edgex_error *err);
 
 #endif

--- a/src/c/service.h
+++ b/src/c/service.h
@@ -30,6 +30,7 @@ struct edgex_device_service
   edgex_device_autoevent_stop_handler autoevstop;
   iot_logger_t *logger;
   edgex_device_config config;
+  atomic_bool *stopconfig;
   edgex_rest_server *daemon;
   edgex_device_operatingstate opstate;
   edgex_device_adminstate adminstate;


### PR DESCRIPTION
Addresses #80 
Initial implementation allows for LogLevel to be reconfigured without restart. Other settings to be added later.
As this required further enhancements to the http client support, took the opportunity to rework rest.c and factor out much of the common code.