### PR TITLE
refac: reorder shutdown sequence (#284) 

### DIFF
--- a/src/c/metadata.c
+++ b/src/c/metadata.c
@@ -317,6 +317,7 @@ edgex_device *edgex_metadata_client_get_devices
   curl_free (ename);
   if (err->code)
   {
+    free (ctx.buff);
     return 0;
   }
 
@@ -421,6 +422,7 @@ edgex_device *edgex_metadata_client_get_device
 
   if (err->code)
   {
+    free (ctx.buff);
     return 0;
   }
 
@@ -561,6 +563,7 @@ edgex_watcher *edgex_metadata_client_get_watchers
   curl_free (ename);
   if (err->code)
   {
+    free (ctx.buff);
     return 0;
   }
 
@@ -597,6 +600,7 @@ edgex_watcher *edgex_metadata_client_get_watcher
 
   if (err->code)
   {
+    free (ctx.buff);
     return 0;
   }
 

--- a/src/c/service.c
+++ b/src/c/service.c
@@ -821,7 +821,6 @@ void devsdk_service_stop (devsdk_service_t *svc, bool force, devsdk_error *err)
   {
     edgex_rest_server_destroy (svc->daemon);
   }
-  svc->userfns.stop (svc->userdata, force);
   if (svc->registry)
   {
     devsdk_registry_deregister_service (svc->registry, svc->name, err);
@@ -832,8 +831,8 @@ void devsdk_service_stop (devsdk_service_t *svc, bool force, devsdk_error *err)
   }
   iot_threadpool_wait (svc->eventq);
   iot_threadpool_wait (svc->thpool);
+  svc->userfns.stop (svc->userdata, force);
   edgex_devmap_clear (svc->devices);
-  iot_scheduler_free (svc->scheduler);
   iot_log_info (svc->logger, "Stopped device service");
 }
 
@@ -841,6 +840,7 @@ void devsdk_service_free (devsdk_service_t *svc)
 {
   if (svc)
   {
+    iot_scheduler_free (svc->scheduler);
     edgex_devmap_free (svc->devices);
     edgex_watchlist_free (svc->watchlist);
     iot_threadpool_free (svc->thpool);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Potential for driver's "stop" function to be called while service still active
Issue Number: #284 


## What is the new behavior?
Stop call moved to later in the shutdown process so that system is quiescent

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information