### PR TITLE
fix: support ipv6 listener addresses (#332)

### DIFF
--- a/src/c/rest-server.c
+++ b/src/c/rest-server.c
@@ -319,7 +319,6 @@ edgex_rest_server *edgex_rest_server_create
 {
   edgex_rest_server *svr;
   uint16_t flags = MHD_USE_THREAD_PER_CONNECTION;
-  /* config: flags |= MHD_USE_IPv6 ? */
 
   svr = calloc (1, sizeof (edgex_rest_server));
   svr->lc = lc;
@@ -340,6 +339,10 @@ edgex_rest_server *edgex_rest_server_create
       iot_log_info (lc, "Starting HTTP server on interface %s, port %d", bindaddr, port);
       edgex_rest_sa_out (resaddr, res->ai_addr);
       iot_log_debug (lc, "Resolved interface is %s", resaddr);
+      if (res->ai_family == AF_INET6)
+      {
+        flags |= MHD_USE_IPv6;
+      }
       svr->daemon = MHD_start_daemon (flags, port, 0, 0, http_handler, svr, MHD_OPTION_SOCK_ADDR, res->ai_addr, MHD_OPTION_END);
       freeaddrinfo (res);
     }


### PR DESCRIPTION
Signed-off-by: Iain Anderson <iain@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Service fails to start if the resolved listener address is IPv6

## Issue Number: #332 


## What is the new behavior?
Appropriate option set on server to support IPv6

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
