### PR TITLE
Add initial provision watcher support (#8)

### DIFF
--- a/include/edgex/edgex-base.h
+++ b/include/edgex/edgex-base.h
@@ -11,6 +11,10 @@
 
 #include "edgex/os.h"
 
+typedef enum { LOCKED, UNLOCKED } edgex_device_adminstate;
+
+typedef enum { ENABLED, DISABLED } edgex_device_operatingstate;
+
 typedef struct edgex_strings
 {
   char *str;
@@ -23,6 +27,15 @@ typedef struct edgex_nvpairs
   char *value;
   struct edgex_nvpairs *next;
 } edgex_nvpairs;
+
+/**
+ * @brief Finds a named value in an n-v pair list.
+ * @param nvp A list of name-value pairs.
+ * @param name The named value to search for.
+ * @returns The value corresponding to the given name, or NULL if not found.
+ */
+
+const char *edgex_nvpairs_value (const edgex_nvpairs *nvp, const char *name);
 
 typedef struct edgex_blob
 {

--- a/include/edgex/edgex.h
+++ b/include/edgex/edgex.h
@@ -11,10 +11,6 @@
 
 #include "edgex/edgex-base.h"
 
-typedef enum { LOCKED, UNLOCKED } edgex_device_adminstate;
-
-typedef enum { ENABLED, DISABLED } edgex_device_operatingstate;
-
 typedef struct
 {
   bool enabled;
@@ -144,6 +140,24 @@ typedef struct edgex_deviceprofile
   struct edgex_cmdinfo *cmdinfo;
   struct edgex_deviceprofile *next;
 } edgex_deviceprofile;
+
+typedef struct edgex_blocklist
+{
+  char *name;
+  edgex_strings *values;
+  struct edgex_blocklist *next;
+} edgex_blocklist;
+
+typedef struct edgex_watcher
+{
+  char *id;
+  char *name;
+  edgex_nvpairs *identifiers;
+  edgex_blocklist *blocking_identifiers;
+  char *profile;
+  edgex_device_adminstate adminstate;
+  struct edgex_watcher *next;
+} edgex_watcher;
 
 typedef struct edgex_device_autoevents
 {

--- a/src/c/edgex-base.c
+++ b/src/c/edgex-base.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2019
+ * IoTech Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#include "edgex/edgex-base.h"
+
+const char *edgex_nvpairs_value (const edgex_nvpairs *nvp, const char *name)
+{
+  if (name)
+  {
+    for (; nvp; nvp = nvp->next)
+    {
+      if (strcmp (nvp->name, name) == 0)
+      {
+        return nvp->value;
+      }
+    }
+  }
+  return NULL;
+}

--- a/src/c/edgex-rest.h
+++ b/src/c/edgex-rest.h
@@ -43,6 +43,10 @@ void edgex_addressable_free (edgex_addressable *e);
 edgex_valuedescriptor *edgex_valuedescriptor_read (const char *json);
 char *edgex_valuedescriptor_write (const edgex_valuedescriptor *e);
 void edgex_valuedescriptor_free (edgex_valuedescriptor *e);
+edgex_watcher *edgex_watcher_read (const char *json);
+edgex_watcher *edgex_watchers_read (const char *json);
+edgex_watcher *edgex_watcher_dup (const edgex_watcher *e);
+void edgex_watcher_free (edgex_watcher *e);
 
 #ifdef EDGEX_DEBUG_DUMP
 void edgex_deviceprofile_dump (edgex_deviceprofile * e);

--- a/src/c/metadata.c
+++ b/src/c/metadata.c
@@ -536,6 +536,78 @@ void edgex_metadata_client_delete_device_byname
   free (ctx.buff);
 }
 
+edgex_watcher *edgex_metadata_client_get_watchers
+(
+  iot_logger_t * lc,
+  edgex_service_endpoints * endpoints,
+  const char * servicename,
+  edgex_error * err
+)
+{
+  edgex_ctx ctx;
+  edgex_watcher *result = 0;
+  char url[URL_BUF_SIZE];
+
+  memset (&ctx, 0, sizeof (edgex_ctx));
+  snprintf
+  (
+    url,
+    URL_BUF_SIZE - 1,
+    "http://%s:%u/api/v1/provisionwatcher/servicename/%s",
+    endpoints->metadata.host,
+    endpoints->metadata.port,
+    servicename
+  );
+
+  edgex_http_get (lc, &ctx, url, edgex_http_write_cb, err);
+
+  if (err->code)
+  {
+    return 0;
+  }
+
+  result = edgex_watchers_read (ctx.buff);
+  free (ctx.buff);
+  *err = EDGEX_OK;
+  return result;
+}
+
+edgex_watcher *edgex_metadata_client_get_watcher
+(
+  iot_logger_t * lc,
+  edgex_service_endpoints * endpoints,
+  const char * watcherId,
+  edgex_error * err
+)
+{
+  edgex_ctx ctx;
+  edgex_watcher *result = 0;
+  char url[URL_BUF_SIZE];
+
+  memset (&ctx, 0, sizeof (edgex_ctx));
+  snprintf
+  (
+    url,
+    URL_BUF_SIZE - 1,
+    "http://%s:%u/api/v1/provisionwatcher/%s",
+    endpoints->metadata.host,
+    endpoints->metadata.port,
+    watcherId
+  );
+
+  edgex_http_get (lc, &ctx, url, edgex_http_write_cb, err);
+
+  if (err->code)
+  {
+    return 0;
+  }
+
+  result = edgex_watcher_read (ctx.buff);
+  free (ctx.buff);
+  *err = EDGEX_OK;
+  return result;
+}
+
 edgex_addressable *edgex_metadata_client_get_addressable
 (
   iot_logger_t *lc,

--- a/src/c/metadata.h
+++ b/src/c/metadata.h
@@ -132,6 +132,20 @@ void edgex_metadata_client_delete_device_byname
   const char * devicename,
   edgex_error * err
 );
+edgex_watcher *edgex_metadata_client_get_watchers
+(
+  iot_logger_t * lc,
+  edgex_service_endpoints * endpoints,
+  const char * servicename,
+  edgex_error * err
+);
+edgex_watcher *edgex_metadata_client_get_watcher
+(
+  iot_logger_t * lc,
+  edgex_service_endpoints * endpoints,
+  const char * watcherId,
+  edgex_error * err
+);
 edgex_addressable * edgex_metadata_client_get_addressable
 (
   iot_logger_t * lc,

--- a/src/c/service.h
+++ b/src/c/service.h
@@ -16,6 +16,7 @@
 #include "edgex/registry.h"
 #include "config.h"
 #include "devmap.h"
+#include "watchers.h"
 #include "rest-server.h"
 #include "iot/threadpool.h"
 #include "iot/scheduler.h"
@@ -41,6 +42,7 @@ struct edgex_device_service
   uint64_t starttime;
 
   edgex_devmap_t *devices;
+  edgex_watchlist_t *watchlist;
   iot_threadpool_t *thpool;
   iot_scheduler_t *scheduler;
   pthread_mutex_t discolock;

--- a/src/c/watchers.c
+++ b/src/c/watchers.c
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2019
+ * IoTech Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#include "watchers.h"
+#include "edgex-rest.h"
+
+typedef struct edgex_watchlist_t
+{
+  pthread_rwlock_t lock;
+  edgex_watcher *list;
+} edgex_watchlist_t;
+
+edgex_watchlist_t *edgex_watchlist_alloc ()
+{
+  edgex_watchlist_t *res = calloc (1, sizeof (edgex_watchlist_t));
+  pthread_rwlock_init (&res->lock, NULL);
+  return res;
+}
+
+void edgex_watchlist_free (edgex_watchlist_t *wl)
+{
+  if (wl)
+  {
+    pthread_rwlock_destroy (&wl->lock);
+    edgex_watcher_free (wl->list);
+    free (wl);
+  }
+}
+
+static edgex_watcher **find_locked (edgex_watcher **list, const char *id)
+{
+  while (*list && strcmp ((*list)->id, id))
+  {
+    list = &((*list)->next);
+  }
+  return list;
+}
+
+static void add_locked (edgex_watchlist_t *wl, const edgex_watcher *w)
+{
+  edgex_watcher *newelem = edgex_watcher_dup (w);
+  newelem->next = wl->list;
+  wl->list = newelem;
+}
+
+bool edgex_watchlist_remove_watcher (edgex_watchlist_t *wl, const char *id)
+{
+  bool result = false;
+  pthread_rwlock_wrlock (&wl->lock);
+
+  edgex_watcher **ptr = find_locked (&wl->list, id);
+  edgex_watcher *found = *ptr;
+  if (found)
+  {
+    *ptr = found->next;
+    found->next = NULL;
+    edgex_watcher_free (found);
+    result = true;
+  }
+
+  pthread_rwlock_unlock (&wl->lock);
+  return result;
+}
+
+void edgex_watchlist_update_watcher (edgex_watchlist_t *wl, const edgex_watcher *updated)
+{
+  pthread_rwlock_wrlock (&wl->lock);
+
+  edgex_watcher **ptr = find_locked (&wl->list, updated->id);
+  edgex_watcher *found = *ptr;
+  if (found)
+  {
+    *ptr = edgex_watcher_dup (updated);
+    (*ptr)->next = found->next;
+    found->next = NULL;
+    edgex_watcher_free (found);
+  }
+  else
+  {
+    add_locked (wl, updated);
+  }
+
+  pthread_rwlock_unlock (&wl->lock);
+}
+
+unsigned edgex_watchlist_populate (edgex_watchlist_t *wl, const edgex_watcher *newlist)
+{
+  unsigned count = 0;
+  pthread_rwlock_wrlock (&wl->lock);
+
+  for (const edgex_watcher *w = newlist; w; w = w->next)
+  {
+    if (*find_locked (&wl->list, w->id) == NULL)
+    {
+      count++;
+      add_locked (wl, w);
+    }
+  }
+
+  pthread_rwlock_unlock (&wl->lock);
+  return count;
+}
+
+/* Placeholder matching algorithm. Matches for literals only, no blacklist */
+
+static bool matchpw (const edgex_watcher *pw, const edgex_nvpairs *ids)
+{
+  const edgex_nvpairs *pair;
+  for (pair = pw->identifiers; pair; pair = pair->next)
+  {
+    const char *matching = edgex_nvpairs_value (ids, pair->name);
+    if (matching && strcmp (pair->value, matching))
+    {
+      break;
+    }
+  }
+  return pair;
+}
+
+const edgex_watcher *edgex_watchlist_match (const edgex_watchlist_t *wl, const edgex_nvpairs *ids)
+{
+  pthread_rwlock_rdlock ((pthread_rwlock_t *)&wl->lock);
+
+  edgex_watcher *result = NULL;
+  const edgex_watcher *w = wl->list;
+
+  while (w && !result)
+  {
+    if (matchpw (w, ids))
+    {
+      result = edgex_watcher_dup (w);
+      break;
+    }
+    w = w->next;
+  }
+
+  pthread_rwlock_unlock ((pthread_rwlock_t *)&wl->lock);
+  return result;
+}
+
+void edgex_watchlist_dump (const edgex_watchlist_t *wl, iot_logger_t *logger)
+{
+  pthread_rwlock_rdlock ((pthread_rwlock_t *)&wl->lock);
+
+  for (const edgex_watcher *w = wl->list; w; w = w->next)
+  {
+    iot_log_debug (logger, "PW: Id=%s Name=%s Profile=%s", w->id, w->name, w->profile);
+    for (const edgex_nvpairs *match = w->identifiers; match; match = match->next)
+    {
+      iot_log_debug (logger, "PW: Match %s = %s", match->name, match->value);
+    }
+    for (const edgex_blocklist *bl = w->blocking_identifiers; bl; bl = bl->next)
+    {
+      for (edgex_strings *s = bl->values; s; s = s->next)
+      {
+        iot_log_debug (logger, "PW: Block %s = %s", bl->name, s->str);
+      }
+    }
+  }
+
+  pthread_rwlock_unlock ((pthread_rwlock_t *)&wl->lock);
+}

--- a/src/c/watchers.h
+++ b/src/c/watchers.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2019
+ * IoTech Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#ifndef _EDGEX_DEVICE_WATCHERS_H_
+#define _EDGEX_DEVICE_WATCHERS_H_ 1
+
+/* Manages provision watchers for the SDK. */
+
+#include "edgex/edgex.h"
+#include "iot/logger.h"
+
+struct edgex_watchlist_t;
+typedef struct edgex_watchlist_t edgex_watchlist_t;
+
+extern edgex_watchlist_t *edgex_watchlist_alloc (void);
+extern void edgex_watchlist_free (edgex_watchlist_t *list);
+
+extern unsigned edgex_watchlist_populate (edgex_watchlist_t *list, const edgex_watcher *entry);
+extern bool edgex_watchlist_remove_watcher (edgex_watchlist_t *list, const char *id);
+extern void edgex_watchlist_update_watcher (edgex_watchlist_t *list, const edgex_watcher *updated);
+
+extern const edgex_watcher *edgex_watchlist_match (const edgex_watchlist_t *list, const edgex_nvpairs *ids);
+
+extern void edgex_watchlist_dump (const edgex_watchlist_t *list, iot_logger_t *logger);
+
+#endif


### PR DESCRIPTION
- Obtains PWs from core-metadata
- Updates PW list from core-metadata callbacks
- Includes outline of matching algorithm for use during discovery

Signed-off-by: Iain Anderson <iain@iotechsys.com>