### PR TITLE
feat: support autoevent definitions in provision watchers (#309)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ This is the C SDK for EdgeX. Its API is based largely on the Go SDK.
 
 Changes for 2.0.0 "Ireland":
 
+- Ports for EdgeX microservices are re-assigned, eg device services move from 499xx to 599xx.
 - Provision Watchers may include AutoEvents to be added on discovered devices.
 - Support event transmission by mqtt or redis streams rather than rest
 - Device definitions for upload no longer supported in configuration. Instead files may be read from a specified directory (as for profiles)

--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ This is the C SDK for EdgeX. Its API is based largely on the Go SDK.
 
 Changes for 2.0.0 "Ireland":
 
+- Provision Watchers may include AutoEvents to be added on discovered devices.
 - Support event transmission by mqtt or redis streams rather than rest
 - Device definitions for upload no longer supported in configuration. Instead files may be read from a specified directory (as for profiles)
   - These may be in .json files or the previous .toml format

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,7 +19,7 @@ For example, `Service_ServerBindAddr`.
 Option | Type | Notes
 :--- | :--- | :---
 Host | String | This is the hostname to use when the service generates URLs pointing to itself. It must be resolvable by other services in the EdgeX deployment.
-Port | Int | Port on which to accept the device service's REST API. The assigned port for experimental / in-development device services is 49999.
+Port | Int | Port on which to accept the device service's REST API. The assigned port for experimental / in-development device services is 59999.
 Timeout | Int | Time (in milliseconds) to wait between attempts to contact core-data and core-metadata when starting up.
 ConnectRetries | Int | Number of times to attempt to contact core-data and core-metadata when starting up.
 StartupMsg | String | Message to log on successful startup.
@@ -31,14 +31,14 @@ MaxRequestSize | Int | Amount of data beyond which the service will reject an in
 
 Defines the endpoints for other microservices in an EdgeX system.
 
-### edgex-core-data
+### core-data
 
 Option | Type | Notes
 :--- | :--- | :---
 Host | String | Hostname on which to contact the core-data service.
 Port | Int | Port on which to contact the core-data service.
 
-### edgex-core-metadata
+### core-metadata
 
 Option | Type | Notes
 :--- | :--- | :---

--- a/include/edgex/edgex.h
+++ b/include/edgex/edgex.h
@@ -113,13 +113,14 @@ typedef struct edgex_watcher
   edgex_blocklist *blocking_identifiers;
   char *profile;
   edgex_device_adminstate adminstate;
+  struct edgex_device_autoevents *autoevents;
   struct edgex_watcher *next;
 } edgex_watcher;
 
 typedef struct edgex_device_autoevents
 {
   char *resource;
-  char *frequency;
+  char *interval;
   bool onChange;
   struct edgex_autoimpl *impl;
   struct edgex_device_autoevents *next;

--- a/src/c/autoevent.c
+++ b/src/c/autoevent.c
@@ -171,14 +171,14 @@ void edgex_device_autoevent_start (devsdk_service_t *svc, edgex_device *dev)
         );
         continue;
       }
-      uint64_t interval = parseTime (ae->frequency);
+      uint64_t interval = parseTime (ae->interval);
       if (interval == 0)
       {
         iot_log_error
         (
           svc->logger,
-          "AutoEvents: device %s: unable to parse %s for frequency.",
-          dev->name, ae->frequency
+          "AutoEvents: device %s: unable to parse %s for interval.",
+          dev->name, ae->interval
         );
         continue;
       }

--- a/src/c/config.c
+++ b/src/c/config.c
@@ -56,7 +56,7 @@ iot_data_t *edgex_config_defaults (const iot_data_t *driverconf)
   iot_data_string_map_add (result, DYN_PREFIX "Device/MaxCmdResultLen", iot_data_alloc_ui32 (0));
 
   iot_data_string_map_add (result, "Service/Host", iot_data_alloc_string (utsbuffer.nodename, IOT_DATA_COPY));
-  iot_data_string_map_add (result, "Service/Port", iot_data_alloc_ui16 (49999));
+  iot_data_string_map_add (result, "Service/Port", iot_data_alloc_ui16 (59999));
   iot_data_string_map_add (result, "Service/Timeout", iot_data_alloc_ui32 (1000));
   iot_data_string_map_add (result, "Service/ConnectRetries", iot_data_alloc_ui32 (20));
   iot_data_string_map_add (result, "Service/StartupMsg", iot_data_alloc_string ("", IOT_DATA_REF));
@@ -282,11 +282,11 @@ void edgex_device_parseTomlClients
 {
   if (clients)
   {
-    parseClient (lc, toml_table_in (clients, "edgex-core-data"), &endpoints->data, err);
-    parseClient (lc, toml_table_in (clients, "edgex-core-metadata"), &endpoints->metadata, err);
+    parseClient (lc, toml_table_in (clients, "core-data"), &endpoints->data, err);
+    parseClient (lc, toml_table_in (clients, "core-metadata"), &endpoints->metadata, err);
   }
-  checkClientOverride (lc, "EDGEX_CORE_DATA", &endpoints->data);
-  checkClientOverride (lc, "EDGEX_CORE_METADATA", &endpoints->metadata);
+  checkClientOverride (lc, "CORE_DATA", &endpoints->data);
+  checkClientOverride (lc, "CORE_METADATA", &endpoints->metadata);
 }
 
 static char *checkOverride (char *qstr)

--- a/src/c/config.c
+++ b/src/c/config.c
@@ -800,7 +800,7 @@ void edgex_device_process_configured_devices
               toml_rtos2
                 (toml_raw_in (aetable, "Resource"), &newauto->resource);
               toml_rtos2
-                (toml_raw_in (aetable, "Frequency"), &newauto->frequency);
+                (toml_raw_in (aetable, "Interval"), &newauto->interval);
               toml_rtob2
                 (toml_raw_in (aetable, "OnChange"), &newauto->onChange);
               newauto->next = autos;

--- a/src/c/devman.c
+++ b/src/c/devman.c
@@ -199,14 +199,17 @@ void devsdk_add_discovered_devices (devsdk_service_t *svc, uint32_t ndevices, de
       if (w)
       {
         devsdk_strings *labels = NULL;
-        const iot_data_t *ldata = iot_data_string_map_get (devices[i].properties, "Labels");
-        if (ldata)
+        if (devices[i].properties)
         {
-          iot_data_vector_iter_t iter;
-          iot_data_vector_iter (ldata, &iter);
-          while (iot_data_vector_iter_next (&iter))
+          const iot_data_t *ldata = iot_data_string_map_get (devices[i].properties, "Labels");
+          if (ldata)
           {
-            labels = devsdk_strings_new (iot_data_vector_iter_string (&iter), labels);
+            iot_data_vector_iter_t iter;
+            iot_data_vector_iter (ldata, &iter);
+            while (iot_data_vector_iter_next (&iter))
+            {
+              labels = devsdk_strings_new (iot_data_vector_iter_string (&iter), labels);
+            }
           }
         }
         edgex_metadata_client_add_or_modify_device

--- a/src/c/devman.c
+++ b/src/c/devman.c
@@ -218,6 +218,7 @@ void devsdk_add_discovered_devices (devsdk_service_t *svc, uint32_t ndevices, de
           labels,
           w->adminstate,
           devices[i].protocols,
+          w->autoevents,
           svc->name,
           w->profile
         );

--- a/src/c/devsdk-base.c
+++ b/src/c/devsdk-base.c
@@ -213,7 +213,7 @@ LIST_EQUAL_FUNCTION(devsdk_protocols, name, protocol_equal)
 
 static bool autoevent_equal (const edgex_device_autoevents *e1, const edgex_device_autoevents *e2)
 {
-  return strcmp (e1->frequency, e2->frequency) == 0 && e1->onChange == e2->onChange;
+  return strcmp (e1->interval, e2->interval) == 0 && e1->onChange == e2->onChange;
 }
 
 LIST_EQUAL_FUNCTION(edgex_device_autoevents, resource, autoevent_equal)

--- a/src/c/edgex-rest.c
+++ b/src/c/edgex-rest.c
@@ -1129,7 +1129,7 @@ char *edgex_updateDevOpreq_write (const char *name, edgex_device_operatingstate 
   JSON_Object *obj = json_value_get_object (jval);
 
   json_object_set_string (obj, "name", name);
-  json_object_set_string (obj, "opstate", edgex_operatingstate_tostring (opstate));
+  json_object_set_string (obj, "operatingstate", edgex_operatingstate_tostring (opstate));
   val = edgex_wrap_request ("Device", jval);
   json = json_serialize_to_string (val);
   json_value_free (val);

--- a/src/c/edgex-rest.c
+++ b/src/c/edgex-rest.c
@@ -633,7 +633,7 @@ static edgex_device_autoevents *autoevent_read (const JSON_Object *obj)
   edgex_device_autoevents *result = malloc (sizeof (edgex_device_autoevents));
   result->resource = get_string (obj, "sourceName");
   result->onChange = get_boolean (obj, "onChange", false);
-  result->frequency = get_string  (obj, "frequency");
+  result->interval = get_string  (obj, "interval");
   result->impl = NULL;
   result->next = NULL;
   return result;
@@ -649,7 +649,7 @@ static JSON_Value *autoevents_write (const edgex_device_autoevents *e)
     JSON_Value *pval = json_value_init_object ();
     JSON_Object *pobj = json_value_get_object (pval);
     json_object_set_string (pobj, "sourceName", ae->resource);
-    json_object_set_string (pobj, "frequency", ae->frequency);
+    json_object_set_string (pobj, "interval", ae->interval);
     json_object_set_boolean (pobj, "onChange", ae->onChange);
     json_array_append_value (arr, pval);
   }
@@ -664,7 +664,7 @@ static edgex_device_autoevents *autoevents_dup
   {
     result = malloc (sizeof (edgex_device_autoevents));
     result->resource = strdup (e->resource);
-    result->frequency = strdup (e->frequency);
+    result->interval = strdup (e->interval);
     result->onChange = e->onChange;
     result->impl = NULL;
     result->next = autoevents_dup (e->next);
@@ -677,7 +677,7 @@ void edgex_device_autoevents_free (edgex_device_autoevents *e)
   if (e)
   {
     free (e->resource);
-    free (e->frequency);
+    free (e->interval);
     edgex_device_autoevents_free (e->next);
     free (e);
   }
@@ -1239,6 +1239,14 @@ static edgex_watcher *watcher_read (const JSON_Object *obj)
   {
     result->blocking_identifiers = blocklist_read (blockObj);
   }
+  JSON_Array *aearray = json_object_get_array (obj, "autoEvents");
+  size_t count = json_array_get_count (aearray);
+  for (size_t i = 0; i < count; i++)
+  {
+    edgex_device_autoevents *temp = autoevent_read (json_array_get_object (aearray, i));
+    temp->next = result->autoevents;
+    result->autoevents = temp;
+  }
   result->adminstate = edgex_adminstate_fromstring
     (json_object_get_string (obj, "adminState"));
 
@@ -1302,6 +1310,7 @@ edgex_watcher *edgex_watcher_dup (const edgex_watcher *e)
   res->name = strdup (e->name);
   res->identifiers = devsdk_nvpairs_dup (e->identifiers);
   res->blocking_identifiers = edgex_blocklist_dup (e->blocking_identifiers);
+  res->autoevents = autoevents_dup (e->autoevents);
   res->profile = strdup (e->profile);
   res->adminstate = e->adminstate;
   res->next = NULL;
@@ -1318,6 +1327,7 @@ void edgex_watcher_free (edgex_watcher *e)
     devsdk_nvpairs_free (ew->identifiers);
     edgex_watcher_regexes_free (ew->regs);
     edgex_blocklist_free (ew->blocking_identifiers);
+    edgex_device_autoevents_free (ew->autoevents);
     free (ew->profile);
     free (ew);
     ew = next;

--- a/src/c/examples/README.md
+++ b/src/c/examples/README.md
@@ -52,7 +52,7 @@ An EdgeX system containing at least a database and the core-data and core-metada
 Once the service is running it will begin to send a sequence of Events every ten seconds. It will also respond to the REST API for device services. To obtain a reading manually,
 
 ```
-curl 0:49999/api/v2/device/name/Device1/SensorOne
+curl 0:59999/api/v2/device/name/Device1/SensorOne
 ```
 
 Note that the template device service returns a constant String reading regardless of the requested operation.

--- a/src/c/examples/bitfields/README.md
+++ b/src/c/examples/bitfields/README.md
@@ -60,11 +60,11 @@ An EdgeX system containing at least a database and the core-data and core-metada
 To read value "B" (bits 8-15):
 
 ```
-curl 0:49999/api/v2/device/name/Bitfields/B
+curl 0:59999/api/v2/device/name/Bitfields/B
 ```
 
 To write a value into "B":
 
 ```
-curl -X PUT -d '{"B":"221"}' 0:49999/api/v2/device/name/Bitfields/B
+curl -X PUT -d '{"B":"221"}' 0:59999/api/v2/device/name/Bitfields/B
 ```

--- a/src/c/examples/bitfields/res/configuration.toml
+++ b/src/c/examples/bitfields/res/configuration.toml
@@ -6,7 +6,7 @@
     MaxCmdResultLen = 256
 
 [Service]
-  Port = 49999
+  Port = 59999
   Timeout = 5000
   ConnectRetries = 10
   Labels = [ 'Bitfields' ]
@@ -14,13 +14,13 @@
   CheckInterval = '10s'
 
 [Clients]
-  [Clients.edgex-core-data]
+  [Clients.core-data]
     Host = 'localhost'
-    Port = 48080
+    Port = 59880
 
-  [Clients.edgex-core-metadata]
+  [Clients.core-metadata]
     Host = 'localhost'
-    Port = 48081
+    Port = 59881
 
 [Device]
   ProfilesDir = 'res/profiles'

--- a/src/c/examples/counters/README.md
+++ b/src/c/examples/counters/README.md
@@ -39,13 +39,13 @@ An EdgeX system containing at least a database and the core-data and core-metada
 Once the service is running it will begin to send Events from the Counter1 device every ten seconds. To manually generate an Event,
 
 ```
-curl 0:49999/api/v2/device/name/Counter2/Counter
+curl 0:59999/api/v2/device/name/Counter2/Counter
 ```
 
 To reset one of the counters,
 
 ```
-curl -X PUT -d '{"Counter":"0"}' 0:49999/api/v2/device/name/Counter1/Counter
+curl -X PUT -d '{"Counter":"0"}' 0:59999/api/v2/device/name/Counter1/Counter
 ```
 
 ### Device details

--- a/src/c/examples/counters/res/configuration.toml
+++ b/src/c/examples/counters/res/configuration.toml
@@ -6,7 +6,7 @@
     MaxCmdResultLen = 256
 
 [Service]
-  Port = 49999
+  Port = 59999
   Timeout = 5000
   ConnectRetries = 10
   Labels = [ 'Counter' ]
@@ -14,13 +14,13 @@
   CheckInterval = '10s'
 
 [Clients]
-  [Clients.edgex-core-data]
+  [Clients.core-data]
     Host = 'localhost'
-    Port = 48080
+    Port = 59880
 
-  [Clients.edgex-core-metadata]
+  [Clients.core-metadata]
     Host = 'localhost'
-    Port = 48081
+    Port = 59881
 
 [Device]
   ProfilesDir = 'res/profiles'

--- a/src/c/examples/counters/res/devices/Counters.json
+++ b/src/c/examples/counters/res/devices/Counters.json
@@ -9,7 +9,7 @@
     },
     "autoEvents":
     [
-      { "sourceName": "Counter", "onChange": false, "frequency": "10s" }
+      { "sourceName": "Counter", "onChange": false, "interval": "10s" }
     ]
   },
   {

--- a/src/c/examples/discovery/README.md
+++ b/src/c/examples/discovery/README.md
@@ -39,7 +39,7 @@ Discovery/Interval to 0), discovery may be forced by calling the discovery
 endpoint manually:
 
 ```
-curl -X POST 0:49999/api/v2/discovery
+curl -X POST 0:59999/api/v2/discovery
 ```
 
 Initially, none of the discovered devices will be added to EdgeX, but by
@@ -47,8 +47,8 @@ using appropriate Provision Watchers they can be accepted. To upload the
 supplied Provision Watchers to core-metadata:
 
 ```
-curl -X POST -d@watcher1.json 0:48081/api/v2/provisionwatcher
-curl -X POST -d@watcher2.json 0:48081/api/v2/provisionwatcher
+curl -X POST -d@watcher1.json 0:59881/api/v2/provisionwatcher
+curl -X POST -d@watcher2.json 0:59881/api/v2/provisionwatcher
 ```
 
 The Provision Watchers each match one of the discovered devices. They work by

--- a/src/c/examples/discovery/res/configuration.toml
+++ b/src/c/examples/discovery/res/configuration.toml
@@ -9,7 +9,7 @@
       Interval = 10
 
 [Service]
-  Port = 49999
+  Port = 59999
   Timeout = 5000
   ConnectRetries = 10
   Labels = [ 'Template' ]
@@ -17,13 +17,13 @@
   CheckInterval = '10s'
 
 [Clients]
-  [Clients.edgex-core-data]
+  [Clients.core-data]
     Host = 'localhost'
-    Port = 48080
+    Port = 59880
 
-  [Clients.edgex-core-metadata]
+  [Clients.core-metadata]
     Host = 'localhost'
-    Port = 48081
+    Port = 59881
 
 [Driver]
   TestParam1 = 'Hello'

--- a/src/c/examples/file/res/configuration.toml
+++ b/src/c/examples/file/res/configuration.toml
@@ -2,13 +2,13 @@
   LogLevel = 'DEBUG'
 
 [Clients]
-  [Clients.edgex-core-data]
+  [Clients.core-data]
     Host = 'localhost'
-    Port = 48080
+    Port = 59880
 
-  [Clients.edgex-core-metadata]
+  [Clients.core-metadata]
     Host = 'localhost'
-    Port = 48081
+    Port = 59881
 
 [Device]
   ProfilesDir = 'res/profiles'

--- a/src/c/examples/gyro/README.md
+++ b/src/c/examples/gyro/README.md
@@ -39,7 +39,7 @@ An EdgeX system containing at least a database and the core-data and core-metada
 To take a set of readings from the gyro:
 
 ```
-curl 0:49999/api/v2/device/name/Gyro/rotation
+curl 0:59999/api/v2/device/name/Gyro/rotation
 ```
 
 This returns an Event containing three Readings representing the three axes of measurement.

--- a/src/c/examples/gyro/res/configuration.toml
+++ b/src/c/examples/gyro/res/configuration.toml
@@ -7,7 +7,7 @@
 
 
 [Service]
-  Port = 49999
+  Port = 59999
   Timeout = 5000
   ConnectRetries = 10
   Labels = [ 'Gyro' ]
@@ -15,13 +15,13 @@
   CheckInterval = '10s'
 
 [Clients]
-  [Clients.edgex-core-data]
+  [Clients.core-data]
     Host = 'localhost'
-    Port = 48080
+    Port = 59880
 
-  [Clients.edgex-core-metadata]
+  [Clients.core-metadata]
     Host = 'localhost'
-    Port = 48081
+    Port = 59881
 
 [Device]
   ProfilesDir = 'res/profiles'

--- a/src/c/examples/random/README.md
+++ b/src/c/examples/random/README.md
@@ -36,18 +36,18 @@ An EdgeX system containing at least a database and the core-data and core-metada
 Once the service is running it will begin to send one sequence of Events every ten seconds, and another every fifteen. To obtain a reading manually,
 
 ```
-curl 0:49999/api/v2/device/name/RandomDevice1/SensorOne
+curl 0:59999/api/v2/device/name/RandomDevice1/SensorOne
 ```
 
 To read the switch state,
 ```
-curl 0:49999/api/v2/device/name/RandomDevice1/Switch
+curl 0:59999/api/v2/device/name/RandomDevice1/Switch
 ```
 
 To set the switch state,
 
 ```
-curl -X PUT -d '{"Switch":"true"}' 0:49999/api/v2/device/name/RandomDevice1/Switch
+curl -X PUT -d '{"Switch":"true"}' 0:59999/api/v2/device/name/RandomDevice1/Switch
 ```
 
 ### Device details

--- a/src/c/examples/random/res/configuration.toml
+++ b/src/c/examples/random/res/configuration.toml
@@ -6,7 +6,7 @@
     MaxCmdResultLen = 256
 
 [Service]
-  Port = 49999
+  Port = 59999
   Timeout = 5000
   ConnectRetries = 10
   Labels = [ 'Random' ]
@@ -14,13 +14,13 @@
   CheckInterval = '10s'
 
 [Clients]
-  [Clients.edgex-core-data]
+  [Clients.core-data]
     Host = 'localhost'
-    Port = 48080
+    Port = 59880
 
-  [Clients.edgex-core-metadata]
+  [Clients.core-metadata]
     Host = 'localhost'
-    Port = 48081
+    Port = 59881
 
 [Device]
   ProfilesDir = 'res/profiles'

--- a/src/c/examples/random/res/devices/randomdevice1.json
+++ b/src/c/examples/random/res/devices/randomdevice1.json
@@ -8,7 +8,7 @@
   },
   "autoEvents":
   [
-    { "sourceName": "SensorOne", "onChange": false, "frequency": "10s" },
-    { "sourceName": "SensorTwo", "onChange": true, "frequency": "15000ms" }
+    { "sourceName": "SensorOne", "onChange": false, "interval": "10s" },
+    { "sourceName": "SensorTwo", "onChange": true, "interval": "15000ms" }
   ]
 }

--- a/src/c/examples/res/configuration.toml
+++ b/src/c/examples/res/configuration.toml
@@ -9,7 +9,7 @@
     TestParam3 = 'Goodbye'
 
 [Service]
-  Port = 49999
+  Port = 59999
   Timeout = 5000
   ConnectRetries = 10
   Labels = [ 'Template' ]
@@ -17,13 +17,13 @@
   CheckInterval = '10s'
 
 [Clients]
-  [Clients.edgex-core-data]
+  [Clients.core-data]
     Host = 'localhost'
-    Port = 48080
+    Port = 59880
 
-  [Clients.edgex-core-metadata]
+  [Clients.core-metadata]
     Host = 'localhost'
-    Port = 48081
+    Port = 59881
 
 [Driver]
   TestParam1 = 'Hello'

--- a/src/c/examples/res/devices/device1.json
+++ b/src/c/examples/res/devices/device1.json
@@ -8,6 +8,6 @@
   },
   "autoEvents":
   [
-    { "sourceName": "SensorOne", "onChange": false, "frequency": "10s" }
+    { "sourceName": "SensorOne", "onChange": false, "interval": "10s" }
   ]
 }

--- a/src/c/examples/terminal/README.md
+++ b/src/c/examples/terminal/README.md
@@ -46,7 +46,7 @@ An EdgeX system containing at least a database and the core-data and core-metada
 Note that for this example the logging level is set to WARNING to keep the display clear in normal operation. To display a message on the terminal,
 
 ```
-curl -X PUT -d '{"Message":"Hello World", "Xposition":"35", "Yposition":"12"}' 0:49999/api/v2/device/name/Terminal/WriteMsg
+curl -X PUT -d '{"Message":"Hello World", "Xposition":"35", "Yposition":"12"}' 0:59999/api/v2/device/name/Terminal/WriteMsg
 ```
 
 ### Implementation notes

--- a/src/c/examples/terminal/res/configuration.toml
+++ b/src/c/examples/terminal/res/configuration.toml
@@ -6,7 +6,7 @@
     MaxCmdResultLen = 256
 
 [Service]
-  Port = 49999
+  Port = 59999
   Timeout = 5000
   ConnectRetries = 10
   Labels = [ 'Counter' ]
@@ -14,13 +14,13 @@
   CheckInterval = '10s'
 
 [Clients]
-  [Clients.edgex-core-data]
+  [Clients.core-data]
     Host = 'localhost'
-    Port = 48080
+    Port = 59880
 
-  [Clients.edgex-core-metadata]
+  [Clients.core-metadata]
     Host = 'localhost'
-    Port = 48081
+    Port = 59881
 
 [Device]
   ProfilesDir = 'res/profiles'

--- a/src/c/metadata.c
+++ b/src/c/metadata.c
@@ -401,6 +401,7 @@ void edgex_metadata_client_add_or_modify_device
   const devsdk_strings * labels,
   edgex_device_adminstate adminstate,
   devsdk_protocols * protocols,
+  edgex_device_autoevents *autos,
   const char * service_name,
   const char * profile_name
 )
@@ -422,6 +423,7 @@ void edgex_metadata_client_add_or_modify_device
   dev->operatingState = UP;
   dev->labels = (devsdk_strings *)labels;
   dev->protocols = protocols;
+  dev->autos = autos;
   dev->servicename = (char *)service_name;
   dev->profile = calloc (1, sizeof (edgex_deviceprofile));
   dev->profile->name = (char *)profile_name;

--- a/src/c/metadata.h
+++ b/src/c/metadata.h
@@ -95,6 +95,7 @@ void edgex_metadata_client_add_or_modify_device
   const devsdk_strings * labels,
   edgex_device_adminstate adminstate,
   devsdk_protocols * protocols,
+  edgex_device_autoevents * autos,
   const char * service_name,
   const char * profile_name
 );

--- a/src/c/service.c
+++ b/src/c/service.c
@@ -820,8 +820,8 @@ void devsdk_service_start (devsdk_service_t *svc, iot_data_t *driverdfls, devsdk
   if (svc->registry)
   {
     devsdk_error e;
-    devsdk_registry_query_service (svc->registry, "edgex-core-metadata", &svc->config.endpoints.metadata.host, &svc->config.endpoints.metadata.port, &e);
-    devsdk_registry_query_service (svc->registry, "edgex-core-data", &svc->config.endpoints.data.host, &svc->config.endpoints.data.port, &e);
+    devsdk_registry_query_service (svc->registry, "core-metadata", &svc->config.endpoints.metadata.host, &svc->config.endpoints.metadata.port, &e);
+    devsdk_registry_query_service (svc->registry, "core-data", &svc->config.endpoints.data.host, &svc->config.endpoints.data.port, &e);
   }
   else
   {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
No support for autoevent field in PWs
AutoEvent uses legacy `frequency` field
OperatingState update fails
Microservice names are prefixed with `edgex-`
Legacy port assignments in use by default
Discovery fails with segfault in the absence of labels for discovered devices

## Issue Number: #309 #310 


## What is the new behavior?
AutoEvents added to ProvisionWatchers
`interval` replaces `frequency`
Marshaling for operating state update request is corrected
Default ports moved to new assigned values
`null` checking added to discovery

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

AutoEvent specifications need to be updated with the renamed field (`interval`)
Port usage should be updated

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
