### PR TITLE
Issue 295

### DIFF
--- a/include/devsdk/devsdk.h
+++ b/include/devsdk/devsdk.h
@@ -254,6 +254,16 @@ devsdk_devices *devsdk_get_device (devsdk_service_t *svc, const char *name);
 
 void devsdk_free_devices (devsdk_devices *d);
 
+/**
+ * @brief Set the operational state of a device
+ * @param svc The device service.
+ * @param devname The device name.
+ * @param operational true if the device is operational (enabled)
+ * @param err Nonzero reason codes will be set here in the event of errors.
+ */
+
+void devsdk_set_device_opstate (devsdk_service_t *svc, char *devname, bool operational, devsdk_error *err);
+
 
 /**
  * @brief Stop the event service. Any automatic events will be cancelled and the rest api for the device service will be shut down.

--- a/include/edgex/devices.h
+++ b/include/edgex/devices.h
@@ -115,16 +115,6 @@ edgex_device * edgex_get_device (devsdk_service_t *svc, const char *id);
 edgex_device * edgex_get_device_byname (devsdk_service_t *svc, const char *name);
 
 /**
- * @brief Set the operational state of a device
- * @param svc The device service.
- * @param devname The device name.
- * @param operational true if the device is operational (enabled)
- * @param err Nonzero reason codes will be set here in the event of errors.
- */
-
-void edgex_set_device_opstate (devsdk_service_t *svc, char *devname, bool operational, devsdk_error *err);
-
-/**
  * @brief Free a device structure or list of device structures.
  * @param d The device or the first device in the list.
  */

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,7 +5,7 @@ CPPCHECK=false
 DOCGEN=false
 
 TOMLVER=SDK-0.2
-CUTILVER=1.1-branch
+CUTILVER=1.1.1
 
 # Process arguments
 

--- a/src/c/device.c
+++ b/src/c/device.c
@@ -350,7 +350,21 @@ static iot_data_t *populateValue (edgex_propertytype rtype, const char *val)
       bool *arr = malloc (jsz * sizeof (bool));
       for (size_t i = 0; i < jsz; i++)
       {
-        arr[i] = (strcasecmp (json_array_get_string (jarr, i), "true") == 0);
+        const char *bval = json_array_get_string (jarr, i);
+        if (strcasecmp (bval, "true") == 0)
+        {
+          arr[i] = true;
+        }
+        else if (strcasecmp (bval, "false") == 0)
+        {
+          arr[i] = false;
+        }
+        else
+        {
+          free (arr);
+          json_value_free (jval);
+          return NULL;
+        }
       }
       json_value_free (jval);
       return iot_data_alloc_array (arr, jsz, IOT_DATA_BOOL, IOT_DATA_TAKE);

--- a/src/c/devman.c
+++ b/src/c/devman.c
@@ -229,7 +229,7 @@ void devsdk_add_discovered_devices (devsdk_service_t *svc, uint32_t ndevices, de
   }
 }
 
-void edgex_set_device_opstate (devsdk_service_t *svc, char *devname, bool operational, devsdk_error *err)
+void devsdk_set_device_opstate (devsdk_service_t *svc, char *devname, bool operational, devsdk_error *err)
 {
   *err = EDGEX_OK;
   edgex_metadata_client_set_device_opstate_byname

--- a/src/c/examples/discovery/template.c
+++ b/src/c/examples/discovery/template.c
@@ -244,10 +244,6 @@ int main (int argc, char *argv[])
     template_stop          /* Stop */
   };
 
-  iot_data_t *confparams = iot_data_alloc_map (IOT_DATA_STRING);
-  iot_data_string_map_add (confparams, "TestParam1", iot_data_alloc_string ("X", IOT_DATA_REF));
-  iot_data_string_map_add (confparams, "TestParam2", iot_data_alloc_string ("Y", IOT_DATA_REF));
-
   /* Initalise a new device service */
   devsdk_service_t *service = devsdk_service_new
     ("device-template", "1.0", impl, templateImpls, &argc, argv, &e);
@@ -271,6 +267,9 @@ int main (int argc, char *argv[])
   }
 
   impl->svc = service;
+  iot_data_t *confparams = iot_data_alloc_map (IOT_DATA_STRING);
+  iot_data_string_map_add (confparams, "TestParam1", iot_data_alloc_string ("X", IOT_DATA_REF));
+  iot_data_string_map_add (confparams, "TestParam2", iot_data_alloc_string ("Y", IOT_DATA_REF));
 
   /* Start the device service*/
   devsdk_service_start (service, confparams, &e);

--- a/src/c/examples/template.c
+++ b/src/c/examples/template.c
@@ -212,10 +212,6 @@ int main (int argc, char *argv[])
     template_stop          /* Stop */
   };
 
-  iot_data_t *confparams = iot_data_alloc_map (IOT_DATA_STRING);
-  iot_data_string_map_add (confparams, "TestParam1", iot_data_alloc_string ("X", IOT_DATA_REF));
-  iot_data_string_map_add (confparams, "TestParam2", iot_data_alloc_string ("Y", IOT_DATA_REF));
-
   /* Initalise a new device service */
   devsdk_service_t *service = devsdk_service_new
     ("device-template", "1.0", impl, templateImpls, &argc, argv, &e);
@@ -237,6 +233,11 @@ int main (int argc, char *argv[])
       return 0;
     }
   }
+
+  /* Set default config */
+  iot_data_t *confparams = iot_data_alloc_map (IOT_DATA_STRING);
+  iot_data_string_map_add (confparams, "TestParam1", iot_data_alloc_string ("X", IOT_DATA_REF));
+  iot_data_string_map_add (confparams, "TestParam2", iot_data_alloc_string ("Y", IOT_DATA_REF));
 
   /* Start the device service*/
   devsdk_service_start (service, confparams, &e);

--- a/src/c/metadata.c
+++ b/src/c/metadata.c
@@ -116,15 +116,19 @@ void edgex_metadata_client_set_device_opstate_byname
 )
 {
   edgex_ctx ctx;
+  char *ename;
   char url[URL_BUF_SIZE];
   char data[sizeof ("{*operatingstate*:*disabled*}")];
 
   memset (&ctx, 0, sizeof (edgex_ctx));
-  snprintf (url, URL_BUF_SIZE - 1, "http://%s:%u/api/v1/device/name/%s", endpoints->metadata.host, endpoints->metadata.port, devicename);
+  ename = curl_easy_escape (NULL, devicename, 0);
+
+  snprintf (url, URL_BUF_SIZE - 1, "http://%s:%u/api/v1/device/name/%s", endpoints->metadata.host, endpoints->metadata.port, ename);
   sprintf (data, "{\"operatingstate\":\"%s\"}", (opstate == ENABLED) ? "enabled" : "disabled");
 
   edgex_http_put (lc, &ctx, url, data, edgex_http_write_cb, err);
   free (ctx.buff);
+  curl_free (ename);
 }
 
 void edgex_metadata_client_set_device_adminstate

--- a/src/c/service.c
+++ b/src/c/service.c
@@ -231,6 +231,7 @@ devsdk_service_t *devsdk_service_new
     return NULL;
   }
 
+  iot_init ();
   if (result->name)
   {
     const char *n = result->name;
@@ -622,7 +623,6 @@ void devsdk_service_start (devsdk_service_t *svc, iot_data_t *driverdfls, devsdk
 
   *err = EDGEX_OK;
   svc->starttime = iot_time_msecs();
-  iot_init ();
   iot_threadpool_start (svc->thpool);
 
   configmap = edgex_config_defaults (svc->confdir, driverdfls);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

* Issue Number: #295 SDK does not build
* When writing BoolArray values the incoming data is not validated
* opstate setting fails when a Device name contains spaces
* setting up the default config may deadlock

## What is the new behavior?
SDK uses a fixed version of the c-utils dependency
c-utils are initialized in service_new() so that the iot_data_t functions may be used before service_start()
BoolArrays are validated
Device names URL-encoded


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

v2 API only - opstate setting function renamed
## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information