### PR TITLE
fix: align default behavior for listening interface with other services

### DIFF
--- a/src/c/config.c
+++ b/src/c/config.c
@@ -43,7 +43,7 @@ iot_data_t *edgex_config_defaults (const char *dflprofiledir, const iot_data_t *
   iot_data_string_map_add (result, "Service/StartupMsg", iot_data_alloc_string ("", IOT_DATA_REF));
   iot_data_string_map_add (result, "Service/CheckInterval", iot_data_alloc_string ("", IOT_DATA_REF));
   iot_data_string_map_add (result, "Service/Labels", iot_data_alloc_string ("", IOT_DATA_REF));
-  iot_data_string_map_add (result, "Service/ServerBindAddr", iot_data_alloc_string ("0.0.0.0", IOT_DATA_REF));
+  iot_data_string_map_add (result, "Service/ServerBindAddr", iot_data_alloc_string ("", IOT_DATA_REF));
 
   iot_data_string_map_add (result, "Device/DataTransform", iot_data_alloc_bool (true));
   iot_data_string_map_add (result, "Device/Discovery/Enabled", iot_data_alloc_bool (true));

--- a/src/c/data.c
+++ b/src/c/data.c
@@ -150,6 +150,28 @@ static char *edgex_value_tostring (const iot_data_t *value, bool binfloat)
   return res;
 }
 
+/* Event data structure:
+
+Reading:
+  id: String (filled in by core-data)
+  created, modified, pushed: Timestamps (filled in by core-data)
+  name: String (name of the DeviceResource)
+  origin: Timestamp (filled in by the implementation or the SDK)
+  valueType: String
+  value: String
+  binaryValue: String (one of value or binaryValue is used)
+  mediaType: String (only if binaryValue)
+  floatEncoding: String (only for float types)
+
+Event:
+  id: String (filled in by core-data)
+  created, modified, pushed: Timestamps (filled in by core-data)
+  device: String (name of the Device)
+  origin: Timestamp (filled in by the SDK)
+  tags: Array of Strings (may be added to at any stage)
+  readings: Array of Readings
+*/
+
 edgex_event_cooked *edgex_data_process_event
 (
   const char *device_name,

--- a/src/c/data.h
+++ b/src/c/data.h
@@ -14,31 +14,6 @@
 #include "cmdinfo.h"
 #include "rest-server.h"
 
-typedef struct edgex_reading
-{
-  uint64_t created;
-  char *id;
-  uint64_t modified;
-  const char *name;
-  uint64_t origin;
-  uint64_t pushed;
-  devsdk_commandresult value;
-  bool binfloat;
-  struct edgex_reading *next;
-} edgex_reading;
-
-typedef struct edgex_event
-{
-  uint64_t created;
-  const char *device;
-  char *id;
-  uint64_t modified;
-  uint64_t origin;
-  uint64_t pushed;
-  edgex_reading *readings;
-  struct edgex_event *next;
-} edgex_event;
-
 typedef enum { JSON, CBOR} edgex_event_encoding;
 
 typedef struct edgex_event_cooked

--- a/src/c/rest-server.c
+++ b/src/c/rest-server.c
@@ -317,7 +317,7 @@ edgex_rest_server *edgex_rest_server_create
 
   /* Start http server */
 
-  if (strlen (bindaddr) && strcmp (bindaddr, "0.0.0.0"))
+  if (strcmp (bindaddr, "0.0.0.0"))
   {
     struct addrinfo *res;
     char svc[6];

--- a/src/c/service.c
+++ b/src/c/service.c
@@ -463,7 +463,8 @@ static void startConfigured (devsdk_service_t *svc, toml_table_t *config, devsdk
 
   /* Start REST server now so that we get the callbacks on device addition */
 
-  svc->daemon = edgex_rest_server_create (svc->logger, svc->config.service.bindaddr, svc->config.service.port, err);
+  const char *bindaddr = strlen (svc->config.service.bindaddr) ? svc->config.service.bindaddr : svc->config.service.host;
+  svc->daemon = edgex_rest_server_create (svc->logger, bindaddr, svc->config.service.port, err);
   if (err->code)
   {
     return;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
By default, service listens on all interfaces
Issue Number: #278 


## What is the new behavior?
Default for Hanoi is to listen on a single interface

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information