### PR TITLE
fix: wrong map size for CBOR readings

### DIFF
--- a/src/c/data.c
+++ b/src/c/data.c
@@ -200,8 +200,17 @@ edgex_event_cooked *edgex_data_process_event
     for (uint32_t i = 0; i < commandinfo->nreqs; i++)
     {
       cbor_item_t *cread;
-      cbor_item_t *crdg = cbor_new_definite_map (3);
+      cbor_item_t *crdg;
+
       edgex_propertytype pt = edgex_propertytype_data (values[i].value);
+      if (pt == Edgex_Binary || pt == Edgex_Float32 || pt == Edgex_Float64 || pt == Edgex_Float32Array || pt == Edgex_Float64Array)
+      {
+        crdg = cbor_new_definite_map (5);
+      }
+      else
+      {
+        crdg = cbor_new_definite_map (4);
+      }
 
       if (pt == Edgex_Binary)
       {

--- a/src/c/edgex-rest.c
+++ b/src/c/edgex-rest.c
@@ -21,10 +21,15 @@
 
 static const char *rwstrings[2][2] = { { "", "W" }, { "R", "RW" } };
 
-static char *get_string (const JSON_Object *obj, const char *name)
+static char *get_string_dfl (const JSON_Object *obj, const char *name, const char *dfl)
 {
   const char *str = json_object_get_string (obj, name);
-  return strdup (str ? str : "");
+  return strdup (str ? str : dfl);
+}
+
+static char *get_string (const JSON_Object *obj, const char *name)
+{
+  return get_string_dfl (obj, name, "");
 }
 
 static char *get_array_string (const JSON_Array *array, size_t index)
@@ -324,7 +329,7 @@ static edgex_propertyvalue *propertyvalue_read
 #else
     result->floatAsBinary = !(fe && (strcmp (fe, "eNotation") == 0));
 #endif
-    result->mediaType = get_string (obj, "mediaType");
+    result->mediaType = get_string_dfl (obj, "mediaType", (pt == Edgex_Binary) ? "application/octet-stream" : "");
   }
   else
   {


### PR DESCRIPTION


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Binary Readings are sent incomplete to core-data due to truncation of the map representing them


## What is the new behavior?
Binary Readings encoded correctly

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information