### PR TITLE
feat: support EDGEX_USE_REGISTRY, EDGEX_STARTUP_DURATION, EDGEX_STARTUP_INTERVAL

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,8 @@ This is the C SDK for EdgeX device services.
 
 Changes for 2.0.1:
 
+- Fix segfault on startup when using MQTT for MessageQueue
+- Support EDGEX_STARTUP_DURATION, EDGEX_STARTUP_INTERVAL
 - Support EDGEX_USE_REGISTRY
 - Support credential loading from Hashicorp Vault
 

--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ This is the C SDK for EdgeX device services.
 
 Changes for 2.0.1:
 
+- Support EDGEX_USE_REGISTRY
 - Support credential loading from Hashicorp Vault
 
 Changes for 2.0.0 "Ireland":

--- a/include/devsdk/devsdk.h
+++ b/include/devsdk/devsdk.h
@@ -56,15 +56,17 @@ typedef void (*devsdk_reconfigure) (void *impl, const iot_data_t *config);
 typedef void (*devsdk_discover) (void *impl);
 
 /**
- * @brief Optional callback for dynamic discovery of device resources. The
- * implementation should return a linked list of resources available on the
- * specified device.
- * @param devname The name of the device being queried
- * @param protocols The location of the device being queried
- * @returns The discovered resources
+ * @brief Optional callback for dynamic discovery of device resources.
+ * @param impl The context data passed in when the service was created.
+ * @param dev The details of the device to be queried.
+ * @param options Service specific discovery options map. May be NULL.
+ * @param resources The operations supported by the device.
+ * @param exception Set this to an IOT_DATA_STRING to give more information if the operation fails.
+ * @return true if the operation was successful, false otherwise.
  */
 
-typedef devsdk_device_resources * (*devsdk_describe) (void *impl, const devsdk_device_t *dev);
+typedef bool (*devsdk_describe)
+  (void *impl, const devsdk_device_t *dev, const iot_data_t *options, devsdk_device_resources **resources, iot_data_t **exception);
 
 /**
  * @brief Callback issued for parsing device addresses.

--- a/src/c/data-mqtt.h
+++ b/src/c/data-mqtt.h
@@ -11,11 +11,12 @@
 
 #include "parson.h"
 #include "data.h"
+#include "devutil.h"
 
 void edgex_mqtt_config_defaults (iot_data_t *allconf);
 
 JSON_Value *edgex_mqtt_config_json (const iot_data_t *allconf);
 
-edgex_data_client_t *edgex_data_client_new_mqtt (const iot_data_t *allconf, iot_logger_t *lc, iot_threadpool_t *queue);
+edgex_data_client_t *edgex_data_client_new_mqtt (const iot_data_t *allconf, iot_logger_t *lc, const devsdk_timeout *tm, iot_threadpool_t *queue);
 
 #endif

--- a/src/c/data-redstr.h
+++ b/src/c/data-redstr.h
@@ -11,9 +11,10 @@
 
 #include "parson.h"
 #include "data.h"
+#include "devutil.h"
 
 JSON_Value *edgex_redstr_config_json (const iot_data_t *allconf);
 
-edgex_data_client_t *edgex_data_client_new_redstr (const iot_data_t *allconf, iot_logger_t *lc, iot_threadpool_t *queue);
+edgex_data_client_t *edgex_data_client_new_redstr (const iot_data_t *allconf, iot_logger_t *lc, const devsdk_timeout *tm, iot_threadpool_t *queue);
 
 #endif

--- a/src/c/devsdk-base.c
+++ b/src/c/devsdk-base.c
@@ -214,6 +214,32 @@ uint64_t edgex_parsetime (const char *spec)
   return 0;
 }
 
+void devsdk_wait_msecs (uint64_t duration)
+{
+  struct timespec tm, rem;
+  tm.tv_sec = duration / 1000;
+  tm.tv_nsec = 1000000 * (duration % 1000);
+  while (nanosleep (&tm, &rem) == -1 && errno == EINTR)
+  {
+    tm = rem;
+  }
+}
+
+unsigned long devsdk_strtoul_dfl (const char *val, unsigned long dfl)
+{
+  if (val && *val)
+  {
+    char *end = NULL;
+    errno = 0;
+    unsigned long l = strtoul (val, &end, 0);
+    if (errno == 0 && *end == 0)
+    {
+      return l;
+    }
+  }
+  return dfl;
+}
+
 /* Macro for generating single-linked-list comparison functions.
  * Assumes a "next" pointer and that the key (name) field is a string.
  */

--- a/src/c/devutil.h
+++ b/src/c/devutil.h
@@ -19,6 +19,12 @@ struct devsdk_protocols
   struct devsdk_protocols *next;
 };
 
+typedef struct
+{
+  uint64_t deadline;
+  unsigned interval;
+} devsdk_timeout;
+
 extern bool devsdk_protocols_equal (const devsdk_protocols *p1, const devsdk_protocols *p2);
 
 extern bool edgex_device_autoevents_equal (const edgex_device_autoevents *e1, const edgex_device_autoevents *e2);
@@ -26,5 +32,9 @@ extern bool edgex_device_autoevents_equal (const edgex_device_autoevents *e1, co
 extern void devsdk_free_resources (devsdk_device_resources *r);
 
 extern uint64_t edgex_parsetime (const char *spec);
+
+extern void devsdk_wait_msecs (uint64_t duration);
+
+extern unsigned long devsdk_strtoul_dfl (const char *val, unsigned long dfl);
 
 #endif

--- a/src/c/registry.h
+++ b/src/c/registry.h
@@ -16,6 +16,7 @@
 
 #include "devsdk/devsdk-base.h"
 #include "edgex/edgex-base.h"
+#include "devutil.h"
 #include "iot/threadpool.h"
 
 /* Callback for dynamic configuration */
@@ -221,14 +222,13 @@ devsdk_registry *devsdk_registry_get_registry
 bool devsdk_registry_ping (devsdk_registry *registry, devsdk_error *err);
 
 /**
- * @brief Wait for the registry service to be running. The time to wait is
- *        controlled by the EDGEX_STARTUP_INTERVAL and EDGEX_STARTUP_DURATION
- *        environment variables.
+ * @brief Wait for the registry service to be running.
  * @param registry The registry instance.
+ * @param deadline How long to wait.
  * @returns true if the registry service is running after waiting.
  */
 
-bool devsdk_registry_waitfor (devsdk_registry *registry);
+bool devsdk_registry_waitfor (devsdk_registry *registry, const devsdk_timeout *deadline);
 
 /**
  * @brief Retrieve configuration values from the registry.

--- a/src/c/service.c
+++ b/src/c/service.c
@@ -103,6 +103,22 @@ static void checkEnv (const char **setting, const char *varname)
   }
 }
 
+static void checkEnvBool (bool *setting, const char *varname)
+{
+  const char *val = getenv (varname);
+  if (val)
+  {
+    if (strcmp (val, "true") == 0)
+    {
+      *setting = true;
+    }
+    else if (strcmp (val, "false") == 0)
+    {
+      *setting = false;
+    }
+  }
+}
+
 static bool processCmdLine (int *argc_p, char **argv, devsdk_service_t *svc)
 {
   bool result = true;
@@ -162,6 +178,7 @@ static bool processCmdLine (int *argc_p, char **argv, devsdk_service_t *svc)
   checkEnv (&svc->confdir, "EDGEX_CONF_DIR");
   checkEnv (&svc->conffile, "EDGEX_CONFIG_FILE");
   checkEnv ((const char **)&svc->name, "EDGEX_INSTANCE_NAME");
+  checkEnvBool (&usereg, "EDGEX_USE_REGISTRY");
 
   if (usereg)
   {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Standard environment variables listed are ignored
SDK crashes on startup when MQTT is selected as the MessageQueue

## Issue Number:
#361 

## What is the new behavior?
Startup is controlled via the standard environment variables. MQTT initialization no longer refers to nonexistent configuration entries.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [ ] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
