### PR TITLE
Fixes for container build

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,9 @@ Once you have the builder image, to compile the code, run the following command:
 `docker run --rm -e "UID=`id -u`" -e "GID=`id -g`" -v $PWD/results:/edgex-c-sdk/results device-sdk-c-builder`
 
 This will generate the sdk files in a results directory at the root of this project.
+
+Alternatively, you can build a docker image which can be used to build device services in, with the following command:
+
+`docker build -t edgex-csdk-base:1.1.0 -f scripts/Dockerfile.alpine-3.9-base .`
+
+You can then write a Dockerfile for your service that begins `FROM edgex-csdk-base:1.0.0`

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ usage.
 
 To build the docker image which will build the deliverable, run the following command:
 
-`docker build -t device-sdk-go-c-builder -f scripts/Dockerfile.alpine-3.7 .`
+`docker build -t device-sdk-c-builder -f scripts/Dockerfile.alpine-3.9 .`
 
 Once you have the builder image, to compile the code, run the following command:
 
-`docker run --rm -e UID -e GID -v $PWD/release:/edgex-c-sdk/build/release device-sdk-go-c-builder`
+`docker run --rm -e "UID=`id -u`" -e "GID=`id -g`" -v $PWD/results:/edgex-c-sdk/results device-sdk-c-builder`
 
-This will generate the release files at the root of this project.
+This will generate the sdk files in a results directory at the root of this project.

--- a/scripts/Dockerfile.alpine-3.9
+++ b/scripts/Dockerfile.alpine-3.9
@@ -1,5 +1,5 @@
 FROM alpine:3.9
-MAINTAINER Steve Osselton <steve@iotechsys.com>
+MAINTAINER Iain Anderson <iain@iotechsys.com>
 RUN apk add --update --no-cache build-base wget git gcc cmake make yaml-dev libcurl curl-dev libmicrohttpd-dev util-linux-dev ncurses-dev && mkdir -p /edgex-c-sdk/build
 COPY VERSION /edgex-c-sdk/
 COPY src /edgex-c-sdk/src/

--- a/scripts/Dockerfile.alpine-3.9
+++ b/scripts/Dockerfile.alpine-3.9
@@ -1,6 +1,6 @@
-FROM alpine:3.7
+FROM alpine:3.9
 MAINTAINER Steve Osselton <steve@iotechsys.com>
-RUN apk add --update --no-cache build-base wget git gcc cmake make yaml-dev libcurl curl-dev libmicrohttpd-dev util-linux-dev && mkdir -p /edgex-c-sdk/build
+RUN apk add --update --no-cache build-base wget git gcc cmake make yaml-dev libcurl curl-dev libmicrohttpd-dev util-linux-dev ncurses-dev && mkdir -p /edgex-c-sdk/build
 COPY VERSION /edgex-c-sdk/
 COPY src /edgex-c-sdk/src/
 COPY include /edgex-c-sdk/include/

--- a/scripts/Dockerfile.alpine-3.9-base
+++ b/scripts/Dockerfile.alpine-3.9-base
@@ -1,5 +1,5 @@
 FROM alpine:3.9
-MAINTAINER Steve Osselton <steve@iotechsys.com>
+MAINTAINER Iain Anderson <iain@iotechsys.com>
 RUN apk add --update --no-cache build-base wget git gcc cmake make yaml-dev libcurl curl-dev libmicrohttpd-dev util-linux-dev ncurses-dev
 
 ENV CBOR_VERSION=0.5.0

--- a/scripts/Dockerfile.alpine-3.9-base
+++ b/scripts/Dockerfile.alpine-3.9-base
@@ -1,0 +1,25 @@
+FROM alpine:3.9
+MAINTAINER Steve Osselton <steve@iotechsys.com>
+RUN apk add --update --no-cache build-base wget git gcc cmake make yaml-dev libcurl curl-dev libmicrohttpd-dev util-linux-dev ncurses-dev
+
+ENV CBOR_VERSION=0.5.0
+RUN mkdir /tmp/cbor \
+  && cd /tmp/cbor \
+  && wget -O - https://github.com/PJK/libcbor/archive/v${CBOR_VERSION}.tar.gz | tar -z -x -f - \
+  && sed -e 's/-flto//' -i libcbor-${CBOR_VERSION}/CMakeLists.txt \
+  && cmake -DCMAKE_BUILD_TYPE=Release -DCBOR_CUSTOM_ALLOC=ON libcbor-${CBOR_VERSION} \
+  && make \
+  && make install
+
+RUN mkdir /tmp/sdk
+COPY VERSION /tmp/sdk
+COPY src /tmp/sdk/src
+COPY include /tmp/sdk/include
+COPY scripts /tmp/sdk/scripts
+COPY LICENSE /tmp/sdk
+COPY Attribution.txt /tmp/sdk
+RUN cd /tmp/sdk \
+  && ./scripts/build.sh \
+  && make -C build/release install
+
+RUN rm -rf /tmp/cbor /tmp/sdk

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,11 +1,13 @@
 #!/bin/sh
 set -x -e
 
+CBOR_VERSION=0.5.0
+
 mkdir /deps
 cd /deps
-git clone https://github.com/PJK/libcbor
-sed -e 's/-flto//' -i libcbor/CMakeLists.txt
-cmake -DCMAKE_BUILD_TYPE=Release -DCBOR_CUSTOM_ALLOC=ON libcbor
+wget -O - https://github.com/PJK/libcbor/archive/v${CBOR_VERSION}.tar.gz | tar -z -x -f -
+sed -e 's/-flto//' -i libcbor-${CBOR_VERSION}/CMakeLists.txt
+cmake -DCMAKE_BUILD_TYPE=Release -DCBOR_CUSTOM_ALLOC=ON libcbor-${CBOR_VERSION}
 make
 make install
 
@@ -13,6 +15,11 @@ make install
 
 /edgex-c-sdk/scripts/build.sh $*
 
+mkdir -p /edgex-c-sdk/results/debug
+cp /edgex-c-sdk/build/debug/c/libcsdk.so /edgex-c-sdk/results/debug
+cp /edgex-c-sdk/build/release/csdk-*.tar.gz /edgex-c-sdk/results
+cp /edgex-c-sdk/build/release/release.log /edgex-c-sdk/results
+
 # Set ownership of generated files
 
-chown -R $UID:$GID /edgex-c-sdk/build
+chown -R $UID:$GID /edgex-c-sdk/results


### PR DESCRIPTION
Move docker builds to Alpine 3.9
Use released version of CBOR library rather than HEAD  ( Fixes #190 )
Declutter the output of the docker build
Add dockerfile for producing a container in which to build a service