### PR TITLE
fix: remove stale profiles when devices are removed

### DIFF
--- a/include/edgex/edgex.h
+++ b/include/edgex/edgex.h
@@ -188,6 +188,7 @@ typedef struct edgex_device
   edgex_deviceprofile *profile;
   struct edgex_device *next;
   atomic_uint_fast32_t refs;
+  bool ownprofile;
 } edgex_device;
 
 #endif


### PR DESCRIPTION
Signed-off-by: Iain Anderson <iain@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
The SDK holds device profiles in its cache indefinitely. This can lead to it being out of sync with core-metadata if profiles are updated.

## What is the new behavior?
A profile is purged from the cache when the last device using it is deleted. A fresh copy of the profile will be retrieved on-demand should a newly-created device require it.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information