### PR TITLE
fix: update v2 REST API with recent changes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ This is the C SDK for EdgeX. Its API is based largely on the Go SDK.
 
 Changes for 2.0.0 "Ireland":
 
+- Add queryparams for PUT operations (Changes signature of put handler function)
 - Add MaxRequestSize configuration for limiting inbound http data transfers
 - EdgeX resource type names are now CamelCase as per Go services
 - Configuration elements which may be updated without restarting the service are found in the "Writable" section of the configuration. The following elements are moved:

--- a/include/devsdk/devsdk.h
+++ b/include/devsdk/devsdk.h
@@ -88,6 +88,7 @@ typedef bool (*devsdk_handle_get)
  * @param nvalues The number of set operations requested.
  * @param requests An array specifying the resources to which to write.
  * @param values An array specifying the values to be written.
+ * @param qparams Query Parameters which were set for this request.
  * @param exception Set this to an IOT_DATA_STRING to give more information if the operation fails.
  * @return true if the operation was successful, false otherwise.
  */
@@ -100,6 +101,7 @@ typedef bool (*devsdk_handle_put)
   uint32_t nvalues,
   const devsdk_commandrequest *requests,
   const iot_data_t *values[],
+  const devsdk_nvpairs *qparams,
   iot_data_t **exception
 );
 

--- a/src/c/api.h
+++ b/src/c/api.h
@@ -25,22 +25,21 @@
 #define EDGEX_DEV_API2_DISCOVERY "/api/v2/discovery"
 #define EDGEX_DEV_API2_CONFIG "/api/v2/config"
 #define EDGEX_DEV_API2_METRICS "/api/v2/metrics"
-#define EDGEX_DEV_API2_DEVICE "/api/v2/device/{id}/{cmd}"
 #define EDGEX_DEV_API2_DEVICE_NAME "/api/v2/device/name/{name}/{cmd}"
 #define EDGEX_DEV_API2_CALLBACK_DEVICE "/api/v2/callback/device"
-#define EDGEX_DEV_API2_CALLBACK_DEVICE_ID "/api/v2/callback/device/id/{id}"
+#define EDGEX_DEV_API2_CALLBACK_DEVICE_NAME "/api/v2/callback/device/name/{name}"
 #define EDGEX_DEV_API2_CALLBACK_PROFILE "/api/v2/callback/profile"
-#define EDGEX_DEV_API2_CALLBACK_PROFILE_ID "/api/v2/callback/profile/id/{id}"
 #define EDGEX_DEV_API2_CALLBACK_WATCHER "/api/v2/callback/watcher"
-#define EDGEX_DEV_API2_CALLBACK_WATCHER_ID "/api/v2/callback/watcher/id/{id}"
+#define EDGEX_DEV_API2_CALLBACK_WATCHER_NAME "/api/v2/callback/watcher/name/{name}"
+#define EDGEX_DEV_API2_CALLBACK_SERVICE "/api/v2/callback/service"
 
 /* Query parameters */
 
 #define DS_PREFIX "ds-"
 
-#define DS_POST "ds-postevent"
+#define DS_PUSH "ds-pushevent"
 #define DS_RETURN "ds-returnevent"
 
-#define DS_PARAMLIST { DS_POST, DS_RETURN }
+#define DS_PARAMLIST { DS_PUSH, DS_RETURN }
 
 #endif

--- a/src/c/callback2.h
+++ b/src/c/callback2.h
@@ -12,12 +12,13 @@
 #include "rest-server.h"
 
 extern void edgex_device_handler_callback_device (void *ctx, const devsdk_http_request *req, devsdk_http_reply *reply);
-extern void edgex_device_handler_callback_device_id (void *ctx, const devsdk_http_request *req, devsdk_http_reply *reply);
+extern void edgex_device_handler_callback_device_name (void *ctx, const devsdk_http_request *req, devsdk_http_reply *reply);
 
 extern void edgex_device_handler_callback_profile (void *ctx, const devsdk_http_request *req, devsdk_http_reply *reply);
-extern void edgex_device_handler_callback_profile_id (void *ctx, const devsdk_http_request *req, devsdk_http_reply *reply);
 
 extern void edgex_device_handler_callback_watcher (void *ctx, const devsdk_http_request *req, devsdk_http_reply *reply);
-extern void edgex_device_handler_callback_watcher_id (void *ctx, const devsdk_http_request *req, devsdk_http_reply *reply);
+extern void edgex_device_handler_callback_watcher_name (void *ctx, const devsdk_http_request *req, devsdk_http_reply *reply);
+
+extern void edgex_device_handler_callback_service (void *ctx, const devsdk_http_request *req, devsdk_http_reply *reply);
 
 #endif

--- a/src/c/devmap.c
+++ b/src/c/devmap.c
@@ -338,7 +338,7 @@ edgex_device *edgex_devmap_device_byname (edgex_devmap_t *map, const char *name)
   return result;
 }
 
-void edgex_devmap_removedevice_byname (edgex_devmap_t *map, const char *name)
+bool edgex_devmap_removedevice_byname (edgex_devmap_t *map, const char *name)
 {
   edgex_device **olddev;
   char **id;
@@ -351,6 +351,7 @@ void edgex_devmap_removedevice_byname (edgex_devmap_t *map, const char *name)
     remove_locked (map, *olddev);
   }
   pthread_rwlock_unlock (&map->lock);
+  return id;
 }
 
 bool edgex_devmap_removedevice_byid (edgex_devmap_t *map, const char *id)

--- a/src/c/devmap.c
+++ b/src/c/devmap.c
@@ -351,7 +351,7 @@ bool edgex_devmap_removedevice_byname (edgex_devmap_t *map, const char *name)
     remove_locked (map, *olddev);
   }
   pthread_rwlock_unlock (&map->lock);
-  return id;
+  return (id != NULL);
 }
 
 bool edgex_devmap_removedevice_byid (edgex_devmap_t *map, const char *id)
@@ -364,7 +364,7 @@ bool edgex_devmap_removedevice_byid (edgex_devmap_t *map, const char *id)
     remove_locked (map, *olddev);
   }
   pthread_rwlock_unlock (&map->lock);
-  return olddev;
+  return (olddev != NULL);
 }
 
 void edgex_devmap_add_profile (edgex_devmap_t *map, edgex_deviceprofile *dp)

--- a/src/c/devmap.h
+++ b/src/c/devmap.h
@@ -89,7 +89,7 @@ extern void edgex_device_release (edgex_device *dev);
 
 extern bool edgex_devmap_removedevice_byid
   (edgex_devmap_t *map, const char *id);
-extern void edgex_devmap_removedevice_byname
+extern bool edgex_devmap_removedevice_byname
   (edgex_devmap_t *map, const char *name);
 
 /*

--- a/src/c/examples/bitfields/device-bitfields.c
+++ b/src/c/examples/bitfields/device-bitfields.c
@@ -61,6 +61,7 @@ static bool bitfield_put_handler
   uint32_t nvalues,
   const devsdk_commandrequest * requests,
   const iot_data_t * values[],
+  const devsdk_nvpairs *qparams,
   iot_data_t ** exception
 )
 {

--- a/src/c/examples/counters/device-counter.c
+++ b/src/c/examples/counters/device-counter.c
@@ -129,6 +129,7 @@ static bool counter_put_handler
   uint32_t nvalues,
   const devsdk_commandrequest *requests,
   const iot_data_t *values[],
+  const devsdk_nvpairs *qparams,
   iot_data_t **exception
 )
 {

--- a/src/c/examples/discovery/template.c
+++ b/src/c/examples/discovery/template.c
@@ -185,6 +185,7 @@ static bool template_put_handler
   uint32_t nvalues,
   const devsdk_commandrequest *requests,
   const iot_data_t *values[],
+  const devsdk_nvpairs *qparams,
   iot_data_t **exception
 )
 {

--- a/src/c/examples/file/device-file.c
+++ b/src/c/examples/file/device-file.c
@@ -86,6 +86,7 @@ static bool file_put_handler
   uint32_t nvalues,
   const devsdk_commandrequest *requests,
   const iot_data_t *values[],
+  const devsdk_nvpairs *qparams,
   iot_data_t **exception
 )
 {

--- a/src/c/examples/gyro/device-gyro.c
+++ b/src/c/examples/gyro/device-gyro.c
@@ -87,6 +87,7 @@ static bool gyro_put_handler
   uint32_t nvalues,
   const devsdk_commandrequest * requests,
   const iot_data_t * values[],
+  const devsdk_nvpairs *qparams,
   iot_data_t ** exception
 )
 {

--- a/src/c/examples/random/device-random.c
+++ b/src/c/examples/random/device-random.c
@@ -112,6 +112,7 @@ static bool random_put_handler
   uint32_t nvalues,
   const devsdk_commandrequest *requests,
   const iot_data_t *values[],
+  const devsdk_nvpairs *qparams,
   iot_data_t **exception
 )
 {

--- a/src/c/examples/template.c
+++ b/src/c/examples/template.c
@@ -159,6 +159,7 @@ static bool template_put_handler
   uint32_t nvalues,
   const devsdk_commandrequest *requests,
   const iot_data_t *values[],
+  const devsdk_nvpairs *qparams,
   iot_data_t **exception
 )
 {

--- a/src/c/examples/terminal/device-terminal.c
+++ b/src/c/examples/terminal/device-terminal.c
@@ -122,6 +122,7 @@ static bool terminal_put_handler
   uint32_t nvalues,
   const devsdk_commandrequest * requests,
   const iot_data_t * values[],
+  const devsdk_nvpairs *qparams,
   iot_data_t ** exception
 )
 {

--- a/src/c/service.c
+++ b/src/c/service.c
@@ -501,15 +501,15 @@ static void startConfigured (devsdk_service_t *svc, toml_table_t *config, devsdk
 
   /* Register REST handlers */
 
-  edgex_rest_server_register_handler (svc->daemon, EDGEX_DEV_API2_CALLBACK_DEVICE_ID, DevSDK_Delete, svc, edgex_device_handler_callback_device_id);
+  edgex_rest_server_register_handler (svc->daemon, EDGEX_DEV_API2_CALLBACK_DEVICE_NAME, DevSDK_Delete, svc, edgex_device_handler_callback_device_name);
 
   edgex_rest_server_register_handler (svc->daemon, EDGEX_DEV_API2_CALLBACK_PROFILE, DevSDK_Put | DevSDK_Post, svc, edgex_device_handler_callback_profile);
 
-  edgex_rest_server_register_handler (svc->daemon, EDGEX_DEV_API2_CALLBACK_PROFILE_ID, DevSDK_Delete, svc, edgex_device_handler_callback_profile_id);
-
   edgex_rest_server_register_handler (svc->daemon, EDGEX_DEV_API2_CALLBACK_WATCHER, DevSDK_Put | DevSDK_Post, svc, edgex_device_handler_callback_watcher);
 
-  edgex_rest_server_register_handler (svc->daemon, EDGEX_DEV_API2_CALLBACK_WATCHER_ID, DevSDK_Delete, svc, edgex_device_handler_callback_watcher_id);
+  edgex_rest_server_register_handler (svc->daemon, EDGEX_DEV_API2_CALLBACK_WATCHER_NAME, DevSDK_Delete, svc, edgex_device_handler_callback_watcher_name);
+
+  edgex_rest_server_register_handler (svc->daemon, EDGEX_DEV_API2_CALLBACK_SERVICE, DevSDK_Put, svc, edgex_device_handler_callback_service);
 
   edgex_rest_server_register_handler
   (
@@ -529,17 +529,7 @@ static void startConfigured (devsdk_service_t *svc, toml_table_t *config, devsdk
     edgex_device_handler_device
   );
 
-  edgex_rest_server_register_handler
-  (
-    svc->daemon, EDGEX_DEV_API2_DEVICE_NAME, DevSDK_Get | DevSDK_Put | DevSDK_Post, svc,
-    edgex_device_handler_device_namev2
-  );
-
-  edgex_rest_server_register_handler
-  (
-    svc->daemon, EDGEX_DEV_API2_DEVICE, DevSDK_Get | DevSDK_Put | DevSDK_Post, svc,
-    edgex_device_handler_devicev2
-  );
+  edgex_rest_server_register_handler (svc->daemon, EDGEX_DEV_API2_DEVICE_NAME, DevSDK_Get | DevSDK_Put, svc, edgex_device_handler_device_namev2);
 
   edgex_rest_server_register_handler
   (

--- a/src/c/watchers.c
+++ b/src/c/watchers.c
@@ -51,9 +51,9 @@ void edgex_watcher_regexes_free (edgex_watcher_regexes_t *regs)
   }
 }
 
-static edgex_watcher **find_locked (edgex_watcher **list, const char *id)
+static edgex_watcher **find_locked (edgex_watcher **list, const char *name)
 {
-  while (*list && strcmp ((*list)->id, id))
+  while (*list && strcmp ((*list)->name, name))
   {
     list = &((*list)->next);
   }
@@ -81,12 +81,12 @@ static void add_locked (edgex_watchlist_t *wl, const edgex_watcher *w)
   wl->list = newelem;
 }
 
-bool edgex_watchlist_remove_watcher (edgex_watchlist_t *wl, const char *id)
+bool edgex_watchlist_remove_watcher (edgex_watchlist_t *wl, const char *name)
 {
   bool result = false;
   pthread_rwlock_wrlock (&wl->lock);
 
-  edgex_watcher **ptr = find_locked (&wl->list, id);
+  edgex_watcher **ptr = find_locked (&wl->list, name);
   edgex_watcher *found = *ptr;
   if (found)
   {
@@ -104,7 +104,7 @@ void edgex_watchlist_update_watcher (edgex_watchlist_t *wl, const edgex_watcher 
 {
   pthread_rwlock_wrlock (&wl->lock);
 
-  edgex_watcher **ptr = find_locked (&wl->list, updated->id);
+  edgex_watcher **ptr = find_locked (&wl->list, updated->name);
   edgex_watcher *found = *ptr;
   if (found)
   {
@@ -128,7 +128,7 @@ unsigned edgex_watchlist_populate (edgex_watchlist_t *wl, const edgex_watcher *n
 
   for (const edgex_watcher *w = newlist; w; w = w->next)
   {
-    if (*find_locked (&wl->list, w->id) == NULL)
+    if (*find_locked (&wl->list, w->name) == NULL)
     {
       count++;
       add_locked (wl, w);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
A number of minor updates have been made to the v2 REST API since its implementation in the CSDK. The SDK needs to be updated accordingly

## Issue Number: #322 


## What is the new behavior?
* Allow query params on device put requests
* rename postevent queryparam to pushevent
* DeviceProfile add and delete callbacks are removed
* Device and Watcher delete callbacks are now by name not id
* Add Service update callback as per v1
* device/{id}/{command} not to be supported, only device/name/{name}/{command}


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

Additional parameter required on put-handler, to specify query parameters on the request

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
