### PR TITLE
fix: deviceProfile format changes (#310)

### DIFF
--- a/docs/deviceprofiles.md
+++ b/docs/deviceprofiles.md
@@ -16,49 +16,36 @@ The profile contains some identification information - it has a name and
 a description, and a set of labels. It also indicates the brand name of the
 device to which it applies, and the manufacturer of that device.
 
-This information is followed by three sections, "deviceResources",
-"deviceCommands" and "coreCommands".
-
-coreCommands
-------------
-
-This section specifies the commands which are available via the core-command
-microservice, for reading and writing to the device.
-
-Commands may allow get or put methods (or both). For a get type, the returned
-values are specified in the "expectedValues" field, for a put type, the
-parameters to be given are specified in "parameterNames". In either case, the
-different http response codes that the service may generate are shown.
+This information is followed by two sections, "deviceResources" and "deviceCommands"
 
 deviceCommands
 --------------
 
 These are presented at the "device" endpoint,
 ```
-http://<device-service>:<port>/api/v1/device/<device id>/<command name>
+http://<device-service>:<port>/api/v2/device/name/<device name>/<command name>
 ```
 
 This section defines access to reads and writes for multiple simultaneous
-values. Each deviceCommand should contain a get and/or a set section, describing
-the read or write operation respectively.
+values. Each deviceCommand contains a resourceOperations section which
+defines which values comprise the command.
 
-Each line of a get section indicates a deviceResource which is to be read, and
-the lines in a set section indicate deviceResources to be written. The values
-in these lines are as follows:
+Each line of a resourceOperations section has the following elements:
 
-* index - a number, used to define an order in which the resource is processed.
-* operation - get or set. Ignored in this implementation, mixing of get and set
-operations is not supported.
-* deviceResource - the name of the deviceResource to access.
-* parameter - optional, a value that will be used if a PUT request does not
-specify one.
+* deviceResource - required - the name of the deviceResource to access.
+* defaultValue - optional - a value that will be used if a PUT request does not specify one.
+* mappings - optional - a one-to-one transformation for string data
+
+Mappings are specified as "X": "Y" indicating that if the string "X" is read, the string "Y"
+will be the reading value. If a value is read which does not have a mapping specified, it is
+passed through unchanged. Mappings are applied in reverse for data to be written.
 
 deviceResources
 ---------------
 
 These are also presented at the "device" endpoint,
 ```
-http://<device-service>:<port>/api/v1/device/<device id>/<deviceResource name>
+http://<device-service>:<port>/api/v2/device/name/<device name>/<resource name>
 ```
 
 however if a profile contains a deviceCommand with the same name as a
@@ -74,14 +61,14 @@ will have its own set of named values that are required here, for example a
 BACnet device service may need an Object Identifier and a Property Identifier
 whereas a Bluetooth device service could use a UUID to identify a value.
 
-The properties section in a deviceResource describes the value. Conventionally
-each logical value is given two properties, named value and units. The
+The properties section in a deviceResource describes the value. The
 following fields are available in a property:
 
 * type - Required. The data type of the value. Supported types are Bool,
 Int8 - Int64, Uint8 - Uint64, Float32, Float64, Binary and String. Arrays of
 all types other than String and Binary are also supported and named by adding
 "Array" to the typename eg Int8Array.
+* units - indicates the units of the value, eg Amperes, degrees C, etc.
 * readWrite - "R", "RW", or "W" indicating whether the value is readable or
 writable.
 * defaultValue - a value used for PUT requests which do not specify one.
@@ -101,8 +88,6 @@ implemented in the driver)
 The minimum and maximum values may be used to enforce a range limit on values
 provided in write requests. They are only valid for numeric data, ie ints and floats.
 
-The units property is used to indicate the units of the value, eg Amperes,
-degrees C, etc. It should have only one field, a defaultValue that specifies the units.
 
 The Device Profile in the C SDK
 -------------------------------

--- a/include/devsdk/devsdk-base.h
+++ b/include/devsdk/devsdk-base.h
@@ -191,6 +191,15 @@ bool devsdk_nvpairs_ulong_value (const devsdk_nvpairs *nvp, const char *name, un
 bool devsdk_nvpairs_float_value (const devsdk_nvpairs *nvp, const char *name, float *val);
 
 /**
+ * @brief Finds a name for a value in an n-v pair list.
+ * @param nvp A list of name-value pairs.
+ * @param name The value to search for.
+ * @returns The name corresponding to the given value, or NULL if not found.
+ */
+
+const char *devsdk_nvpairs_reverse_value (const devsdk_nvpairs *nvp, const char *name);
+
+/**
  * @brief Duplicates a n-v pair list
  * @param e The list to duplicate
  * @returns The new list

--- a/include/edgex/edgex.h
+++ b/include/edgex/edgex.h
@@ -37,7 +37,7 @@ typedef struct edgex_deviceservice
 typedef struct edgex_resourceoperation
 {
   char *deviceResource;
-  char *parameter;
+  char *defaultValue;
   devsdk_nvpairs *mappings;
   struct edgex_resourceoperation *next;
 } edgex_resourceoperation;
@@ -73,8 +73,9 @@ typedef struct edgex_deviceresource
 typedef struct edgex_devicecommand
 {
   char *name;
-  edgex_resourceoperation *set;
-  edgex_resourceoperation *get;
+  edgex_resourceoperation *resourceOperations;
+  bool readable;
+  bool writable;
   struct edgex_devicecommand *next;
 } edgex_devicecommand;
 

--- a/src/c/device.c
+++ b/src/c/device.c
@@ -383,8 +383,7 @@ static iot_typecode_t *typecodeFromType (edgex_propertytype pt)
   }
 }
 
-static edgex_cmdinfo *infoForRes
-  (edgex_deviceprofile *prof, edgex_devicecommand *cmd, bool forGet)
+static edgex_cmdinfo *infoForRes (edgex_deviceprofile *prof, edgex_devicecommand *cmd, bool forGet)
 {
   edgex_cmdinfo *result = malloc (sizeof (edgex_cmdinfo));
   result->name = cmd->name;
@@ -392,7 +391,7 @@ static edgex_cmdinfo *infoForRes
   result->isget = forGet;
   unsigned n = 0;
   edgex_resourceoperation *ro;
-  for (ro = forGet ? cmd->get : cmd->set; ro; ro = ro->next)
+  for (ro = cmd->resourceOperations; ro; ro = ro->next)
   {
     n++;
   }
@@ -401,7 +400,7 @@ static edgex_cmdinfo *infoForRes
   result->pvals = calloc (n, sizeof (edgex_propertyvalue *));
   result->maps = calloc (n, sizeof (devsdk_nvpairs *));
   result->dfls = calloc (n, sizeof (char *));
-  for (n = 0, ro = forGet ? cmd->get : cmd->set; ro; n++, ro = ro->next)
+  for (n = 0, ro = cmd->resourceOperations; ro; n++, ro = ro->next)
   {
     edgex_deviceresource *devres =
       findDevResource (prof->device_resources, ro->deviceResource);
@@ -414,9 +413,9 @@ static edgex_cmdinfo *infoForRes
     }
     result->pvals[n] = devres->properties;
     result->maps[n] = ro->mappings;
-    if (ro->parameter && *ro->parameter)
+    if (ro->defaultValue && *ro->defaultValue)
     {
-      result->dfls[n] = ro->parameter;
+      result->dfls[n] = ro->defaultValue;
     }
     else if (devres->properties->defaultvalue && *devres->properties->defaultvalue)
     {
@@ -465,12 +464,12 @@ static void populateCmdInfo (edgex_deviceprofile *prof)
   edgex_devicecommand *cmd = prof->device_commands;
   while (cmd)
   {
-    if (cmd->get)
+    if (cmd->readable)
     {
       *head = infoForRes (prof, cmd, true);
       head = &((*head)->next);
     }
-    if (cmd->set)
+    if (cmd->writable)
     {
       *head = infoForRes (prof, cmd, false);
       head = &((*head)->next);

--- a/src/c/devsdk-base.c
+++ b/src/c/devsdk-base.c
@@ -27,6 +27,21 @@ devsdk_nvpairs *devsdk_nvpairs_new (const char *name, const char *value, devsdk_
   return result;
 }
 
+const char *devsdk_nvpairs_reverse_value (const devsdk_nvpairs *nvp, const char *name)
+{
+  if (name)
+  {
+    for (; nvp; nvp = nvp->next)
+    {
+      if (strcmp (nvp->value, name) == 0)
+      {
+        return nvp->name;
+      }
+    }
+  }
+  return NULL;
+}
+
 const char *devsdk_nvpairs_value (const devsdk_nvpairs *nvp, const char *name)
 {
   if (name)

--- a/src/c/examples/bitfields/res/profiles/Bitfields.yaml
+++ b/src/c/examples/bitfields/res/profiles/Bitfields.yaml
@@ -27,9 +27,3 @@ deviceResources:
     description: "Byte 3 (MSB)"
     properties:
         { valueType: "Uint32", readWrite: "RW", mask: "0xFF000000", shift: "24", units: "things" }
-
-coreCommands:
-  - { name: "A", get: true, set: true }
-  - { name: "B", get: true, set: true }
-  - { name: "C", get: true, set: true }
-  - { name: "D", get: true, set: true }

--- a/src/c/examples/counters/res/profiles/Counter.yaml
+++ b/src/c/examples/counters/res/profiles/Counter.yaml
@@ -14,6 +14,3 @@ deviceResources:
       { register: "count01" }
     properties:
       { valueType: "Uint32", readWrite: "RW", units: "things" }
-
-coreCommands:
-  - { name: "Counter", get: true, set: true }

--- a/src/c/examples/discovery/res/profiles/TemplateProfile.yaml
+++ b/src/c/examples/discovery/res/profiles/TemplateProfile.yaml
@@ -29,8 +29,3 @@ deviceResources:
             { SensorID: "Switch1", SensorType: "Switch" }
         properties:
             { valueType: "Bool", readWrite: "RW", units: "State" }
-
-coreCommands:
-  - { name: "SensorOne", get: true }
-  - { name: "SensorTwo", get: true }
-  - { name: "Switch", get: true, set: true }

--- a/src/c/examples/file/res/profiles/FileExampleProfile.yaml
+++ b/src/c/examples/file/res/profiles/FileExampleProfile.yaml
@@ -10,4 +10,3 @@ deviceResources:
         description: "The content of a file"
         properties:
                 { valueType: "Binary", readWrite: "R", mediaType: "text/plain", units: "data" }
-

--- a/src/c/examples/gyro/res/profiles/Gyro.yaml
+++ b/src/c/examples/gyro/res/profiles/Gyro.yaml
@@ -32,10 +32,8 @@ deviceResources:
 deviceCommands:
   -
     name: rotation
-    get:
+    readWrite: "R"
+    resourceOperations:
       - { deviceResource: "Xrotation" }
       - { deviceResource: "Yrotation" }
       - { deviceResource: "Zrotation" }
-
-coreCommands:
-  - { name: "rotation", get: true }

--- a/src/c/examples/random/res/profiles/RandomExampleProfile.yaml
+++ b/src/c/examples/random/res/profiles/RandomExampleProfile.yaml
@@ -29,8 +29,3 @@ deviceResources:
             { SwitchID: "Switch1" }
         properties:
             { valueType: "Bool", readWrite: "RW", units: "State" }
-
-coreCommands:
-  - { name: "SensorOne", get: true }
-  - { name: "SensorTwo", get: true }
-  - { name: "Switch", get: true, set: true }

--- a/src/c/examples/res/profiles/TemplateProfile.yaml
+++ b/src/c/examples/res/profiles/TemplateProfile.yaml
@@ -29,8 +29,3 @@ deviceResources:
             { SensorID: "Switch1", SensorType: "Switch" }
         properties:
             { valueType: "Bool", readWrite: "RW", units: "State" }
-
-coreCommands:
-  - { name: "SensorOne", get: true }
-  - { name: "SensorTwo", get: true }
-  - { name: "Switch", get: true, set: true }

--- a/src/c/examples/terminal/README.md
+++ b/src/c/examples/terminal/README.md
@@ -51,4 +51,4 @@ curl -X PUT -d '{"Message":"Hello World", "Xposition":"35", "Yposition":"12"}' 0
 
 ### Implementation notes
 
-The service uses the defaulting mechanism in deviceCommands in order to pass the name of the operation being requested to the implementation. The `parameter` field in a resource operation sets a value to be used if one is not supplied in the PUT request.
+The service uses the defaulting mechanism in deviceCommands in order to pass the name of the operation being requested to the implementation. The `defaultValue` field in a resource operation sets a value to be used if one is not supplied in the PUT request.

--- a/src/c/examples/terminal/res/profiles/Terminal.yaml
+++ b/src/c/examples/terminal/res/profiles/Terminal.yaml
@@ -39,11 +39,9 @@ deviceResources:
 deviceCommands:
   -
     name: WriteMsg
-    set:
-      - { deviceResource: "Cmd", parameter: "WriteMsg" }
+    readWrite: "W"
+    resourceOperations:
+      - { deviceResource: "Cmd", defaultValue: "WriteMsg" }
       - { deviceResource: "Xposition" }
       - { deviceResource: "Yposition" }
       - { deviceResource: "Message" }
-
-coreCommands:
-  - { name: "WriteMsg", set: true }

--- a/src/c/transform.c
+++ b/src/c/transform.c
@@ -211,7 +211,7 @@ void edgex_transform_incoming (iot_data_t **cres, edgex_propertyvalue *props, de
     break;
     case IOT_DATA_STRING:
     {
-      const char *remap = devsdk_nvpairs_value (mappings, iot_data_string (*cres));
+      const char *remap = devsdk_nvpairs_reverse_value (mappings, iot_data_string (*cres));
       if (remap)
       {
         iot_data_free (*cres);


### PR DESCRIPTION
Update to new deviceCommand format, remove coreCommands from sample profiles

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
SDK expects device profiles in v1 format


## Issue Number: #310 


## What is the new behavior?
Device profiles rationalized for EdgeX v2.0 

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

Device Profiles will need to be migrated to v2

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
