### PR TITLE
Bring configuration behaviour into line with go-mod-bootstrap

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,7 @@ differs as follows:
 
 Changes for 1.2.0 "Geneva":
 
+- Commandline and environment options aligned with Go microservices.
 - Arrays of primitive types supported in Readings.
 - Device Readings are populated with datatype information.
 - Full dynamic discovery implementation with Provision Watchers.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,12 +1,14 @@
 # Device service configuration options
 
-The device service configuration is held in TOML format. By default the SDK will load configuration from a file named `configuration.toml` in the `res` directory, but this may be changed using the --confdir and --profile options.
+The device service configuration is held in TOML format. By default the SDK will load configuration from a file named `configuration.toml` in the `res` directory, but this may be changed using the --confdir, --file and --profile options.
 
 Configuration parameters are organized within a number of sections. A section is represented by a TOML table, eg `[Service]`.
 
 If the Registry is in use, configuration is contained in subfolders of `edgex/core/1.0/<service-name>`. The "Clients" section is not present in this scenario, as the Registry provides a specific mechanism for maintaining service information.
 
-When a device service is run for the first time with Registry enabled, it reads its configuration from a TOML file and uploads it to the Registry. The value of any configuration element can be over-ridden at this time with a value from a corresponding environment variable. The service first looks for an environment variable whose name is of the form
+When a device service is run for the first time with Registry enabled, it reads its configuration from a TOML file and uploads it to the Registry.
+
+The value of any configuration element can be over-ridden with a value from a corresponding environment variable. The service first looks for an environment variable whose name is of the form
 
 `<service-name>_<section-name>_<config-element>`
 
@@ -79,4 +81,3 @@ LogLevel | String | Sets the logging level. Available settings in order of incre
 ## Driver section
 
 This section is for driver-specific options. Any configuration specified here will be passed to the driver implementation during initialization.
-

--- a/docs/startup.md
+++ b/docs/startup.md
@@ -1,41 +1,52 @@
 # Device service startup parameters
 
-Certain aspects of a device service's operation are controlled by command-line options and environment variable settings. These are not stored with the service configuration as they may be required before the configuration is read - in particular, they may be required in order to locate the configuration.
+Certain aspects of a device service's operation are controlled by command-line options and environment variable settings. These are not stored with the service configuration as they may be required before the configuration is read - in particular, they may be required in order to locate the configuration. Each commandline option may be overridden by an environment variable.
 
 ## Registry
 
-If the Registry is to be used, its location may be specified as a URL. The `scheme` part of the URL indicates the registry implementation to use. Currently the only supported implentation in the SDK is `consul`, but other implementations may be added via the APIs presented in `edgex/registry.h`. For Consul, the URL takes the form `consul://hostname:port`.
+If configuration is to be obtained from the Registry, its location may be specified as a URL. The `scheme` part of the URL indicates the registry implementation to use. Currently the only supported implentation in the SDK is `consul.http`, but other implementations may be added via the APIs presented in `edgex/registry.h`. For Consul, the URL takes the form `consul.http://hostname:port`.
 
-|Environment variable||
-|-|-|
-`edgex_registry` | specifies the registry URL
-`edgex_registry_retry_count` | sets the number of attempts to connect to the registry before abandoning startup
-`edgex_registry_retry_wait` | sets the interval (in seconds) between attempts to connect to the registry
-
-|Long option | short option||
-|-|-|-|
-`--registry` | `-r` | specifies the registry URL. Overrides the environment setting
+|Long option | Short option|Environment ||
+|-|-|-|-|
+`--configProvider` | `-cp` | `EDGEX_REGISTRY` | specifies the registry URL.
 
 ## Service name
 
 Typically a device service will have a default service name, eg device-modbus or device-virtual. However when an EdgeX deployment contains multiple instances of a particular device service, they must be assigned different names. This can be done on the command line:
 
-|Long option | short option||
-|-|-|-|
-`--name` | `-n` | specifies the device service name
+|Long option | Short option|Environment ||
+|-|-|-|-|
+`--name` | `-n` | `EDGEX_SERVICE_NAME` | specifies the device service name
 
 ## Profile
 
 A service has a default configuration profile, but other profiles may be selected using this option. In file-based configuration, additional profiles may be defined in files named `configuration-<profilename>.toml`. In Consul, they are stored in KV-store folders named `<servicename>;<profilename>`.
 
-|Long option | short option||
-|-|-|-|
-`--profile` | `-p` | specifies the configuration profile
+|Long option | Short option|Environment ||
+|-|-|-|-|
+`--profile` | `-p` | `EDGEX_PROFILE` | specifies the configuration profile
 
 ## Configuration directory
 
 For file-based configuration, this is the directory containing TOML files. The default value is `res` (note that this is a relative path).
 
-|Long option | short option||
-|-|-|-|
-`--confdir` | `-c` | specifies the configuration directory
+|Long option | Short option|Environment ||
+|-|-|-|-|
+`--confdir` | `-c` | `EDGEX_CONF_DIR` | specifies the configuration directory
+
+## Configuration file
+
+For file-based configuration, this is the filename of the TOML configuration file. If this option is used, the `--profile` option will be ineffective.
+
+|Long option | Short option|Environment ||
+|-|-|-|-|
+`--file` | `-f` | `EDGEX_CONFIG_FILE` | specifies the configuration filename
+
+## Timeouts
+
+Two additional environment variables control the retry behavior when contacting the registry at startup:
+
+|Environment variable||
+|-|-|
+`EDGEX_STARTUP_DURATION` | sets the amount of time (in seconds) in which to attempt to connect to the registry before abandoning startup
+`EDGEX_STARTUP_INTERVAL` | sets the interval (in seconds) between attempts to connect to the registry

--- a/src/c/config.h
+++ b/src/c/config.h
@@ -84,6 +84,7 @@ toml_table_t *edgex_device_loadConfig
 (
   iot_logger_t *lc,
   const char *dir,
+  const char *fname,
   const char *profile,
   devsdk_error *err
 );

--- a/src/c/examples/v2/counters/device-counter.c
+++ b/src/c/examples/v2/counters/device-counter.c
@@ -177,7 +177,7 @@ int main (int argc, char *argv[])
     if (strcmp (argv[n], "-h") == 0 || strcmp (argv[n], "--help") == 0)
     {
       printf ("Options:\n");
-      printf ("  -h, --help\t\t: Show this text\n");
+      printf ("  -h, --help\t\t\tShow this text\n");
       return 0;
     }
     else

--- a/src/c/examples/v2/gyro/device-gyro.c
+++ b/src/c/examples/v2/gyro/device-gyro.c
@@ -132,7 +132,7 @@ int main (int argc, char * argv[])
     if (strcmp (argv[n], "-h") == 0 || strcmp (argv[n], "--help") == 0)
     {
       printf ("Options:\n");
-      printf ("  -h, --help\t\t: Show this text\n");
+      printf ("  -h, --help\t\t\tShow this text\n");
       return 0;
     }
     else

--- a/src/c/examples/v2/random/device-random.c
+++ b/src/c/examples/v2/random/device-random.c
@@ -156,7 +156,7 @@ int main (int argc, char *argv[])
     if (strcmp (argv[n], "-h") == 0 || strcmp (argv[n], "--help") == 0)
     {
       printf ("Options:\n");
-      printf ("  -h, --help\t\t: Show this text\n");
+      printf ("  -h, --help\t\t\tShow this text\n");
       return 0;
     }
     else

--- a/src/c/examples/v2/template.c
+++ b/src/c/examples/v2/template.c
@@ -202,7 +202,7 @@ int main (int argc, char *argv[])
     if (strcmp (argv[n], "-h") == 0 || strcmp (argv[n], "--help") == 0)
     {
       printf ("Options:\n");
-      printf ("  -h, --help\t\t: Show this text\n");
+      printf ("  -h, --help\t\t\tShow this text\n");
       devsdk_usage ();
       return 0;
     }

--- a/src/c/examples/v2/terminal/device-terminal.c
+++ b/src/c/examples/v2/terminal/device-terminal.c
@@ -207,7 +207,7 @@ int main (int argc, char * argv[])
     if (strcmp (argv[n], "-h") == 0 || strcmp (argv[n], "--help") == 0)
     {
       printf ("Options:\n");
-      printf ("  -h, --help\t\t: Show this text\n");
+      printf ("  -h, --help\t\t\tShow this text\n");
       return 0;
     }
     else

--- a/src/c/registry.c
+++ b/src/c/registry.c
@@ -40,6 +40,7 @@ static void reginit (void)
     regmap = malloc (sizeof (devsdk_map_registry));
     edgex_map_init (regmap);
     edgex_map_set (regmap, "consul", consulimpl);
+    edgex_map_set (regmap, "consul.http", consulimpl);
   }
   pthread_mutex_unlock (&reglock);
 }

--- a/src/c/service.h
+++ b/src/c/service.h
@@ -26,6 +26,7 @@ struct devsdk_service_t
   const char *regURL;
   const char *profile;
   const char *confdir;
+  const char *conffile;
   void *userdata;
   devsdk_callbacks userfns;
   iot_logger_t *logger;


### PR DESCRIPTION
* Add new environment variables (maintain old ones for v1 compat)
* Env vars now override cmdline
* Env vars can override config elements at any time
* Add new --configProvider and --file options
* Use consul.http to identify the consul registry implementation

Signed-off-by: Iain Anderson <iain@iotechsys.com>