### PR TITLE
Allow config overrides from environment when populating the registry

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,7 +8,10 @@ differs as follows:
 
 Changes for 1.1.0 "Fuji":
 
-- Device services de-register from the registry on exit
+- Configuration can be overridden via environment variables when populating
+  the registry.
+- Subtables are supported in the Driver configuration.
+- Device services de-register from the registry on exit.
 - Event timestamps are now at nanosecond resolution, and are monotonic.
 
 Changes for 1.0.0 "Edinburgh":

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,7 +4,17 @@ The device service configuration is held in TOML format. The SDK method `edgex_d
 
 Configuration parameters are organized within a number of sections. A section is represented by a TOML table, eg `[Service]`.
 
-If the Registry is in use, configuration is contained in subfolders of edgex/core/1.0/<service-name>. The "Clients" section is not present in this scenario, as the Registry provides a specific mechanism for maintaining service information.
+If the Registry is in use, configuration is contained in subfolders of `edgex/core/1.0/<service-name>`. The "Clients" section is not present in this scenario, as the Registry provides a specific mechanism for maintaining service information.
+
+When a device service is run for the first time with Registry enabled, it reads its configuration from a TOML file and uploads it to the Registry. The value of any configuration element can be over-ridden at this time with a value from a corresponding environment variable. The service first looks for an environment variable whose name is of the form
+
+`<service-name>_<section-name>_<config-element>`
+
+and if that is not present, then tries
+
+`<section-name>_<config-element>`
+
+For example, `device-template_Device_MaxCmdOps` or `Logging_LogLevel`.
 
 ## Service section
 

--- a/src/c/config.h
+++ b/src/c/config.h
@@ -21,7 +21,7 @@ typedef struct edgex_device_serviceinfo
   uint32_t connectretries;
   char **labels;
   char *startupmsg;
-  uint32_t timeout;
+  struct timespec timeout;
   char *checkinterval;
 } edgex_device_serviceinfo;
 
@@ -87,19 +87,16 @@ toml_table_t *edgex_device_loadConfig
   edgex_error *err
 );
 
-void edgex_device_populateConfig
-  (edgex_device_service *svc, toml_table_t *config, edgex_error *err);
+edgex_nvpairs *edgex_device_parseToml (toml_table_t *config);
 
-void edgex_device_populateConfigNV
+void edgex_device_parseTomlClients (iot_logger_t *lc, toml_table_t *clients, edgex_service_endpoints *endpoints, edgex_error *err);
+
+void edgex_device_populateConfig
   (edgex_device_service *svc, const edgex_nvpairs *config, edgex_error *err);
 
+void edgex_device_overrideConfig (iot_logger_t *lc, const char *sname, edgex_nvpairs *config);
+
 void edgex_device_updateConf (void *svc, const edgex_nvpairs *config);
-
-void edgex_device_validateConfig (edgex_device_service *svc, edgex_error *err);
-
-edgex_nvpairs *edgex_device_getConfig (const edgex_device_service *svc);
-
-void edgex_device_dumpConfig (edgex_device_service *svc);
 
 void edgex_device_freeConfig (edgex_device_service *svc);
 

--- a/src/c/data.c
+++ b/src/c/data.c
@@ -382,27 +382,3 @@ edgex_valuedescriptor *edgex_data_client_add_valuedescriptor
 
   return result;
 }
-
-bool edgex_data_client_ping
-(
-  iot_logger_t *lc,
-  edgex_service_endpoints *endpoints,
-  edgex_error *err
-)
-{
-  edgex_ctx ctx;
-  char url[URL_BUF_SIZE];
-
-  memset (&ctx, 0, sizeof (edgex_ctx));
-  snprintf
-  (
-    url,
-    URL_BUF_SIZE - 1,
-    "http://%s:%u/api/v1/ping",
-    endpoints->data.host,
-    endpoints->data.port
-  );
-
-  edgex_http_get (lc, &ctx, url, NULL, err);
-  return (err->code == 0);
-}

--- a/src/c/data.h
+++ b/src/c/data.h
@@ -111,13 +111,6 @@ edgex_valuedescriptor *edgex_data_client_add_valuedescriptor
   edgex_error *err
 );
 
-bool edgex_data_client_ping
-(
-  iot_logger_t *lc,
-  edgex_service_endpoints *endpoints,
-  edgex_error *err
-);
-
 void edgex_device_commandresult_free (edgex_device_commandresult *res, int n);
 
 edgex_device_commandresult *edgex_device_commandresult_dup (const edgex_device_commandresult *res, int n);

--- a/src/c/metadata.c
+++ b/src/c/metadata.c
@@ -631,27 +631,3 @@ void edgex_metadata_client_delete_addressable
 
   free (ctx.buff);
 }
-
-bool edgex_metadata_client_ping
-(
-  iot_logger_t *lc,
-  edgex_service_endpoints *endpoints,
-  edgex_error *err
-)
-{
-  edgex_ctx ctx;
-  char url[URL_BUF_SIZE];
-
-  memset (&ctx, 0, sizeof (edgex_ctx));
-  snprintf
-  (
-    url,
-    URL_BUF_SIZE - 1,
-    "http://%s:%u/api/v1/ping",
-    endpoints->metadata.host,
-    endpoints->metadata.port
-  );
-
-  edgex_http_get (lc, &ctx, url, NULL, err);
-  return (err->code == 0);
-}

--- a/src/c/metadata.h
+++ b/src/c/metadata.h
@@ -153,11 +153,5 @@ void edgex_metadata_client_delete_addressable
   const char * name,
   edgex_error * err
 );
-bool edgex_metadata_client_ping
-(
-  iot_logger_t * lc,
-  edgex_service_endpoints * endpoints,
-  edgex_error * err
-);
 
 #endif


### PR DESCRIPTION
Make TOML parsing return name-value pairs like the registry does.
Rework the configuration part of service startup.
Use a generic ping function for supporting services.

Implements #147 

Signed-off-by: Iain Anderson <iain@iotechsys.com>