### PR TITLE
Process cmdline arguments in the sdk (#146)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,7 @@ differs as follows:
 
 Changes for 1.1.0 "Fuji":
 
+- Commandline argument processing mostly handled within the SDK.
 - Added callback API for device addition/update/removal events.
 - Configuration can be overridden via environment variables when populating
   the registry.

--- a/include/edgex/devsdk.h
+++ b/include/edgex/devsdk.h
@@ -19,6 +19,41 @@
 #include "edgex/edgex-logging.h"
 
 /**
+ * @brief Structure containing startup parameters.
+ */
+
+typedef struct edgex_device_svcparams
+{
+  /** The name of the device service */
+  const char *svcname;
+  /** The configuration directory to read from */
+  const char *confdir;
+  /** The location of the registry service, if enabled */
+  const char *regURL;
+  /** The configuration profile to use */
+  const char *profile;
+} edgex_device_svcparams;
+
+/**
+ * @brief Extracts startup parameters from command line and environment. The
+ *        command-line argument array argc and argv are altered to represent
+ *        whatever arguments remain unprocessed.
+ * @param argc A pointer to argc as passed into main().
+ * @param argv argv as passed into main().
+ * @param params The startup parameters to populate.
+ * @returns true if there were no errors in processing.
+ */
+
+bool edgex_device_service_processparams
+  (int *argc, char **argv, edgex_device_svcparams *params);
+
+/**
+ * @brief Prints usage information.
+ */
+
+void edgex_device_service_usage (void);
+
+/**
  * @brief Structure containing information about a device resource which is
  *        the subject of a get or set request.
  */

--- a/src/c/examples/counters/device-counter.c
+++ b/src/c/examples/counters/device-counter.c
@@ -192,92 +192,33 @@ static bool counter_disconnect (void *impl, edgex_protocols *device)
 static void counter_stop (void *impl, bool force) {}
 
 
-static void usage (void)
-{
-  printf ("Options: \n");
-  printf ("   -h, --help           : Show this text\n");
-  printf ("   -n, --name=<name>    : Set the device service name\n");
-  printf ("   -r, --registry=<url> : Use the registry service\n");
-  printf ("   -p, --profile=<name> : Set the profile name\n");
-  printf ("   -c, --confdir=<dir>  : Set the configuration directory\n");
-}
-
-static bool testArg (int argc, char *argv[], int *pos, const char *pshort, const char *plong, char **var)
-{
-  if (strcmp (argv[*pos], pshort) == 0 || strcmp (argv[*pos], plong) == 0)
-  {
-    if (*pos < argc - 1)
-    {
-      (*pos)++;
-      *var = argv[*pos];
-      (*pos)++;
-      return true;
-    }
-    else
-    {
-      printf ("Option %s requires an argument\n", argv[*pos]);
-      exit (0);
-    }
-  }
-  char *eq = strchr (argv[*pos], '=');
-  if (eq)
-  {
-    if (strncmp (argv[*pos], pshort, eq - argv[*pos]) == 0 || strncmp (argv[*pos], plong, eq - argv[*pos]) == 0)
-    {
-      if (strlen (++eq))
-      {
-        *var = eq;
-        (*pos)++;
-        return true;
-      }
-      else
-      {
-        printf ("Option %s requires an argument\n", argv[*pos]);
-        exit (0);
-      }
-    }
-  }
-  return false;
-}
-
 int main (int argc, char *argv[])
 {
-  char *profile = "";
-  char *confdir = "";
-  char *svcname = "device-counter";
-  char *regURL = getenv ("EDGEX_REGISTRY");
+  edgex_device_svcparams params = { "device-counter", "", "", "" };
 
   counter_driver * impl = malloc (sizeof (counter_driver));
   impl->lc = NULL;
+
+  if (!edgex_device_service_processparams (&argc, argv, &params))
+  {
+    return  0;
+  }
 
   int n = 1;
   while (n < argc)
   {
     if (strcmp (argv[n], "-h") == 0 || strcmp (argv[n], "--help") == 0)
     {
-      usage ();
+      printf ("Options:\n");
+      printf ("  -h, --help\t\t: Show this text\n");
+      edgex_device_service_usage ();
       return 0;
     }
-    if (testArg (argc, argv, &n, "-r", "--registry", &regURL))
+    else
     {
-      continue;
+      printf ("%s: Unrecognized option %s\n", argv[0], argv[n]);
+      return 0;
     }
-    if (testArg (argc, argv, &n, "-n", "--name", &svcname))
-    {
-      continue;
-    }
-    if (testArg (argc, argv, &n, "-p", "--profile", &profile))
-    {
-      continue;
-    }
-    if (testArg (argc, argv, &n, "-c", "--confdir", &confdir))
-    {
-      continue;
-    }
-
-    printf ("Unknown option %s\n", argv[n]);
-    usage ();
-    return 0;
   }
 
   edgex_error e;
@@ -294,10 +235,10 @@ int main (int argc, char *argv[])
   };
 
   edgex_device_service *service = edgex_device_service_new
-    (svcname, "1.0", impl, counterImpls, &e);
+    (params.svcname, "1.0", impl, counterImpls, &e);
   ERR_CHECK (e);
 
-  edgex_device_service_start (service, regURL, profile, confdir, &e);
+  edgex_device_service_start (service, params.regURL, params.profile, params.confdir, &e);
   ERR_CHECK (e);
 
   signal (SIGINT, inthandler);

--- a/src/c/examples/random/device-random.c
+++ b/src/c/examples/random/device-random.c
@@ -144,93 +144,33 @@ static bool random_disconnect (void *impl, edgex_protocols *device)
 
 static void random_stop (void *impl, bool force) {}
 
-
-static void usage (void)
-{
-  printf ("Options: \n");
-  printf ("   -h, --help           : Show this text\n");
-  printf ("   -n, --name=<name>    : Set the device service name\n");
-  printf ("   -r, --registry=<url> : Use the registry service\n");
-  printf ("   -p, --profile=<name> : Set the profile name\n");
-  printf ("   -c, --confdir=<dir>  : Set the configuration directory\n");
-}
-
-static bool testArg (int argc, char *argv[], int *pos, const char *pshort, const char *plong, char **var)
-{
-  if (strcmp (argv[*pos], pshort) == 0 || strcmp (argv[*pos], plong) == 0)
-  {
-    if (*pos < argc - 1)
-    {
-      (*pos)++;
-      *var = argv[*pos];
-      (*pos)++;
-      return true;
-    }
-    else
-    {
-      printf ("Option %s requires an argument\n", argv[*pos]);
-      exit (0);
-    }
-  }
-  char *eq = strchr (argv[*pos], '=');
-  if (eq)
-  {
-    if (strncmp (argv[*pos], pshort, eq - argv[*pos]) == 0 || strncmp (argv[*pos], plong, eq - argv[*pos]) == 0)
-    {
-      if (strlen (++eq))
-      {
-        *var = eq;
-        (*pos)++;
-        return true;
-      }
-      else
-      {
-        printf ("Option %s requires an argument\n", argv[*pos]);
-        exit (0);
-      }
-    }
-  }
-  return false;
-}
-
 int main (int argc, char *argv[])
 {
-  char *profile = "";
-  char *confdir = "";
-  char *svcname = "device-random";
-  char *regURL = getenv ("EDGEX_REGISTRY");
+  edgex_device_svcparams params = { "device-random", "", "", "" };
 
   random_driver * impl = malloc (sizeof (random_driver));
   memset (impl, 0, sizeof (random_driver));
+
+  if (!edgex_device_service_processparams (&argc, argv, &params))
+  {
+    return  0;
+  }
 
   int n = 1;
   while (n < argc)
   {
     if (strcmp (argv[n], "-h") == 0 || strcmp (argv[n], "--help") == 0)
     {
-      usage ();
+      printf ("Options:\n");
+      printf ("  -h, --help\t\t: Show this text\n");
+      edgex_device_service_usage ();
       return 0;
     }
-    if (testArg (argc, argv, &n, "-r", "--registry", &regURL))
+    else
     {
-      continue;
+      printf ("%s: Unrecognized option %s\n", argv[0], argv[n]);
+      return 0;
     }
-    if (testArg (argc, argv, &n, "-n", "--name", &svcname))
-    {
-      continue;
-    }
-    if (testArg (argc, argv, &n, "-p", "--profile", &profile))
-    {
-      continue;
-    }
-    if (testArg (argc, argv, &n, "-c", "--confdir", &confdir))
-    {
-      continue;
-    }
-
-    printf ("Unknown option %s\n", argv[n]);
-    usage ();
-    return 0;
   }
 
   edgex_error e;
@@ -249,11 +189,11 @@ int main (int argc, char *argv[])
 
   /* Initalise a new device service */
   edgex_device_service *service = edgex_device_service_new
-    (svcname, "1.0", impl, randomImpls, &e);
+    (params.svcname, "1.0", impl, randomImpls, &e);
   ERR_CHECK (e);
 
   /* Start the device service*/
-  edgex_device_service_start (service, regURL, profile, confdir, &e);
+  edgex_device_service_start (service, params.regURL, params.profile, params.confdir, &e);
   ERR_CHECK (e);
 
   signal (SIGINT, inthandler);


### PR DESCRIPTION
As per #146 except that:

-  --help is left outside of the sdk (avoids having to bounce the help request back to the caller)
- the argument processing is an additional function rather than a change to service_new (so as not to change an existing API. Probably we'll consolidate this when we go to 2.0).


Signed-off-by: Iain Anderson <iain@iotechsys.com>