### PR TITLE
Fix precision loss when encoding large integers in JSON

### DIFF
--- a/src/c/config.c
+++ b/src/c/config.c
@@ -712,19 +712,19 @@ int edgex_device_handler_config
   JSON_Value *mval = json_value_init_object ();
   JSON_Object *mobj = json_value_get_object (mval);
   json_object_set_string (mobj, "Host", svc->config.endpoints.metadata.host);
-  json_object_set_number (mobj, "Port", svc->config.endpoints.metadata.port);
+  json_object_set_uint (mobj, "Port", svc->config.endpoints.metadata.port);
   json_object_set_value (cobj, "Metadata", mval);
 
   JSON_Value *dval = json_value_init_object ();
   JSON_Object *dobj = json_value_get_object (dval);
   json_object_set_string (dobj, "Host", svc->config.endpoints.data.host);
-  json_object_set_number (dobj, "Port", svc->config.endpoints.data.port);
+  json_object_set_uint (dobj, "Port", svc->config.endpoints.data.port);
   json_object_set_value (cobj, "Data", dval);
 
   JSON_Value *lsval = json_value_init_object ();
   JSON_Object *lsobj = json_value_get_object (lsval);
   json_object_set_string (lsobj, "Host", svc->config.endpoints.logging.host);
-  json_object_set_number (lsobj, "Port", svc->config.endpoints.logging.port);
+  json_object_set_uint (lsobj, "Port", svc->config.endpoints.logging.port);
   json_object_set_value (cobj, "Data", lsval);
 
   json_object_set_value (obj, "Clients", cval);
@@ -738,9 +738,9 @@ int edgex_device_handler_config
   JSON_Value *sval = json_value_init_object ();
   JSON_Object *sobj = json_value_get_object (sval);
   json_object_set_string (sobj, "Host", svc->config.service.host);
-  json_object_set_number (sobj, "Port", svc->config.service.port);
-  json_object_set_number (sobj, "Timeout", svc->config.service.timeout);
-  json_object_set_number
+  json_object_set_uint (sobj, "Port", svc->config.service.port);
+  json_object_set_uint (sobj, "Timeout", svc->config.service.timeout);
+  json_object_set_uint
     (sobj, "ConnectRetries", svc->config.service.connectretries);
   json_object_set_string (sobj, "StartupMsg", svc->config.service.startupmsg);
   json_object_set_string
@@ -763,8 +763,8 @@ int edgex_device_handler_config
   json_object_set_boolean (dobj, "Discovery", svc->config.device.discovery);
   json_object_set_string (dobj, "InitCmd", svc->config.device.initcmd);
   json_object_set_string (dobj, "InitCmdArgs", svc->config.device.initcmdargs);
-  json_object_set_number (dobj, "MaxCmdOps", svc->config.device.maxcmdops);
-  json_object_set_number
+  json_object_set_uint (dobj, "MaxCmdOps", svc->config.device.maxcmdops);
+  json_object_set_uint
     (dobj, "MaxCmdResultLen", svc->config.device.maxcmdresultlen);
   json_object_set_string (dobj, "RemoveCmd", svc->config.device.removecmd);
   json_object_set_string

--- a/src/c/consul.c
+++ b/src/c/consul.c
@@ -330,7 +330,7 @@ void edgex_consul_client_register_service
   JSON_Object *obj = json_value_get_object (params);
   json_object_set_string (obj, "Name", servicename);
   json_object_set_string (obj, "Address", host);
-  json_object_set_number (obj, "Port", port);
+  json_object_set_uint (obj, "Port", port);
   if (checkInterval)
   {
     char myUrl[URL_BUF_SIZE];
@@ -430,7 +430,7 @@ void edgex_consul_client_query_service
       if (name)
       {
         *host = strdup (name);
-        *port = json_object_get_number (obj, "ServicePort");
+        *port = json_object_get_uint (obj, "ServicePort");
       }
       else
       {

--- a/src/c/data.c
+++ b/src/c/data.c
@@ -122,13 +122,13 @@ edgex_event_cooked *edgex_data_process_event
 
       json_object_set_string (robj, "name", commandinfo->reqs[i].resname);
       json_object_set_string (robj, "value", reading);
-      json_object_set_number (robj, "origin", values[i].origin ? values[i].origin : timenow);
+      json_object_set_uint (robj, "origin", values[i].origin ? values[i].origin : timenow);
       json_array_append_value (jrdgs, rval);
       free (reading);
     }
 
     json_object_set_string (jobj, "device", device_name);
-    json_object_set_number (jobj, "origin", timenow);
+    json_object_set_uint (jobj, "origin", timenow);
     json_object_set_value (jobj, "readings", arrval);
     result->encoding = JSON;
     result->value.json = json_serialize_to_string (jevent);

--- a/src/c/edgex-rest.c
+++ b/src/c/edgex-rest.c
@@ -785,9 +785,9 @@ static edgex_deviceprofile *deviceprofile_read
   result->id = get_string (obj, "id");
   result->name = get_string (obj, "name");
   result->description = get_string (obj, "description");
-  result->created = (uint64_t) json_object_get_number (obj, "created");
-  result->modified = (uint64_t) json_object_get_number (obj, "modified");
-  result->origin = (uint64_t) json_object_get_number (obj, "origin");
+  result->created = json_object_get_uint (obj, "created");
+  result->modified = json_object_get_uint (obj, "modified");
+  result->origin = json_object_get_uint (obj, "origin");
   result->manufacturer = get_string (obj, "manufacturer");
   result->model = get_string (obj, "model");
   result->labels = array_to_strings (json_object_get_array (obj, "labels"));
@@ -848,12 +848,12 @@ deviceprofile_write (const edgex_deviceprofile *e, bool create)
   if (!create)
   {
     json_object_set_string (obj, "id", e->id);
-    json_object_set_number (obj, "created", e->created);
-    json_object_set_number (obj, "modified", e->modified);
+    json_object_set_uint (obj, "created", e->created);
+    json_object_set_uint (obj, "modified", e->modified);
   }
   json_object_set_string (obj, "name", e->name);
   json_object_set_string (obj, "description", e->description);
-  json_object_set_number (obj, "origin", e->origin);
+  json_object_set_uint (obj, "origin", e->origin);
   json_object_set_string (obj, "manufacturer", e->manufacturer);
   json_object_set_string (obj, "model", e->model);
   json_object_set_value (obj, "labels", strings_to_array (e->labels));
@@ -1027,15 +1027,15 @@ static edgex_addressable *addressable_read (const JSON_Object *obj)
 {
   edgex_addressable *result = malloc (sizeof (edgex_addressable));
   result->address = get_string (obj, "address");
-  result->created = json_object_get_number (obj, "created");
+  result->created = json_object_get_uint (obj, "created");
   result->id = get_string (obj, "id");
   result->method = get_string (obj, "method");
-  result->modified = json_object_get_number (obj, "modified");
+  result->modified = json_object_get_uint (obj, "modified");
   result->name = get_string (obj, "name");
-  result->origin = json_object_get_number (obj, "origin");
+  result->origin = json_object_get_uint (obj, "origin");
   result->password = get_string (obj, "password");
   result->path = get_string (obj, "path");
-  result->port = json_object_get_number (obj, "port");
+  result->port = json_object_get_uint (obj, "port");
   result->protocol = get_string (obj, "protocol");
   result->publisher = get_string (obj, "publisher");
   result->topic = get_string (obj, "topic");
@@ -1052,17 +1052,17 @@ static JSON_Value *addressable_write (const edgex_addressable *e, bool create)
   if (!create)
   {
     json_object_set_string (obj, "id", e->id);
-    json_object_set_number (obj, "created", e->created);
-    json_object_set_number (obj, "modified", e->modified);
+    json_object_set_uint (obj, "created", e->created);
+    json_object_set_uint (obj, "modified", e->modified);
   }
 
   json_object_set_string (obj, "address", e->address);
   json_object_set_string (obj, "method", e->method);
   json_object_set_string (obj, "name", e->name);
-  json_object_set_number (obj, "origin", e->origin);
+  json_object_set_uint (obj, "origin", e->origin);
   json_object_set_string (obj, "password", e->password);
   json_object_set_string (obj, "path", e->path);
-  json_object_set_number (obj, "port", e->port);
+  json_object_set_uint (obj, "port", e->port);
   json_object_set_string (obj, "protocol", e->protocol);
   json_object_set_string (obj, "publisher", e->publisher);
   json_object_set_string (obj, "topic", e->topic);
@@ -1120,17 +1120,17 @@ static edgex_deviceservice *deviceservice_read (const JSON_Object *obj)
     (json_object_get_object (obj, "addressable"));;
   result->adminState = edgex_adminstate_fromstring
     (json_object_get_string (obj, "adminState"));
-  result->created = json_object_get_number (obj, "created");
+  result->created = json_object_get_uint (obj, "created");
   result->description = get_string (obj, "description");
   result->id = get_string (obj, "id");
   result->labels = array_to_strings (json_object_get_array (obj, "labels"));
-  result->lastConnected = json_object_get_number (obj, "lastConnected");
-  result->lastReported = json_object_get_number (obj, "lastReported");
-  result->modified = json_object_get_number (obj, "modified");
+  result->lastConnected = json_object_get_uint (obj, "lastConnected");
+  result->lastReported = json_object_get_uint (obj, "lastReported");
+  result->modified = json_object_get_uint (obj, "modified");
   result->name = get_string (obj, "name");
   result->operatingState = edgex_operatingstate_fromstring
     (json_object_get_string (obj, "operatingState"));
-  result->origin = json_object_get_number (obj, "origin");
+  result->origin = json_object_get_uint (obj, "origin");
 
   return result;
 }
@@ -1144,8 +1144,8 @@ deviceservice_write (const edgex_deviceservice *e, bool create)
   if (!create)
   {
     json_object_set_string (obj, "id", e->id);
-    json_object_set_number (obj, "created", e->created);
-    json_object_set_number (obj, "modified", e->modified);
+    json_object_set_uint (obj, "created", e->created);
+    json_object_set_uint (obj, "modified", e->modified);
   }
 
   json_object_set_value
@@ -1154,12 +1154,12 @@ deviceservice_write (const edgex_deviceservice *e, bool create)
     (obj, "adminState", edgex_adminstate_tostring (e->adminState));
   json_object_set_string (obj, "description", e->description);
   json_object_set_value (obj, "labels", strings_to_array (e->labels));
-  json_object_set_number (obj, "lastConnected", e->lastConnected);
-  json_object_set_number (obj, "lastReported", e->lastReported);
+  json_object_set_uint (obj, "lastConnected", e->lastConnected);
+  json_object_set_uint (obj, "lastReported", e->lastReported);
   json_object_set_string (obj, "name", e->name);
   json_object_set_string
     (obj, "operatingState", edgex_operatingstate_tostring (e->operatingState));
-  json_object_set_number (obj, "origin", e->origin);
+  json_object_set_uint (obj, "origin", e->origin);
 
   return result;
 }
@@ -1293,17 +1293,17 @@ static edgex_device *device_read
     (json_object_get_object (obj, "protocols"));
   result->adminState = edgex_adminstate_fromstring
     (json_object_get_string (obj, "adminState"));
-  result->created = json_object_get_number (obj, "created");
+  result->created = json_object_get_uint (obj, "created");
   result->description = get_string (obj, "description");
   result->id = get_string (obj, "id");
   result->labels = array_to_strings (json_object_get_array (obj, "labels"));
-  result->lastConnected = json_object_get_number (obj, "lastConnected");
-  result->lastReported = json_object_get_number (obj, "lastReported");
-  result->modified = json_object_get_number (obj, "modified");
+  result->lastConnected = json_object_get_uint (obj, "lastConnected");
+  result->lastReported = json_object_get_uint (obj, "lastReported");
+  result->modified = json_object_get_uint (obj, "modified");
   result->name = get_string (obj, "name");
   result->operatingState = edgex_operatingstate_fromstring
     (json_object_get_string (obj, "operatingState"));
-  result->origin = json_object_get_number (obj, "origin");
+  result->origin = json_object_get_uint (obj, "origin");
   result->autos = NULL;
   JSON_Array *array = json_object_get_array (obj, "autoEvents");
   size_t count = json_array_get_count (array);
@@ -1334,8 +1334,8 @@ static JSON_Value *device_write (const edgex_device *e, bool create)
       (obj, "profile", deviceprofile_write_name (e->profile));
     json_object_set_value
       (obj, "service", deviceservice_write_name (e->service));
-    json_object_set_number (obj, "lastConnected", 0);
-    json_object_set_number (obj, "lastReported", 0);
+    json_object_set_uint (obj, "lastConnected", 0);
+    json_object_set_uint (obj, "lastReported", 0);
   }
   else
   {
@@ -1344,14 +1344,14 @@ static JSON_Value *device_write (const edgex_device *e, bool create)
     json_object_set_string
       (obj, "operatingState", edgex_operatingstate_tostring(e->operatingState));
     json_object_set_string (obj, "id", e->id);
-    json_object_set_number (obj, "created", e->created);
-    json_object_set_number (obj, "modified", e->modified);
+    json_object_set_uint (obj, "created", e->created);
+    json_object_set_uint (obj, "modified", e->modified);
     json_object_set_value
       (obj, "profile", deviceprofile_write (e->profile, false));
     json_object_set_value
       (obj, "service", deviceservice_write (e->service, false));
-    json_object_set_number (obj, "lastConnected", e->lastConnected);
-    json_object_set_number (obj, "lastReported", e->lastReported);
+    json_object_set_uint (obj, "lastConnected", e->lastConnected);
+    json_object_set_uint (obj, "lastReported", e->lastReported);
   }
 
   json_object_set_value
@@ -1365,7 +1365,7 @@ static JSON_Value *device_write (const edgex_device *e, bool create)
   json_object_set_value (obj, "labels", strings_to_array (e->labels));
   json_object_set_string
     (obj, "operatingState", edgex_operatingstate_tostring (e->operatingState));
-  json_object_set_number (obj, "origin", e->origin);
+  json_object_set_uint (obj, "origin", e->origin);
 
   return result;
 }
@@ -1530,7 +1530,7 @@ char *edgex_addressable_write (const edgex_addressable *e, bool create)
 static edgex_valuedescriptor *valuedescriptor_read (const JSON_Object *obj)
 {
   edgex_valuedescriptor *result = malloc (sizeof (edgex_valuedescriptor));
-  result->created = json_object_get_number (obj, "created");
+  result->created = json_object_get_uint (obj, "created");
   result->defaultValue = get_string (obj, "defaultValue");
   result->description = get_string (obj, "description");
   result->formatting = get_string (obj, "formatting");
@@ -1538,9 +1538,9 @@ static edgex_valuedescriptor *valuedescriptor_read (const JSON_Object *obj)
   result->labels = array_to_strings (json_object_get_array (obj, "labels"));
   result->max = get_string (obj, "max");
   result->min = get_string (obj, "min");
-  result->modified = json_object_get_number (obj, "modified");
+  result->modified = json_object_get_uint (obj, "modified");
   result->name = get_string (obj, "name");
-  result->origin = json_object_get_number (obj, "origin");
+  result->origin = json_object_get_uint (obj, "origin");
   result->type = get_string (obj, "type");
   result->uomLabel = get_string (obj, "uomLabel");
   result->mediaType = get_string (obj, "mediaType");
@@ -1553,7 +1553,7 @@ static JSON_Value *valuedescriptor_write (const edgex_valuedescriptor *e)
 {
   JSON_Value *result = json_value_init_object ();
   JSON_Object *obj = json_value_get_object (result);
-  json_object_set_number (obj, "created", e->created);
+  json_object_set_uint (obj, "created", e->created);
   json_object_set_string (obj, "defaultValue", e->defaultValue);
   json_object_set_string (obj, "description", e->description);
   json_object_set_string (obj, "formatting", e->formatting);
@@ -1561,9 +1561,9 @@ static JSON_Value *valuedescriptor_write (const edgex_valuedescriptor *e)
   json_object_set_value (obj, "labels", strings_to_array (e->labels));
   json_object_set_string (obj, "max", e->max);
   json_object_set_string (obj, "min", e->min);
-  json_object_set_number (obj, "modified", e->modified);
+  json_object_set_uint (obj, "modified", e->modified);
   json_object_set_string (obj, "name", e->name);
-  json_object_set_number (obj, "origin", e->origin);
+  json_object_set_uint (obj, "origin", e->origin);
   json_object_set_string (obj, "type", e->type);
   json_object_set_string (obj, "uomLabel", e->uomLabel);
   json_object_set_string (obj, "floatEncoding", e->floatEncoding);

--- a/src/c/metrics.c
+++ b/src/c/metrics.c
@@ -44,8 +44,8 @@ int edgex_device_handler_metrics
   JSON_Object *memobj = json_value_get_object (memval);
 
   struct mallinfo mi = mallinfo ();
-  json_object_set_number (memobj, "Alloc", mi.uordblks);
-  json_object_set_number (memobj, "TotalAlloc", mi.arena + mi.hblkhd);
+  json_object_set_uint (memobj, "Alloc", mi.uordblks);
+  json_object_set_uint (memobj, "TotalAlloc", mi.arena + mi.hblkhd);
 
   json_object_set_value (obj, "Memory", memval);
 

--- a/src/c/parson.h
+++ b/src/c/parson.h
@@ -43,7 +43,8 @@ enum json_value_type {
     JSONNumber  = 3,
     JSONObject  = 4,
     JSONArray   = 5,
-    JSONBoolean = 6
+    JSONBoolean = 6,
+    JSONUint    = 7
 };
 typedef int JSON_Value_Type;
 
@@ -112,6 +113,7 @@ JSON_Object * json_object_get_object (const JSON_Object *object, const char *nam
 JSON_Array  * json_object_get_array  (const JSON_Object *object, const char *name);
 double        json_object_get_number (const JSON_Object *object, const char *name); /* returns 0 on fail */
 int           json_object_get_boolean(const JSON_Object *object, const char *name); /* returns -1 on fail */
+uint64_t      json_object_get_uint   (const JSON_Object *object, const char *name); /* returns 0 on fail */
 
 /* dotget functions enable addressing values with dot notation in nested objects,
  just like in structs or c++/java/c# objects (e.g. objectA.objectB.value).
@@ -123,6 +125,7 @@ JSON_Object * json_object_dotget_object (const JSON_Object *object, const char *
 JSON_Array  * json_object_dotget_array  (const JSON_Object *object, const char *name);
 double        json_object_dotget_number (const JSON_Object *object, const char *name); /* returns 0 on fail */
 int           json_object_dotget_boolean(const JSON_Object *object, const char *name); /* returns -1 on fail */
+uint64_t      json_object_dotget_uint   (const JSON_Object *object, const char *name); /* returns 0 on fail */
 
 /* Functions to get available names */
 size_t        json_object_get_count   (const JSON_Object *object);
@@ -144,6 +147,7 @@ JSON_Status json_object_set_value(JSON_Object *object, const char *name, JSON_Va
 JSON_Status json_object_set_string(JSON_Object *object, const char *name, const char *string);
 JSON_Status json_object_set_number(JSON_Object *object, const char *name, double number);
 JSON_Status json_object_set_boolean(JSON_Object *object, const char *name, int boolean);
+JSON_Status json_object_set_uint(JSON_Object *object, const char *name, uint64_t number);
 JSON_Status json_object_set_null(JSON_Object *object, const char *name);
 
 /* Works like dotget functions, but creates whole hierarchy if necessary.
@@ -152,6 +156,7 @@ JSON_Status json_object_dotset_value(JSON_Object *object, const char *name, JSON
 JSON_Status json_object_dotset_string(JSON_Object *object, const char *name, const char *string);
 JSON_Status json_object_dotset_number(JSON_Object *object, const char *name, double number);
 JSON_Status json_object_dotset_boolean(JSON_Object *object, const char *name, int boolean);
+JSON_Status json_object_dotset_uint(JSON_Object *object, const char *name, uint64_t number);
 JSON_Status json_object_dotset_null(JSON_Object *object, const char *name);
 
 /* Frees and removes name-value pair */
@@ -172,6 +177,7 @@ JSON_Object * json_array_get_object (const JSON_Array *array, size_t index);
 JSON_Array  * json_array_get_array  (const JSON_Array *array, size_t index);
 double        json_array_get_number (const JSON_Array *array, size_t index); /* returns 0 on fail */
 int           json_array_get_boolean(const JSON_Array *array, size_t index); /* returns -1 on fail */
+uint64_t      json_array_get_uint   (const JSON_Array *array, size_t index); /* returns 0 on fail */
 size_t        json_array_get_count  (const JSON_Array *array);
 JSON_Value  * json_array_get_wrapping_value(const JSON_Array *array);
     
@@ -186,6 +192,7 @@ JSON_Status json_array_replace_value(JSON_Array *array, size_t i, JSON_Value *va
 JSON_Status json_array_replace_string(JSON_Array *array, size_t i, const char* string);
 JSON_Status json_array_replace_number(JSON_Array *array, size_t i, double number);
 JSON_Status json_array_replace_boolean(JSON_Array *array, size_t i, int boolean);
+JSON_Status json_array_replace_uint(JSON_Array *array, size_t i, uint64_t number);
 JSON_Status json_array_replace_null(JSON_Array *array, size_t i);
 
 /* Frees and removes all values from array */
@@ -197,6 +204,7 @@ JSON_Status json_array_append_value(JSON_Array *array, JSON_Value *value);
 JSON_Status json_array_append_string(JSON_Array *array, const char *string);
 JSON_Status json_array_append_number(JSON_Array *array, double number);
 JSON_Status json_array_append_boolean(JSON_Array *array, int boolean);
+JSON_Status json_array_append_uint(JSON_Array *array, uint64_t number);
 JSON_Status json_array_append_null(JSON_Array *array);
 
 /*
@@ -207,6 +215,7 @@ JSON_Value * json_value_init_array  (void);
 JSON_Value * json_value_init_string (const char *string); /* copies passed string */
 JSON_Value * json_value_init_number (double number);
 JSON_Value * json_value_init_boolean(int boolean);
+JSON_Value * json_value_init_uint   (uint64_t number);
 JSON_Value * json_value_init_null   (void);
 JSON_Value * json_value_deep_copy   (const JSON_Value *value);
 void         json_value_free        (JSON_Value *value);
@@ -217,6 +226,7 @@ JSON_Array  *   json_value_get_array  (const JSON_Value *value);
 const char  *   json_value_get_string (const JSON_Value *value);
 double          json_value_get_number (const JSON_Value *value);
 int             json_value_get_boolean(const JSON_Value *value);
+uint64_t        json_value_get_uint   (const JSON_Value *value);
 JSON_Value  *   json_value_get_parent (const JSON_Value *value);
 
 /* Same as above, but shorter */
@@ -226,6 +236,7 @@ JSON_Array  *   json_array  (const JSON_Value *value);
 const char  *   json_string (const JSON_Value *value);
 double          json_number (const JSON_Value *value);
 int             json_boolean(const JSON_Value *value);
+uint64_t        json_uint   (const JSON_Value *value);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The new nanosecond timestamps for event/reading origin are sufficiently large that just using "double" for all numbers whether floating-point or not results in misrepresentations.
1) Include support for uint64 as an additional JSON object type
2) Parse numbers into uint64 if they fit, double (as before) otherwise
3) Allow uint64 to be retrieved and compared as if it was a double
4) Use this new type for all numbers that we use in EdgeX that are actually uints.