### PR TITLE
CBOR encoding for Events containing Binary Readings

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,8 @@ differs as follows:
 
 Changes for 1.0.0:
 
+- Events containing binary Readings are encoded using CBOR.
+  - This introduces a dependency on libcbor.
 - Data transformations (other than "mask") are applied for device PUT requests.
 - When querying for Device Profiles they are returned in a list in the same way
   as devices.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The C SDK provides a framework for building EdgeX device services in C.
 * A Linux build host
 * A version of GCC supporting C99.
 * CMake version 3 or greater and make.
-* Development libraries and headers for curl, microhttpd, yaml and libuuid.
+* Development libraries and headers for curl, microhttpd, yaml, libcbor and libuuid.
 
 ### Building
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,6 +1,14 @@
 #!/bin/sh
 set -x -e
 
+mkdir /deps
+cd /deps
+git clone https://github.com/PJK/libcbor
+sed -e 's/-flto//' -i libcbor/CMakeLists.txt
+cmake -DCMAKE_BUILD_TYPE=Release -DCBOR_CUSTOM_ALLOC=ON libcbor
+make
+make install
+
 # Build distribution
 
 /edgex-c-sdk/scripts/build.sh $*

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,10 @@ find_package (LibUUID REQUIRED)
 if (NOT LIBUUID_FOUND)
   message (FATAL_ERROR "UUID library or header not found")
 endif ()
+find_package (LibCBOR REQUIRED)
+if (NOT LIBCBOR_FOUND)
+  message (FATAL_ERROR "CBOR library or header not found")
+endif ()
 
 message (STATUS "C SDK ${CSDK_DOT_VERSION} for ${CMAKE_SYSTEM_NAME}")
 

--- a/src/c/CMakeLists.txt
+++ b/src/c/CMakeLists.txt
@@ -21,7 +21,7 @@ endif ()
 # Set default files to compile and libraries
 
 file (GLOB C_FILES *.c iot/*.c)
-set (LINK_LIBRARIES ${LIBMICROHTTP_LIBRARIES} ${CURL_LIBRARIES} ${LIBYAML_LIBRARIES} ${LIBUUID_LIBRARIES})
+set (LINK_LIBRARIES ${LIBMICROHTTP_LIBRARIES} ${CURL_LIBRARIES} ${LIBYAML_LIBRARIES} ${LIBUUID_LIBRARIES} ${LIBCBOR_LIBRARIES})
 configure_file ("defs.h.in" "${CMAKE_SOURCE_DIR}/../include/edgex/csdk-defs.h")
 
 # Main sdk library

--- a/src/c/autoevent.c
+++ b/src/c/autoevent.c
@@ -123,13 +123,13 @@ static void ae_runner (void *p)
             (ai->svc->logger, &ai->svc->config.endpoints, dev->id, DISABLED, &err);
         }
       }
-      edgex_device_commandresult_free (results, ai->resource->nreqs);
       edgex_device_commandresult_free (resdup, ai->resource->nreqs);
     }
     else
     {
       iot_log_error (ai->svc->logger, "AutoEvent: Driver for %s failed on GET", dev->name);
     }
+    edgex_device_commandresult_free (results, ai->resource->nreqs);
     edgex_device_free_crlid ();
     edgex_device_release (dev);
   }

--- a/src/c/autoevent.c
+++ b/src/c/autoevent.c
@@ -7,6 +7,7 @@
  */
 
 #include "autoevent.h"
+#include "errorlist.h"
 #include "edgex/eventgen.h"
 #include "edgex/edgex.h"
 #include "edgex/edgex-logging.h"
@@ -14,13 +15,14 @@
 #include "parson.h"
 #include "edgex-rest.h"
 #include "correlation.h"
+#include "metadata.h"
 
 #include <microhttpd.h>
 
 typedef struct edgex_autoimpl
 {
   edgex_device_service *svc;
-  struct json_value_t *last;
+  edgex_device_commandresult *last;
   uint64_t interval;
   const edgex_cmdinfo *resource;
   char *device;
@@ -59,21 +61,19 @@ static void edgex_autoimpl_release (edgex_autoimpl *ai)
   {
     free (ai->device);
     edgex_protocols_free (ai->protocols);
-    json_value_free (ai->last);
+    edgex_device_commandresult_free (ai->last, ai->resource->nreqs);
     free (ai);
   }
 }
 
 static void ae_runner (void *p)
 {
-  int res;
   edgex_autoimpl *ai = (edgex_autoimpl *)p;
   atomic_fetch_add (&ai->refs, 1);
 
   edgex_device *dev = edgex_devmap_device_byname (ai->svc->devices, ai->device);
   if (dev)
   {
-    JSON_Value *result = NULL;
     if (dev->adminState == LOCKED || dev->operatingState == DISABLED)
     {
       edgex_device_release (dev);
@@ -81,19 +81,54 @@ static void ae_runner (void *p)
     }
     edgex_device_alloc_crlid (NULL);
     iot_log_info (ai->svc->logger, "AutoEvent: %s/%s", ai->device, ai->resource->name);
-    res = edgex_device_runget
-      (ai->svc, dev, ai->resource, ai->onChange ? ai->last : NULL, &result);
-    if (res == MHD_HTTP_OK)
+    edgex_device_commandresult *results = calloc (ai->resource->nreqs, sizeof (edgex_device_commandresult));
+    if
+    (
+      ai->svc->userfns.gethandler
+        (ai->svc->userdata, dev->name, dev->protocols, ai->resource->nreqs, ai->resource->reqs, results)
+    )
     {
-      if (ai->onChange)
+      edgex_device_commandresult *resdup = NULL;
+      if (!(ai->onChange && ai->last && edgex_device_commandresult_equal (results, ai->last, ai->resource->nreqs)))
       {
-        json_value_free (ai->last);
-        ai->last = result;
+        edgex_error err = EDGEX_OK;
+        if (ai->onChange)
+        {
+          resdup = edgex_device_commandresult_dup (results, ai->resource->nreqs);
+        }
+        edgex_event_cooked *event =
+          edgex_data_process_event (dev->name, ai->resource, results, ai->svc->config.device.datatransform);
+        if (event)
+        {
+          edgex_data_client_add_event (ai->svc->logger, &ai->svc->config.endpoints, event, &err);
+          if (err.code == 0)
+          {
+            if (ai->onChange)
+            {
+              edgex_device_commandresult_free (ai->last, ai->resource->nreqs);
+              ai->last = resdup;
+              resdup = NULL;
+            }
+          }
+          else
+          {
+            iot_log_error (ai->svc->logger, "AutoEvent: unable to push new event");
+          }
+          edgex_event_cooked_free (event);
+        }
+        else
+        {
+          iot_log_error (ai->svc->logger, "Assertion failed for device %s. Disabling.", dev->name);
+          edgex_metadata_client_set_device_opstate
+            (ai->svc->logger, &ai->svc->config.endpoints, dev->id, DISABLED, &err);
+        }
       }
-      else
-      {
-        json_value_free (result);
-      }
+      edgex_device_commandresult_free (results, ai->resource->nreqs);
+      edgex_device_commandresult_free (resdup, ai->resource->nreqs);
+    }
+    else
+    {
+      iot_log_error (ai->svc->logger, "AutoEvent: Driver for %s failed on GET", dev->name);
     }
     edgex_device_free_crlid ();
     edgex_device_release (dev);

--- a/src/c/callback.c
+++ b/src/c/callback.c
@@ -23,7 +23,8 @@ int edgex_device_handler_callback
   edgex_http_method method,
   const char *upload_data,
   size_t upload_data_size,
-  char **reply,
+  void **reply,
+  size_t *reply_size,
   const char **reply_type
 )
 {

--- a/src/c/callback.h
+++ b/src/c/callback.h
@@ -18,7 +18,8 @@ extern int edgex_device_handler_callback
   edgex_http_method method,
   const char *upload_data,
   size_t upload_data_size,
-  char **reply,
+  void **reply,
+  size_t *reply_size,
   const char **reply_type
 );
 

--- a/src/c/config.c
+++ b/src/c/config.c
@@ -694,7 +694,8 @@ int edgex_device_handler_config
   edgex_http_method method,
   const char *upload_data,
   size_t upload_data_size,
-  char **reply,
+  void **reply,
+  size_t *reply_size,
   const char **reply_type
 )
 {
@@ -781,6 +782,7 @@ int edgex_device_handler_config
   }
 
   *reply = json_serialize_to_string (val);
+  *reply_size = strlen (*reply);
   *reply_type = "application/json";
   json_value_free (val);
 

--- a/src/c/config.h
+++ b/src/c/config.h
@@ -113,7 +113,8 @@ int edgex_device_handler_config
   edgex_http_method method,
   const char *upload_data,
   size_t upload_data_size,
-  char **reply,
+  void **reply,
+  size_t *reply_size,
   const char **reply_type
 );
 

--- a/src/c/data.c
+++ b/src/c/data.c
@@ -15,7 +15,7 @@
 #include "device.h"
 #include "transform.h"
 
-JSON_Value *edgex_data_generate_event
+edgex_event_cooked *edgex_data_process_event
 (
   const char *device_name,
   const edgex_cmdinfo *commandinfo,
@@ -23,56 +23,86 @@ JSON_Value *edgex_data_generate_event
   bool doTransforms
 )
 {
+  edgex_event_cooked *result = NULL;
+  bool useCBOR = false;
   uint64_t timenow = edgex_device_millitime ();
-  JSON_Value *jevent = json_value_init_object ();
-  JSON_Object *jobj = json_value_get_object (jevent);
-  JSON_Value *arrval = json_value_init_array ();
-  JSON_Array *jrdgs = json_value_get_array (arrval);
   for (uint32_t i = 0; i < commandinfo->nreqs; i++)
   {
     if (doTransforms)
     {
       edgex_transform_outgoing (&values[i], commandinfo->pvals[i], commandinfo->maps[i]);
     }
-    char *reading = edgex_value_tostring (&values[i], commandinfo->pvals[i]->floatAsBinary);
     const char *assertion = commandinfo->pvals[i]->assertion;
-    if (assertion && *assertion && strcmp (reading, assertion))
+    if (assertion && *assertion)
     {
-       free (reading);
-       json_value_free (jevent);
-       return NULL;
+      char *reading = edgex_value_tostring (&values[i], commandinfo->pvals[i]->floatAsBinary);
+      if (strcmp (reading, assertion))
+      {
+        free (reading);
+        return NULL;
+      }
+      else
+      {
+        free (reading);
+      }
     }
-
-    JSON_Value *rval = json_value_init_object ();
-    JSON_Object *robj = json_value_get_object (rval);
-
-    json_object_set_string (robj, "name", commandinfo->reqs[i].resname);
-    json_object_set_string (robj, "value", reading);
-    if (values[i].origin)
+    if (commandinfo->pvals[i]->type == Binary)
     {
-      json_object_set_number (robj, "origin", values[i].origin);
+      useCBOR = true;
     }
-    json_array_append_value (jrdgs, rval);
-    free (reading);
   }
 
-  json_object_set_string (jobj, "device", device_name);
-  json_object_set_number (jobj, "origin", timenow);
-  json_object_set_value (jobj, "readings", arrval);
-  return jevent;
+  result = malloc (sizeof (edgex_event_cooked));
+  if (useCBOR)
+  {
+    result->encoding = CBOR;
+    result->value.cbor = NULL;
+    return result;
+  }
+  else
+  {
+    JSON_Value *jevent = json_value_init_object ();
+    JSON_Object *jobj = json_value_get_object (jevent);
+    JSON_Value *arrval = json_value_init_array ();
+    JSON_Array *jrdgs = json_value_get_array (arrval);
+
+    for (uint32_t i = 0; i < commandinfo->nreqs; i++)
+    {
+      char *reading = edgex_value_tostring (&values[i], commandinfo->pvals[i]->floatAsBinary);
+
+      JSON_Value *rval = json_value_init_object ();
+      JSON_Object *robj = json_value_get_object (rval);
+
+      json_object_set_string (robj, "name", commandinfo->reqs[i].resname);
+      json_object_set_string (robj, "value", reading);
+      if (values[i].origin)
+      {
+        json_object_set_number (robj, "origin", values[i].origin);
+      }
+      json_array_append_value (jrdgs, rval);
+      free (reading);
+    }
+
+    json_object_set_string (jobj, "device", device_name);
+    json_object_set_number (jobj, "origin", timenow);
+    json_object_set_value (jobj, "readings", arrval);
+    result->encoding = JSON;
+    result->value.json = json_serialize_to_string (jevent);
+    json_value_free (jevent);
+  }
+  return result;
 }
 
 void edgex_data_client_add_event
 (
   iot_logger_t *lc,
   edgex_service_endpoints *endpoints,
-  JSON_Value *eventval,
+  edgex_event_cooked *eventval,
   edgex_error *err
 )
 {
   edgex_ctx ctx;
   char url[URL_BUF_SIZE];
-  char *json;
 
   memset (&ctx, 0, sizeof (edgex_ctx));
   snprintf
@@ -84,11 +114,173 @@ void edgex_data_client_add_event
     endpoints->data.port
   );
 
-  json = json_serialize_to_string (eventval);
-  edgex_http_post (lc, &ctx, url, json, edgex_http_write_cb, err);
+  switch (eventval->encoding)
+  {
+    case JSON:
+    {
+      edgex_http_post (lc, &ctx, url, eventval->value.json, NULL, err);
+      break;
+    }
+    case CBOR:
+    {
+      break;
+    }
+  }
+}
 
-  free (ctx.buff);
-  free (json);
+void edgex_event_cooked_free (edgex_event_cooked *e)
+{
+  if (e)
+  {
+    switch (e->encoding)
+    {
+      case JSON:
+        json_free_serialized_string (e->value.json);
+        break;
+      case CBOR:
+        break;
+    }
+    free (e);
+  }
+}
+
+void edgex_device_commandresult_free (edgex_device_commandresult *res, int n)
+{
+  if (res)
+  {
+    for (int i = 0; i < n; i++)
+    {
+      if (res[i].type == String)
+      {
+        free (res[i].value.string_result);
+      }
+      else if (res[i].type == Binary)
+      {
+        free (res[i].value.binary_result.bytes);
+      }
+    }
+    free (res);
+  }
+}
+
+edgex_device_commandresult *edgex_device_commandresult_dup (const edgex_device_commandresult *res, int n)
+{
+  edgex_device_commandresult *result = calloc (n, sizeof (edgex_device_commandresult));
+  size_t sz;
+  for (int i = 0; i < n; i++)
+  {
+    switch (res[i].type)
+    {
+      case Bool:
+        result[i].value.bool_result = res[i].value.bool_result;
+        break;
+      case Uint8:
+        result[i].value.ui8_result = res[i].value.ui8_result;
+        break;
+      case Uint16:
+        result[i].value.ui16_result = res[i].value.ui16_result;
+        break;
+      case Uint32:
+        result[i].value.ui32_result = res[i].value.ui32_result;
+        break;
+      case Uint64:
+        result[i].value.ui64_result = res[i].value.ui64_result;
+        break;
+      case Int8:
+        result[i].value.i8_result = res[i].value.i8_result;
+        break;
+      case Int16:
+        result[i].value.i16_result = res[i].value.i16_result;
+        break;
+      case Int32:
+        result[i].value.i32_result = res[i].value.i32_result;
+        break;
+      case Int64:
+        result[i].value.i64_result = res[i].value.i64_result;
+        break;
+      case Float32:
+        result[i].value.f32_result = res[i].value.f32_result;
+        break;
+      case Float64:
+        result[i].value.f64_result = res[i].value.f64_result;
+        break;
+      case String:
+        result[i].value.string_result = strdup (res[i].value.string_result);
+        break;
+      case Binary:
+        sz = res[i].value.binary_result.size;
+        result[i].value.binary_result.size = sz;
+        result[i].value.binary_result.bytes = malloc (sz);
+        memcpy (result[i].value.binary_result.bytes, res[i].value.binary_result.bytes, sz);
+        break;
+    }
+  }
+  return result;
+}
+
+bool edgex_device_commandresult_equal
+  (const edgex_device_commandresult *lhs, const edgex_device_commandresult *rhs, int n)
+{
+  bool result = true;
+  for (int i = 0; i < n; i++)
+  {
+    if (lhs[i].type != rhs[i].type)
+    {
+      result = false;
+      break;
+    }
+    switch (lhs[i].type)
+    {
+      case Bool:
+        result = (lhs[i].value.bool_result == rhs[i].value.bool_result);
+        break;
+      case Uint8:
+        result = (lhs[i].value.ui8_result == rhs[i].value.ui8_result);
+        break;
+      case Uint16:
+        result = (lhs[i].value.ui16_result == rhs[i].value.ui16_result);
+        break;
+      case Uint32:
+        result = (lhs[i].value.ui32_result == rhs[i].value.ui32_result);
+        break;
+      case Uint64:
+        result = (lhs[i].value.ui64_result == rhs[i].value.ui64_result);
+        break;
+      case Int8:
+        result = (lhs[i].value.i8_result == rhs[i].value.i8_result);
+        break;
+      case Int16:
+        result = (lhs[i].value.i16_result == rhs[i].value.i16_result);
+        break;
+      case Int32:
+        result = (lhs[i].value.i32_result == rhs[i].value.i32_result);
+        break;
+      case Int64:
+        result = (lhs[i].value.i64_result == rhs[i].value.i64_result);
+        break;
+      case Float32:
+        result = (lhs[i].value.f32_result == rhs[i].value.f32_result);
+        break;
+      case Float64:
+        result = (lhs[i].value.f64_result == rhs[i].value.f64_result);
+        break;
+      case String:
+        result = (strcmp (lhs[i].value.string_result, rhs[i].value.string_result) == 0);
+        break;
+      case Binary:
+        result =
+        (
+          lhs[i].value.binary_result.size == rhs[i].value.binary_result.size &&
+          memcmp (lhs[i].value.binary_result.bytes, rhs[i].value.binary_result.bytes, lhs[i].value.binary_result.size) == 0
+        );
+        break;
+    }
+    if (result == false)
+    {
+      break;
+    }
+  }
+  return result;
 }
 
 edgex_valuedescriptor *edgex_data_client_add_valuedescriptor

--- a/src/c/data.c
+++ b/src/c/data.c
@@ -63,24 +63,28 @@ edgex_event_cooked *edgex_data_process_event
 
     for (uint32_t i = 0; i < commandinfo->nreqs; i++)
     {
+      cbor_item_t *crdg = cbor_new_definite_map (values[i].origin ? 3 : 2);
+
       cbor_item_t *cread;
       if (values[i].type == Binary)
       {
         cread = cbor_build_bytestring (values[i].value.binary_result.bytes, values[i].value.binary_result.size);
+        cbor_map_add (crdg, (struct cbor_pair)
+          { .key = cbor_move (cbor_build_string ("binaryValue")), .value = cbor_move (cread) });
       }
       else
       {
         cread = cbor_build_string (edgex_value_tostring (&values[i], commandinfo->pvals[i]->floatAsBinary));
+        cbor_map_add (crdg, (struct cbor_pair)
+          { .key = cbor_move (cbor_build_string ("value")), .value = cbor_move (cread) });
       }
 
-      cbor_item_t *crdg = cbor_new_definite_map (values[i].origin ? 3 : 2);
       cbor_map_add (crdg, (struct cbor_pair)
       {
         .key = cbor_move (cbor_build_string ("name")),
         .value = cbor_move (cbor_build_string (commandinfo->reqs[i].resname))
       });
-      cbor_map_add (crdg, (struct cbor_pair)
-        { .key = cbor_move (cbor_build_string ("value")), .value = cbor_move (cread) });
+
       if (values[i].origin)
       {
         cbor_map_add (crdg, (struct cbor_pair)
@@ -89,6 +93,7 @@ edgex_event_cooked *edgex_data_process_event
           .value = cbor_move (cbor_build_uint64 (values[i].origin))
         });
       }
+
       cbor_array_push (crdgs, cbor_move (crdg));
     }
 

--- a/src/c/data.c
+++ b/src/c/data.c
@@ -174,7 +174,7 @@ void edgex_data_client_add_event
     case CBOR:
     {
       edgex_http_postbin
-        (lc, &ctx, url, eventval->value.cbor.data, eventval->value.cbor.length, "Application/CBOR", NULL, err);
+        (lc, &ctx, url, eventval->value.cbor.data, eventval->value.cbor.length, "application/cbor", NULL, err);
       break;
     }
   }

--- a/src/c/data.h
+++ b/src/c/data.h
@@ -38,13 +38,19 @@ typedef struct edgex_event
   struct edgex_event *next;
 } edgex_event;
 
+typedef enum { JSON, CBOR} edgex_event_encoding;
+
 typedef struct edgex_event_cooked
 {
-  enum { JSON, CBOR } encoding;
+  edgex_event_encoding encoding;
   union
   {
     char *json;
-    void *cbor;
+    struct
+    {
+      unsigned char *data;
+      size_t length;
+    } cbor;
   } value;
 } edgex_event_cooked;
 

--- a/src/c/data.h
+++ b/src/c/data.h
@@ -18,17 +18,18 @@ typedef struct edgex_reading
   uint64_t created;
   char *id;
   uint64_t modified;
-  char *name;
+  const char *name;
   uint64_t origin;
   uint64_t pushed;
-  char *value;
+  edgex_device_commandresult value;
+  bool binfloat;
   struct edgex_reading *next;
 } edgex_reading;
 
 typedef struct edgex_event
 {
   uint64_t created;
-  char *device;
+  const char *device;
   char *id;
   uint64_t modified;
   uint64_t origin;
@@ -36,6 +37,16 @@ typedef struct edgex_event
   edgex_reading *readings;
   struct edgex_event *next;
 } edgex_event;
+
+typedef struct edgex_event_cooked
+{
+  enum { JSON, CBOR } encoding;
+  union
+  {
+    char *json;
+    void *cbor;
+  } value;
+} edgex_event_cooked;
 
 typedef struct
 {
@@ -58,7 +69,9 @@ typedef struct
 
 typedef struct edgex_service_endpoints edgex_service_endpoints;
 
-JSON_Value *edgex_data_generate_event
+void edgex_event_cooked_free (edgex_event_cooked *e);
+
+edgex_event_cooked *edgex_data_process_event
 (
   const char *device_name,
   const edgex_cmdinfo *commandinfo,
@@ -70,7 +83,7 @@ void edgex_data_client_add_event
 (
   iot_logger_t *lc,
   edgex_service_endpoints *endpoints,
-  JSON_Value *eventval,
+  edgex_event_cooked *eventval,
   edgex_error *err
 );
 
@@ -98,5 +111,12 @@ bool edgex_data_client_ping
   edgex_service_endpoints *endpoints,
   edgex_error *err
 );
+
+void edgex_device_commandresult_free (edgex_device_commandresult *res, int n);
+
+edgex_device_commandresult *edgex_device_commandresult_dup (const edgex_device_commandresult *res, int n);
+
+bool edgex_device_commandresult_equal
+  (const edgex_device_commandresult *lhs, const edgex_device_commandresult *rhs, int n);
 
 #endif

--- a/src/c/device.h
+++ b/src/c/device.h
@@ -12,8 +12,8 @@
 #include "edgex/devsdk.h"
 #include "edgex/edgex.h"
 #include "rest-server.h"
-#include "parson.h"
 #include "cmdinfo.h"
+#include "data.h"
 
 extern int edgex_device_handler_device
 (
@@ -30,14 +30,5 @@ extern char *edgex_value_tostring (const edgex_device_commandresult *value, bool
 
 extern const struct edgex_cmdinfo *edgex_deviceprofile_findcommand
   (const char *name, edgex_deviceprofile *prof, bool forGet);
-
-extern int edgex_device_runget
-(
-  edgex_device_service *svc,
-  edgex_device *dev,
-  const edgex_cmdinfo *commandinfo,
-  const JSON_Value *lastval,
-  JSON_Value **reply
-);
 
 #endif

--- a/src/c/device.h
+++ b/src/c/device.h
@@ -22,7 +22,8 @@ extern int edgex_device_handler_device
   edgex_http_method method,
   const char *upload_data,
   size_t upload_data_size,
-  char **reply,
+  void **reply,
+  size_t *reply_size,
   const char **reply_type
 );
 

--- a/src/c/discovery.c
+++ b/src/c/discovery.c
@@ -24,7 +24,8 @@ int edgex_device_handler_discovery
   edgex_http_method method,
   const char *upload_data,
   size_t upload_data_size,
-  char **reply,
+  void **reply,
+  size_t *reply_size,
   const char **reply_type
 )
 {
@@ -43,6 +44,7 @@ int edgex_device_handler_discovery
   if (!svc->config.device.discovery)
   {
     *reply = strdup ("Discovery disabled by configuration\n");
+    *reply_size = strlen (*reply);
     return MHD_HTTP_SERVICE_UNAVAILABLE;
   }
 
@@ -54,6 +56,7 @@ int edgex_device_handler_discovery
   // else discovery was already running; ignore this request
 
   *reply = strdup ("Running discovery\n");
+  *reply_size = strlen (*reply);
   return MHD_HTTP_OK;
 }
 

--- a/src/c/discovery.h
+++ b/src/c/discovery.h
@@ -20,7 +20,8 @@ extern int edgex_device_handler_discovery
   edgex_http_method method,
   const char *upload_data,
   size_t upload_data_size,
-  char **reply,
+  void **reply,
+  size_t *reply_size,
   const char **reply_type
 );
 

--- a/src/c/metrics.c
+++ b/src/c/metrics.c
@@ -28,7 +28,8 @@ int edgex_device_handler_metrics
   edgex_http_method method,
   const char *upload_data,
   size_t upload_data_size,
-  char **reply,
+  void **reply,
+  size_t *reply_size,
   const char **reply_type
 )
 {
@@ -65,6 +66,7 @@ int edgex_device_handler_metrics
     json_object_set_number (obj, "CpuAvgUsage", cputime / walltime);
   }
   *reply = json_serialize_to_string (val);
+  *reply_size = strlen (*reply);
   *reply_type = "application/json";
   json_value_free (val);
   return MHD_HTTP_OK;

--- a/src/c/metrics.h
+++ b/src/c/metrics.h
@@ -20,7 +20,8 @@ extern int edgex_device_handler_metrics
   edgex_http_method method,
   const char *upload_data,
   size_t upload_data_size,
-  char **reply,
+  void **reply,
+  size_t *reply_size,
   const char **reply_type
 );
 

--- a/src/c/rest-server.h
+++ b/src/c/rest-server.h
@@ -33,7 +33,8 @@ typedef int (*http_method_handler_fn)
   edgex_http_method method,
   const char *upload_data,
   size_t upload_data_size,
-  char **reply,
+  void **reply,
+  size_t *reply_size,
   const char **reply_type
 );
 

--- a/src/c/rest.c
+++ b/src/c/rest.c
@@ -315,6 +315,21 @@ long edgex_http_post
   return edgex_run_curl (lc, ctx, hnd, url, writefunc, slist, err);
 }
 
+long edgex_http_postbin
+  (iot_logger_t *lc, edgex_ctx *ctx, const char *url, void *data, size_t length, const char *mime, void *writefunc, edgex_error *err)
+{
+  struct curl_slist *slist;
+  CURL *hnd = curl_easy_init ();
+
+  curl_easy_setopt (hnd, CURLOPT_CUSTOMREQUEST, "POST");
+  curl_easy_setopt (hnd, CURLOPT_POST, 1L);
+  curl_easy_setopt (hnd, CURLOPT_POSTFIELDS, data);
+  curl_easy_setopt (hnd, CURLOPT_POSTFIELDSIZE_LARGE, length);
+
+  slist = edgex_add_hdr (NULL, "Content-Type", mime);
+  return edgex_run_curl (lc, ctx, hnd, url, writefunc, slist, err);
+}
+
 long edgex_http_postfile
   (iot_logger_t *lc, edgex_ctx *ctx, const char *url, const char *fname, void *writefunc, edgex_error *err)
 {

--- a/src/c/rest.h
+++ b/src/c/rest.h
@@ -62,6 +62,9 @@ long edgex_http_delete
 long edgex_http_post
   (iot_logger_t *lc, edgex_ctx *ctx, const char *url, const char *data, void *writefunc, edgex_error *err);
 
+long edgex_http_postbin
+  (iot_logger_t *lc, edgex_ctx *ctx, const char *url, void *data, size_t length, const char *mime, void *writefunc, edgex_error *err);
+
 long edgex_http_postfile
   (iot_logger_t *lc, edgex_ctx *ctx, const char *url, const char *filename, void *writefunc, edgex_error *err);
 

--- a/src/c/service.c
+++ b/src/c/service.c
@@ -42,7 +42,7 @@
 typedef struct postparams
 {
   edgex_device_service *svc;
-  JSON_Value *jevent;
+  edgex_event_cooked *event;
 } postparams;
 
 edgex_device_service *edgex_device_service_new
@@ -518,11 +518,11 @@ static void doPost (void *p)
   (
     pp->svc->logger,
     &pp->svc->config.endpoints,
-    pp->jevent,
+    pp->event,
     &err
   );
 
-  json_value_free (pp->jevent);
+  edgex_event_cooked_free (pp->event);
   free (pp);
 }
 
@@ -547,14 +547,14 @@ void edgex_device_post_readings
 
   if (command)
   {
-    JSON_Value *jevent = edgex_data_generate_event
+    edgex_event_cooked *event = edgex_data_process_event
       (devname, command, values, svc->config.device.datatransform);
 
-    if (jevent)
+    if (event)
     {
       postparams *pp = malloc (sizeof (postparams));
       pp->svc = svc;
-      pp->jevent = jevent;
+      pp->event = event;
       iot_threadpool_add_work (svc->thpool, doPost, pp, NULL);
     }
   }

--- a/src/c/service.c
+++ b/src/c/service.c
@@ -97,12 +97,14 @@ static int ping_handler
   edgex_http_method method,
   const char *upload_data,
   size_t upload_data_size,
-  char **reply,
+  void **reply,
+  size_t *reply_size,
   const char **reply_type
 )
 {
   edgex_device_service *svc = (edgex_device_service *) ctx;
   *reply = strdup (svc->version);
+  *reply_size = strlen (svc->version);
   *reply_type = "text/plain";
   return MHD_HTTP_OK;
 }

--- a/src/cmake/FindLibCBOR.cmake
+++ b/src/cmake/FindLibCBOR.cmake
@@ -1,0 +1,4 @@
+find_path (LIBCBOR_INCLUDE_DIR cbor.h)
+find_library (LIBCBOR_LIBRARIES NAMES cbor libcbor)
+include (FindPackageHandleStandardArgs)
+find_package_handle_standard_args (LIBCBOR DEFAULT_MSG LIBCBOR_LIBRARIES LIBCBOR_INCLUDE_DIR)


### PR DESCRIPTION
#25 
NB this produces cbor-encoded events which look okay, and runs valgrind-clean, but current core-data does not yet support cbor so I've not been able to verify that it will accept what it is given.