### PR TITLE
fix: MaxCmdOps of zero implies unlimited

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -88,7 +88,7 @@ Option | Type | Notes
 Protocol | String | The protocol to use. For MQTT this is `tcp` or `ssl`. Defaults to `tcp`. For Redis this should be `redis`.
 Host | String | The host on which the MQTT or Redis server is running. Defaults to `localhost`.
 Port | Unsigned Int | The port on which the MQTT or Redis server is running. Defaults to `1883` for MQTT or `6379` for Redis.
-Topic | String | The topic under which events are to be published. Defaults to `edgex/events` which results in events being published to `edgex/events/profile-name/device-name/source-name`. For Redis the `/` delimeter in topic names is replaced with `.`.
+PublishTopicPrefix | String | The topic under which events are to be published. Defaults to `edgex/events/device` which results in events being published to `edgex/events/device/profile-name/device-name/source-name`. For Redis the `/` delimeter in topic names is replaced with `.`.
 
 ### MessageQueue/Optional section
 

--- a/src/c/data-mqtt.c
+++ b/src/c/data-mqtt.c
@@ -17,7 +17,7 @@ void edgex_mqtt_config_defaults (iot_data_t *allconf)
   iot_data_string_map_add (allconf, EX_MQ_PROTOCOL, iot_data_alloc_string ("", IOT_DATA_REF));
   iot_data_string_map_add (allconf, EX_MQ_HOST, iot_data_alloc_string ("localhost", IOT_DATA_REF));
   iot_data_string_map_add (allconf, EX_MQ_PORT, iot_data_alloc_ui16 (0));
-  iot_data_string_map_add (allconf, EX_MQ_TOPIC, iot_data_alloc_string ("edgex/events", IOT_DATA_REF));
+  iot_data_string_map_add (allconf, EX_MQ_TOPIC, iot_data_alloc_string ("edgex/events/device", IOT_DATA_REF));
 
   iot_data_string_map_add (allconf, EX_MQ_USERNAME, iot_data_alloc_string ("", IOT_DATA_REF));
   iot_data_string_map_add (allconf, EX_MQ_PASSWORD, iot_data_alloc_string ("", IOT_DATA_REF));

--- a/src/c/data.h
+++ b/src/c/data.h
@@ -20,7 +20,7 @@
 #define EX_MQ_PROTOCOL "MessageQueue/Protocol"
 #define EX_MQ_HOST "MessageQueue/Host"
 #define EX_MQ_PORT "MessageQueue/Port"
-#define EX_MQ_TOPIC "MessageQueue/Topic"
+#define EX_MQ_TOPIC "MessageQueue/PublishTopicPrefix"
 #define EX_MQ_USERNAME "MessageQueue/Optional/Username"
 #define EX_MQ_PASSWORD "MessageQueue/Optional/Password"
 #define EX_MQ_CLIENTID "MessageQueue/Optional/ClientId"

--- a/src/c/device.c
+++ b/src/c/device.c
@@ -739,7 +739,7 @@ static void edgex_device_v2impl (devsdk_service_t *svc, edgex_device *dev, const
   {
     edgex_error_response (svc->logger, reply, MHD_HTTP_LOCKED, "Device %s is down", dev->name);
   }
-  else if (cmd->nreqs > svc->config.device.maxcmdops)
+  else if (svc->config.device.maxcmdops && (cmd->nreqs > svc->config.device.maxcmdops))
   {
     edgex_error_response (svc->logger, reply, MHD_HTTP_INTERNAL_SERVER_ERROR, "MaxCmdOps (%d) exceeded (%d) for command %s", svc->config.device.maxcmdops, cmd->nreqs, cmdname);
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Setting `MaxCmdOps` to zero disables reads


## Issue Number:


## What is the new behavior?
`MaxCmdOps` of zero results in no limits being applied
The (MessageBus)`Topic` configuration element is renamed to `PublishTopicPrefix` and its default value now includes the `device` element indicating messages which originate from a device service.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

New topic config and default as above; aligns behavior with that of go-mod-messaging in v2

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
