### PR TITLE
Split service_free function into stop() and free()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@ differs as follows:
 
 Changes for 1.0.0:
 
+- Device service now follows the new/start/stop/free lifecycle pattern.
 - Initial support for configuration changes without restarting.
 - Support Correlation IDs. This introduces a requirement for libUUID.
 - The API for Event generation other than via device GET requests is split out

--- a/include/edgex/devsdk.h
+++ b/include/edgex/devsdk.h
@@ -206,9 +206,8 @@ void edgex_device_service_start
 );
 
 /**
- * @brief Stop the event service. Any locally-scheduled events will be
- *        cancelled, the rest api for the device will be shutdown, and
- *        resources will be freed.
+ * @brief Stop the event service. Any automatic events will be cancelled
+          and the rest api for the device service will be shut down.
  * @param svc The device service.
  * @param force Force stop.
  * @param err Nonzero reason codes will be set here in the event of errors.
@@ -221,4 +220,10 @@ void edgex_device_service_stop
   edgex_error *err
 );
 
+/**
+ * @brief Free the device service object and associated resources.
+ * @param svc The device service.
+ */
+
+void edgex_device_service_free (edgex_device_service *svc);
 #endif

--- a/src/c/config.c
+++ b/src/c/config.c
@@ -660,11 +660,14 @@ void edgex_device_freeConfig (edgex_device_service *svc)
   free (svc->config.device.removecmdargs);
   free (svc->config.device.profilesdir);
 
-  for (int i = 0; svc->config.service.labels[i]; i++)
+  if (svc->config.service.labels)
   {
-    free (svc->config.service.labels[i]);
+    for (int i = 0; svc->config.service.labels[i]; i++)
+    {
+      free (svc->config.service.labels[i]);
+    }
+    free (svc->config.service.labels);
   }
-  free (svc->config.service.labels);
 
   edgex_nvpairs_free (svc->config.driverconf);
 
@@ -912,6 +915,7 @@ void edgex_device_process_configured_devices
           if (err->code)
           {
             iot_log_error (svc->logger, "Error registering device %s", devname);
+            free (devname);
             break;
           }
         }
@@ -920,6 +924,7 @@ void edgex_device_process_configured_devices
           iot_log_error
             (svc->logger, "No Protocols section for device %s", devname);
           *err = EDGEX_BAD_CONFIG;
+          free (devname);
           break;
         }
       }

--- a/src/c/consul.c
+++ b/src/c/consul.c
@@ -442,8 +442,6 @@ bool edgex_consul_client_ping
     endpoint->port
   );
 
-  edgex_http_get (lc, &ctx, url, edgex_http_write_cb, err);
-  free (ctx.buff);
-
+  edgex_http_get (lc, &ctx, url, NULL, err);
   return (err->code == 0);
 }

--- a/src/c/data.c
+++ b/src/c/data.c
@@ -164,8 +164,6 @@ bool edgex_data_client_ping
     endpoints->data.port
   );
 
-  edgex_http_get (lc, &ctx, url, edgex_http_write_cb, err);
-  free (ctx.buff);
-
+  edgex_http_get (lc, &ctx, url, NULL, err);
   return (err->code == 0);
 }

--- a/src/c/devmap.c
+++ b/src/c/devmap.c
@@ -52,18 +52,28 @@ edgex_devmap_t *edgex_devmap_alloc (edgex_device_service *svc)
   return res;
 }
 
-void edgex_devmap_free (edgex_devmap_t *map)
+void edgex_devmap_clear (edgex_devmap_t *map)
 {
-  edgex_map_deinit (&map->name_to_id);
-  edgex_map_iter i = edgex_map_iter (map->devices);
   const char *key;
-  while ((key = edgex_map_next (&map->devices, &i)))
+  const char *next;
+  edgex_map_iter i = edgex_map_iter (map->devices);
+  key = edgex_map_next (&map->devices, &i);
+  while (key)
   {
     edgex_device **e = edgex_map_get (&map->devices, key);
     edgex_device_release (*e);
+    next = edgex_map_next (&map->devices, &i);
+    edgex_map_remove (&map->devices, key);
+    key = next;
   }
+}
+
+void edgex_devmap_free (edgex_devmap_t *map)
+{
+  const char *key;
+  edgex_map_deinit (&map->name_to_id);
   edgex_map_deinit (&map->devices);
-  i = edgex_map_iter (map->profiles);
+  edgex_map_iter i = edgex_map_iter (map->profiles);
   while ((key = edgex_map_next (&map->profiles, &i)))
   {
     edgex_deviceprofile **p = edgex_map_get (&map->profiles, key);

--- a/src/c/devmap.h
+++ b/src/c/devmap.h
@@ -33,6 +33,7 @@ typedef struct edgex_cmdqueue_t
  */
 
 extern edgex_devmap_t *edgex_devmap_alloc (edgex_device_service *svc);
+extern void edgex_devmap_clear (edgex_devmap_t *map);
 extern void edgex_devmap_free (edgex_devmap_t *map);
 
 /*

--- a/src/c/examples/template.c
+++ b/src/c/examples/template.c
@@ -13,7 +13,7 @@
 #include <unistd.h>
 #include <signal.h>
 
-#define ERR_CHECK(x) if (x.code) { fprintf (stderr, "Error: %d: %s\n", x.code, x.reason); return x.code; }
+#define ERR_CHECK(x) if (x.code) { fprintf (stderr, "Error: %d: %s\n", x.code, x.reason); edgex_device_service_free (service); free (impl); return x.code; }
 
 typedef struct template_driver
 {
@@ -297,7 +297,7 @@ int main (int argc, char *argv[])
   edgex_device_service_stop (service, true, &e);
   ERR_CHECK (e);
 
+  edgex_device_service_free (service);
   free (impl);
-  exit (0);
   return 0;
 }

--- a/src/c/metadata.c
+++ b/src/c/metadata.c
@@ -652,8 +652,6 @@ bool edgex_metadata_client_ping
     endpoints->metadata.port
   );
 
-  edgex_http_get (lc, &ctx, url, edgex_http_write_cb, err);
-  free (ctx.buff);
-
+  edgex_http_get (lc, &ctx, url, NULL, err);
   return (err->code == 0);
 }

--- a/src/c/rest.c
+++ b/src/c/rest.c
@@ -138,6 +138,13 @@ size_t edgex_http_write_cb (void *contents, size_t size, size_t nmemb, void *use
   return size;
 }
 
+/* Discard incoming data */
+
+static size_t edgex_discarder (void *contents, size_t size, size_t nmemb, void *userp)
+{
+  return size * nmemb;
+}
+
 /* Kill an ongoing request if our flag becomes set */
 
 static int abort_callback (void *clientp, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow)
@@ -219,6 +226,10 @@ static long edgex_run_curl
   {
     curl_easy_setopt(hnd, CURLOPT_WRITEDATA, ctx);
     curl_easy_setopt(hnd, CURLOPT_WRITEFUNCTION, writefunc);
+  }
+  else
+  {
+    curl_easy_setopt(hnd, CURLOPT_WRITEFUNCTION, edgex_discarder);
   }
 
   /* Setup header list */


### PR DESCRIPTION
Don't copy returned data from ping-type calls.