### PR TITLE
Add requests++ to compatible multiple requests

### DIFF
--- a/src/c/examples/template.c
+++ b/src/c/examples/template.c
@@ -102,7 +102,7 @@ static bool template_get_handler
   {
   /* Drill into the attributes to differentiate between resources via the
    * SensorType NVP */
-    const edgex_nvpairs * current = requests->attributes;
+    const edgex_nvpairs * current = requests[i].attributes;
     while (current!=NULL)
     {
       if (strcmp (current->name, "SensorType") ==0 )


### PR DESCRIPTION
If have two or more requests, the parameter of requests should be
directed to next object, otherwise all object will get the same value.

The example of profile config is below:
deviceCommands:
  -
    name: SensorOne
    get:
      - { index: "1", operation: "get", object: "SensorOne", parameter: "SensorOne", property: "value" }
      - { index: "2", operation: "get", object: "SensorTwo", parameter: "SensorTwo", property: "value" }

In this case, the object "SensorOne" and "SensorTwo" will get the same value.

Signed-off-by: Sun Lianwen <sunlianwen@sgepri.sgcc.com.cn>