### PR TITLE
Add parameterName in profile

### DIFF
--- a/src/c/examples/res/ExampleProfile.yaml
+++ b/src/c/examples/res/ExampleProfile.yaml
@@ -99,6 +99,7 @@ coreCommands:
         expectedValues: []
     put:
       path: "/api/v1/device/{deviceId}/Switch"
+      parameterNames: ["Switch"]
       responses:
       - code: "200"
         description: "Successfully set the switch state."


### PR DESCRIPTION
The command  of put do not set parameterName, but the parameter is need
when exec put command.

Signed-off-by: Wei xingshen <weixingshen@sgepri.sgcc.com.cn>