### PR TITLE
Use NULL for default startup parameters. Avoids defaulting registry on.

### DIFF
--- a/src/c/examples/counters/device-counter.c
+++ b/src/c/examples/counters/device-counter.c
@@ -188,7 +188,7 @@ static void counter_stop (void *impl, bool force) {}
 
 int main (int argc, char *argv[])
 {
-  edgex_device_svcparams params = { "device-counter", "", "", "" };
+  edgex_device_svcparams params = { "device-counter", NULL, NULL, NULL };
   sigset_t set;
   int sigret;
 

--- a/src/c/examples/gyro/device-gyro.c
+++ b/src/c/examples/gyro/device-gyro.c
@@ -120,7 +120,7 @@ static void gyro_stop (void *impl, bool force)
 
 int main (int argc, char *argv[])
 {
-  edgex_device_svcparams params = { "device-gyro", "", "", "" };
+  edgex_device_svcparams params = { "device-gyro", NULL, NULL, NULL };
   sigset_t set;
   int sigret;
 

--- a/src/c/examples/random/device-random.c
+++ b/src/c/examples/random/device-random.c
@@ -140,7 +140,7 @@ static void random_stop (void *impl, bool force) {}
 
 int main (int argc, char *argv[])
 {
-  edgex_device_svcparams params = { "device-random", "", "", "" };
+  edgex_device_svcparams params = { "device-random", NULL, NULL, NULL };
   sigset_t set;
   int sigret;
 

--- a/src/c/examples/template.c
+++ b/src/c/examples/template.c
@@ -172,7 +172,7 @@ static void template_stop (void *impl, bool force) {}
 
 int main (int argc, char *argv[])
 {
-  edgex_device_svcparams params = { "device-template", "", "", "" };
+  edgex_device_svcparams params = { "device-template", NULL, NULL, NULL };
   sigset_t set;
   int sigret;
 

--- a/src/c/examples/terminal/device-terminal.c
+++ b/src/c/examples/terminal/device-terminal.c
@@ -178,7 +178,7 @@ static void terminal_stop (void *impl, bool force)
 
 int main (int argc, char *argv[])
 {
-  edgex_device_svcparams params = { "device-terminal", "", "", "" };
+  edgex_device_svcparams params = { "device-terminal", NULL, NULL, NULL };
   sigset_t set;
   int sigret;
 


### PR DESCRIPTION
Signed-off-by: Iain Anderson <iain@iotechsys.com>