### PR TITLE
refactor: make reconfigure callback optional (#349)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ This is the C SDK for EdgeX. Its API is based largely on the Go SDK.
 
 Changes for 2.0.0 "Ireland":
 
+- v2 API update: reconfigure callback no longer mandatory
 - v2 API update: new callbacks for parsing attributes and protocol properties
 - Ports for EdgeX microservices are re-assigned, eg device services move from 499xx to 599xx.
 - Provision Watchers may include AutoEvents to be added on discovered devices.

--- a/README.v2.md
+++ b/README.v2.md
@@ -64,7 +64,6 @@ Mandatory:
 
 ```
 bool (*devsdk_initialize)
-void (*devsdk_reconfigure)
 bool (*devsdk_handle_get)
 bool (*devsdk_handle_put)
 void (*devsdk_stop)
@@ -79,6 +78,7 @@ Optional:
 ```
 void (*devsdk_discover)
 devsdk_device_resources * (*devsdk_describe)
+void (*devsdk_reconfigure)
 void * (*devsdk_autoevent_start_handler)
 void (*devsdk_autoevent_stop_handler)
 void (*devsdk_add_device_callback)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,10 +20,9 @@ Option | Type | Notes
 :--- | :--- | :---
 Host | String | This is the hostname to use when the service generates URLs pointing to itself. It must be resolvable by other services in the EdgeX deployment.
 Port | Int | Port on which to accept the device service's REST API. The assigned port for experimental / in-development device services is 59999.
-Timeout | Int | Time (in milliseconds) to wait between attempts to contact core-data and core-metadata when starting up.
-ConnectRetries | Int | Number of times to attempt to contact core-data and core-metadata when starting up.
+RequestTimeout | String | Time to wait while attempting to connect to other microservices. Use units of ms, s, m or h, eg '30s'.
 StartupMsg | String | Message to log on successful startup.
-CheckInterval | String | The checking interval to request if registering with Consul
+HealthCheckInterval | String | The checking interval to request if registering with Consul
 ServerBindAddr | String | The interface on which the service's REST server should listen. By default the server listens on all available interfaces.
 MaxRequestSize | Int | Amount of data beyond which the service will reject an incoming HTTP request. Zero (the default) disables checking.
 

--- a/docs/servicewritersguide.md
+++ b/docs/servicewritersguide.md
@@ -5,20 +5,15 @@ This document aims to complement the examples provided with the EdgeX C SDK by p
 Fundamentally a Device Service is composed of a number of callbacks. These callbacks are provided by the SDK to allow the service to respond to different events. The required callbacks are as follows:
 
 * init
-* reconfigure
 * get
 * put
 * stop
 
-A device service must provide an implementation of each callback, except for reconfigure (which may be NULL if the service has no driver-specific configuration). A small amount of setup is required of a device service, this is usually performed in the main. A devsdk_service_t should be created, containing, amongst other fields the devsdk_callbacks and an impldata pointer which is passed back every time a callback is invoked. The service must then call devsdk_service_new to create the device service, devsdk_service_start to start it, and upon exit the service should call devsdk_service_stop, followed by devsdk_service_free to clean up.
+A device service must provide an implementation of each callback. A small amount of setup is required of a device service, this is usually performed in the main. A devsdk_service_t should be created, containing, amongst other fields the devsdk_callbacks and an impldata pointer which is passed back every time a callback is invoked. The service must then call devsdk_service_new to create the device service, devsdk_service_start to start it, and upon exit the service should call devsdk_service_stop, followed by devsdk_service_free to clean up.
 
 Init
 ----
 Init is called when the device service starts up, its purpose is to perform protocol-specific initialization for the device service. This typically involves allocating memory for driver specific structures, initialising synchronisation mechanisms (mutex etc.) and setting up a logging client. The logging client is being provided to the implementation, most implementations will want to store the pointer in their impldata structure for later use. Any initialization required by the device should be performed here. 
-
-Reconfigure
------------
-If the Registry is in use, then dynamic updates to configuration are possible. If an element of the driver-specific configuration is changed, this callback will be invoked with the new configuration settings passed through.
 
 Get
 ---
@@ -72,5 +67,7 @@ Optional handlers
 An implementation may implement the device_added, device_updated and device_removed handlers, it will then be notified of changes to the extent of devices managed by the service. This may be helpful if special initialization / shutdown operations are required for optimal usage of the device.
 
 An implementation may also implement the ae_starter and ae_stopper callbacks, in which case it will become responsible for the AutoEvents functionality which is normally handled within the SDK. This facility is currently experimental, it may be useful in scenarios where the device can be set to generate readings autonomously.
+
+If the Registry is in use, then dynamic updates to configuration are possible. If the reconfiguration callback is registered, then when an element of the driver-specific configuration is changed, this callback will be invoked with the new configuration settings passed through.
 
 An implementation may also implement the discover callback. When this is called, the implementation should perform a scan for reachable devices, and register them using the devsdk_add_discovered_devices function.

--- a/include/devsdk/devsdk.h
+++ b/include/devsdk/devsdk.h
@@ -40,7 +40,7 @@ void devsdk_usage (void);
 typedef bool (*devsdk_initialize) (void *impl, struct iot_logger_t *lc, const iot_data_t *config);
 
 /**
- * @brief Function called when configuration is updated.
+ * @brief Optional callback function called when configuration is updated.
  * @param impl The context data passed in when the service was created.
  * @param config A string map containing the new configuration.
  */
@@ -229,7 +229,6 @@ typedef struct devsdk_callbacks devsdk_callbacks;
 devsdk_callbacks *devsdk_callbacks_init
 (
   devsdk_initialize init,
-  devsdk_reconfigure reconf,
   devsdk_handle_get gethandler,
   devsdk_handle_put puthandler,
   devsdk_stop stop,
@@ -244,6 +243,12 @@ devsdk_callbacks *devsdk_callbacks_init
  */
 
 void devsdk_callbacks_set_discovery (devsdk_callbacks *cb, devsdk_discover discover, devsdk_describe describe);
+
+/**
+ * @brief Populate optional reconfiguration function
+ */
+
+void devsdk_callbacks_set_reconfiguration (devsdk_callbacks *cb, devsdk_reconfigure reconf);
 
 /**
  * @brief Populate optional device notification functions

--- a/src/c/autoevent.c
+++ b/src/c/autoevent.c
@@ -32,29 +32,6 @@ typedef struct edgex_autoimpl
   bool onChange;
 } edgex_autoimpl;
 
-struct sfxstruct
-{
-  const char *str;
-  uint64_t factor;
-};
-
-static struct sfxstruct suffixes[] =
-  { { "ms", 1 }, { "s", 1000 }, { "m", 60000 }, { "h", 3600000 }, { NULL, 0 } };
-
-static uint64_t parseTime (const char *spec)
-{
-  char *fend;
-  uint64_t fnum = strtoul (spec, &fend, 10);
-  for (int i = 0; suffixes[i].str; i++)
-  {
-    if (strcmp (fend, suffixes[i].str) == 0)
-    {
-      return fnum * suffixes[i].factor;
-    }
-  }
-  return 0;
-}
-
 static void edgex_autoimpl_release (edgex_autoimpl *ai)
 {
   if (atomic_fetch_add (&ai->refs, -1) == 1)
@@ -181,7 +158,7 @@ void edgex_device_autoevent_start (devsdk_service_t *svc, edgex_device *dev)
         );
         continue;
       }
-      uint64_t interval = parseTime (ae->interval);
+      uint64_t interval = edgex_parsetime (ae->interval);
       if (interval == 0)
       {
         iot_log_error

--- a/src/c/config.h
+++ b/src/c/config.h
@@ -20,10 +20,9 @@ typedef struct edgex_device_serviceinfo
 {
   const char *host;
   uint16_t port;
-  uint32_t connectretries;
   char **labels;
   const char *startupmsg;
-  struct timespec timeout;
+  uint64_t timeout;
   const char *checkinterval;
   const char *bindaddr;
   uint64_t maxreqsz;

--- a/src/c/devsdk-base.c
+++ b/src/c/devsdk-base.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020
+ * Copyright (c) 2020-2021
  * IoTech Ltd
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -189,6 +189,29 @@ void devsdk_callbacks_set_autoevent_handlers (devsdk_callbacks *cb, devsdk_autoe
 {
   cb->ae_starter = ae_starter;
   cb->ae_stopper = ae_stopper;
+}
+
+struct sfx_struct
+{
+  const char *str;
+  uint64_t factor;
+};
+
+static struct sfx_struct time_suffixes[] =
+  { { "ms", 1 }, { "s", 1000 }, { "m", 60000 }, { "h", 3600000 }, { NULL, 0 } };
+
+uint64_t edgex_parsetime (const char *spec)
+{
+  char *fend;
+  uint64_t fnum = strtoul (spec, &fend, 10);
+  for (int i = 0; time_suffixes[i].str; i++)
+  {
+    if (strcmp (fend, time_suffixes[i].str) == 0)
+    {
+      return fnum * time_suffixes[i].factor;
+    }
+  }
+  return 0;
 }
 
 /* Macro for generating single-linked-list comparison functions.

--- a/src/c/devsdk-base.c
+++ b/src/c/devsdk-base.c
@@ -145,7 +145,6 @@ const iot_data_t *devsdk_protocols_properties (const devsdk_protocols *prots, co
 devsdk_callbacks *devsdk_callbacks_init
 (
   devsdk_initialize init,
-  devsdk_reconfigure reconf,
   devsdk_handle_get gethandler,
   devsdk_handle_put puthandler,
   devsdk_stop stop,
@@ -157,7 +156,6 @@ devsdk_callbacks *devsdk_callbacks_init
 {
   devsdk_callbacks *cb = calloc (1, sizeof (devsdk_callbacks));
   cb->init = init;
-  cb->reconfigure = reconf;
   cb->gethandler = gethandler;
   cb->puthandler = puthandler;
   cb->stop = stop;
@@ -172,6 +170,11 @@ void devsdk_callbacks_set_discovery (devsdk_callbacks *cb, devsdk_discover disco
 {
   cb->discover = discover;
   cb->describe = describe;
+}
+
+void devsdk_callbacks_set_reconfiguration (devsdk_callbacks *cb, devsdk_reconfigure reconf)
+{
+  cb->reconfigure = reconf;
 }
 
 void devsdk_callbacks_set_listeners

--- a/src/c/devutil.h
+++ b/src/c/devutil.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019
+ * Copyright (c) 2019-2021
  * IoTech Ltd
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -24,5 +24,7 @@ extern bool devsdk_protocols_equal (const devsdk_protocols *p1, const devsdk_pro
 extern bool edgex_device_autoevents_equal (const edgex_device_autoevents *e1, const edgex_device_autoevents *e2);
 
 extern void devsdk_free_resources (devsdk_device_resources *r);
+
+extern uint64_t edgex_parsetime (const char *spec);
 
 #endif

--- a/src/c/examples/bitfields/device-bitfields.c
+++ b/src/c/examples/bitfields/device-bitfields.c
@@ -132,7 +132,6 @@ int main (int argc, char * argv[])
   devsdk_callbacks *bitfieldImpls = devsdk_callbacks_init
   (
     bitfield_init,
-    NULL,
     bitfield_get_handler,
     bitfield_put_handler,
     bitfield_stop,

--- a/src/c/examples/bitfields/res/configuration.toml
+++ b/src/c/examples/bitfields/res/configuration.toml
@@ -7,11 +7,9 @@
 
 [Service]
   Port = 59999
-  Timeout = 5000
-  ConnectRetries = 10
-  Labels = [ 'Bitfields' ]
+  RequestTimeout = '5s'
   StartupMsg = 'Example bitfields device service started'
-  CheckInterval = '10s'
+  HealthCheckInterval = '10s'
 
 [Clients]
   [Clients.core-data]
@@ -23,5 +21,6 @@
     Port = 59881
 
 [Device]
+  Labels = [ 'Bitfields' ]
   ProfilesDir = 'res/profiles'
   DevicesDir = 'res/devices'

--- a/src/c/examples/counters/device-counter.c
+++ b/src/c/examples/counters/device-counter.c
@@ -174,7 +174,6 @@ int main (int argc, char *argv[])
   devsdk_callbacks *counterImpls = devsdk_callbacks_init
   (
     counter_init,
-    NULL,
     counter_get_handler,
     counter_put_handler,
     counter_stop,

--- a/src/c/examples/counters/res/configuration.toml
+++ b/src/c/examples/counters/res/configuration.toml
@@ -7,11 +7,9 @@
 
 [Service]
   Port = 59999
-  Timeout = 5000
-  ConnectRetries = 10
-  Labels = [ 'Counter' ]
+  RequestTimeout = '5s'
   StartupMsg = 'Example counting device started'
-  CheckInterval = '10s'
+  HealthCheckInterval = '10s'
 
 [Clients]
   [Clients.core-data]
@@ -23,5 +21,6 @@
     Port = 59881
 
 [Device]
+  Labels = [ 'Counter' ]
   ProfilesDir = 'res/profiles'
   DevicesDir = 'res/devices'

--- a/src/c/examples/discovery/res/configuration.toml
+++ b/src/c/examples/discovery/res/configuration.toml
@@ -10,11 +10,9 @@
 
 [Service]
   Port = 59999
-  Timeout = 5000
-  ConnectRetries = 10
-  Labels = [ 'Template' ]
+  RequestTimeout = '5s'
   StartupMsg = 'Template device started'
-  CheckInterval = '10s'
+  HealthCheckInterval = '10s'
 
 [Clients]
   [Clients.core-data]
@@ -30,4 +28,5 @@
   TestParam2 = 'World'
 
 [Device]
+  Labels = [ 'Template' ]
   ProfilesDir = 'res/profiles'

--- a/src/c/examples/discovery/template.c
+++ b/src/c/examples/discovery/template.c
@@ -266,7 +266,6 @@ int main (int argc, char *argv[])
   devsdk_callbacks *templateImpls = devsdk_callbacks_init
   (
     template_init,
-    template_reconfigure,
     template_get_handler,
     template_put_handler,
     template_stop,
@@ -276,6 +275,7 @@ int main (int argc, char *argv[])
     template_free_resource_attr
   );
   devsdk_callbacks_set_discovery (templateImpls, template_discover, NULL);
+  devsdk_callbacks_set_reconfiguration (templateImpls, template_reconfigure);
 
   /* Initalise a new device service */
   devsdk_service_t *service = devsdk_service_new

--- a/src/c/examples/file/device-file.c
+++ b/src/c/examples/file/device-file.c
@@ -145,7 +145,6 @@ int main (int argc, char *argv[])
   devsdk_callbacks *fileImpls = devsdk_callbacks_init
   (
     file_init,
-    NULL,
     file_get_handler,
     file_put_handler,
     file_stop,

--- a/src/c/examples/gyro/device-gyro.c
+++ b/src/c/examples/gyro/device-gyro.c
@@ -148,7 +148,6 @@ int main (int argc, char * argv[])
   devsdk_callbacks *gyroImpls = devsdk_callbacks_init
   (
     gyro_init,
-    NULL,
     gyro_get_handler,
     gyro_put_handler,
     gyro_stop,

--- a/src/c/examples/gyro/res/configuration.toml
+++ b/src/c/examples/gyro/res/configuration.toml
@@ -8,11 +8,9 @@
 
 [Service]
   Port = 59999
-  Timeout = 5000
-  ConnectRetries = 10
-  Labels = [ 'Gyro' ]
+  RequestTimeout = '5s'
   StartupMsg = 'Example gyro device service started'
-  CheckInterval = '10s'
+  HealthCheckInterval = '10s'
 
 [Clients]
   [Clients.core-data]
@@ -24,5 +22,6 @@
     Port = 59881
 
 [Device]
+  Labels = [ 'Gyro' ]
   ProfilesDir = 'res/profiles'
   DevicesDir = 'res/devices'

--- a/src/c/examples/random/device-random.c
+++ b/src/c/examples/random/device-random.c
@@ -170,7 +170,6 @@ int main (int argc, char *argv[])
   devsdk_callbacks *randomImpls = devsdk_callbacks_init
   (
     random_init,
-    NULL,
     random_get_handler,
     random_put_handler,
     random_stop,

--- a/src/c/examples/random/res/configuration.toml
+++ b/src/c/examples/random/res/configuration.toml
@@ -7,11 +7,9 @@
 
 [Service]
   Port = 59999
-  Timeout = 5000
-  ConnectRetries = 10
-  Labels = [ 'Random' ]
+  RequestTimeout = '5s'
   StartupMsg = 'Example random device started'
-  CheckInterval = '10s'
+  HealthCheckInterval = '10s'
 
 [Clients]
   [Clients.core-data]
@@ -23,5 +21,6 @@
     Port = 59881
 
 [Device]
+  Labels = [ 'Random' ]
   ProfilesDir = 'res/profiles'
   DevicesDir = 'res/devices'

--- a/src/c/examples/res/configuration.toml
+++ b/src/c/examples/res/configuration.toml
@@ -10,11 +10,9 @@
 
 [Service]
   Port = 59999
-  Timeout = 5000
-  ConnectRetries = 10
-  Labels = [ 'Template' ]
+  RequestTimeout = '5s'
   StartupMsg = 'Template device started'
-  CheckInterval = '10s'
+  HealthCheckInterval = '10s'
 
 [Clients]
   [Clients.core-data]
@@ -29,5 +27,6 @@
   TestParam1 = 'Hello'
 
 [Device]
+  Labels = [ 'Template' ]
   ProfilesDir = 'res/profiles'
   DevicesDir = 'res/devices'

--- a/src/c/examples/template.c
+++ b/src/c/examples/template.c
@@ -236,7 +236,6 @@ int main (int argc, char *argv[])
   devsdk_callbacks *templateImpls = devsdk_callbacks_init
   (
     template_init,
-    template_reconfigure,
     template_get_handler,
     template_put_handler,
     template_stop,
@@ -246,6 +245,7 @@ int main (int argc, char *argv[])
     template_free_resource_attr
   );
   devsdk_callbacks_set_discovery (templateImpls, template_discover, NULL);
+  devsdk_callbacks_set_reconfiguration (templateImpls, template_reconfigure);
 
   /* Initalise a new device service */
   devsdk_service_t *service = devsdk_service_new

--- a/src/c/examples/terminal/device-terminal.c
+++ b/src/c/examples/terminal/device-terminal.c
@@ -226,7 +226,6 @@ int main (int argc, char * argv[])
   devsdk_callbacks *terminalImpls = devsdk_callbacks_init
   (
     terminal_init,
-    NULL,
     terminal_get_handler,
     terminal_put_handler,
     terminal_stop,

--- a/src/c/examples/terminal/res/configuration.toml
+++ b/src/c/examples/terminal/res/configuration.toml
@@ -7,11 +7,9 @@
 
 [Service]
   Port = 59999
-  Timeout = 5000
-  ConnectRetries = 10
-  Labels = [ 'Counter' ]
+  RequestTimeout = '5s'
   StartupMsg = 'Example terminal device service started'
-  CheckInterval = '10s'
+  HealthCheckInterval = '10s'
 
 [Clients]
   [Clients.core-data]
@@ -23,5 +21,6 @@
     Port = 59881
 
 [Device]
+  Labels = [ 'Counter' ]
   ProfilesDir = 'res/profiles'
   DevicesDir = 'res/devices'


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Implementations must supply a callback function for dynamic reconfiguration even if they do not implement it

## Issue Number: #349 


## What is the new behavior?
Reconfigure callback made optional.
Some configuration elements also moved / renamed to match Go service behavior

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

DS implementations need to have their callback population code updated
Configuration files need updating with new names / groups

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->
Don't squash-merge

## Other information
