### PR TITLE
fix: avoid crash when deviceresource has no attributes

### DIFF
--- a/src/c/edgex-rest.c
+++ b/src/c/edgex-rest.c
@@ -122,9 +122,17 @@ static devsdk_nvpairs *nvpairs_read (const JSON_Object *obj)
 
 static iot_data_t *string_map_read (const JSON_Value *val)
 {
-  char *str = json_serialize_to_string (val);
-  iot_data_t *result = iot_data_from_json (str);
-  json_free_serialized_string (str);
+  iot_data_t *result;
+  if (val)
+  {
+    char *str = json_serialize_to_string (val);
+    result = iot_data_from_json (str);
+    json_free_serialized_string (str);
+  }
+  else
+  {
+    result = iot_data_alloc_map (IOT_DATA_STRING);
+  }
   return result;
 }
 

--- a/src/c/examples/template.c
+++ b/src/c/examples/template.c
@@ -34,11 +34,16 @@ static void dump_protocols (iot_logger_t *lc, const devsdk_protocols *prots)
 
 static void dump_attributes (iot_logger_t *lc, devsdk_resource_attr_t attrs)
 {
-  iot_data_map_iter_t iter;
-  iot_data_map_iter ((iot_data_t *)attrs, &iter);
-  while (iot_data_map_iter_next (&iter))
+  if (lc && lc->level >= IOT_LOG_DEBUG)
   {
-    iot_log_debug (lc, "    %s = %s", iot_data_map_iter_string_key (&iter), iot_data_map_iter_string_value (&iter));
+    iot_data_map_iter_t iter;
+    iot_data_map_iter ((iot_data_t *)attrs, &iter);
+    while (iot_data_map_iter_next (&iter))
+    {
+      char *json = iot_data_to_json (iot_data_map_iter_value (&iter));
+      iot_log_debug (lc, "    %s = %s", iot_data_map_iter_string_key (&iter), json);
+      free (json);
+    }
   }
 }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
When a device profile is parsed, if a device resource has no attributes, the SDK will segfault

## Issue Number:


## What is the new behavior?
SDK creates an empty attribute map if none have been specified

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
