### PR TITLE
fix: reduce startup logging by default (#370)

### DIFF
--- a/docs/startup.md
+++ b/docs/startup.md
@@ -50,3 +50,7 @@ Two additional environment variables control the retry behavior when contacting 
 |-|-|
 `EDGEX_STARTUP_DURATION` | sets the amount of time (in seconds) in which to attempt to connect to the registry before abandoning startup
 `EDGEX_STARTUP_INTERVAL` | sets the interval (in seconds) between attempts to connect to the registry
+
+## Logging
+
+The default log level during startup is INFO. The log level is controlled by the `[Writable]/LogLevel` configuration entry. If debugging of the service startup (before the configuration has been read) is required, the override environment variable `WRITABLE_LOGLEVEL` should be set to the desired level name.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,7 +5,7 @@ CPPCHECK=false
 DOCGEN=false
 
 TOMLVER=SDK-0.2
-CUTILVER=1.1.4
+CUTILVER=1.2.2
 
 # Process arguments
 

--- a/src/c/config.c
+++ b/src/c/config.c
@@ -144,21 +144,17 @@ toml_table_t *edgex_device_loadConfig (iot_logger_t *lc, const char *path, devsd
 static void edgex_config_setloglevel (iot_logger_t *lc, const char *lstr, iot_loglevel_t *result)
 {
   iot_loglevel_t l;
-  for (l = IOT_LOG_ERROR; l <= IOT_LOG_TRACE; l++)
+  if (edgex_logger_nametolevel (lstr, &l))
   {
-    if (strcasecmp (lstr, edgex_logger_levelname (l)) == 0)
+    if (*result != l)
     {
-      if (*result != l)
-      {
-        *result = l;
-        iot_logger_set_level (lc, IOT_LOG_INFO);
-        iot_log_info (lc, "Setting LogLevel to %s", lstr);
-        iot_logger_set_level (lc, l);
-      }
-      break;
+      *result = l;
+      iot_logger_set_level (lc, IOT_LOG_INFO);
+      iot_log_info (lc, "Setting LogLevel to %s", lstr);
+      iot_logger_set_level (lc, l);
     }
   }
-  if (l > IOT_LOG_TRACE)
+  else
   {
     iot_log_error (lc, "Invalid LogLevel %s", lstr);
   }

--- a/src/c/data-mqtt.c
+++ b/src/c/data-mqtt.c
@@ -305,7 +305,7 @@ edgex_data_client_t *edgex_data_client_new_mqtt (const iot_data_t *allconf, iot_
       }
       if (tm->interval > t2 - t1)
       {
-        devsdk_wait_msecs (tm->interval - (t2 - t1));
+        iot_wait_msecs (tm->interval - (t2 - t1));
       }
     }
   }

--- a/src/c/data-redstr.c
+++ b/src/c/data-redstr.c
@@ -160,7 +160,7 @@ edgex_data_client_t *edgex_data_client_new_redstr (const iot_data_t *allconf, io
     }
     if (tm->interval > t2 - t1)
     {
-      devsdk_wait_msecs (tm->interval - (t2 - t1));
+      iot_wait_msecs (tm->interval - (t2 - t1));
     }
   }
   if (cinfo->ctx == NULL || cinfo->ctx->err)

--- a/src/c/devsdk-base.c
+++ b/src/c/devsdk-base.c
@@ -214,17 +214,6 @@ uint64_t edgex_parsetime (const char *spec)
   return 0;
 }
 
-void devsdk_wait_msecs (uint64_t duration)
-{
-  struct timespec tm, rem;
-  tm.tv_sec = duration / 1000;
-  tm.tv_nsec = 1000000 * (duration % 1000);
-  while (nanosleep (&tm, &rem) == -1 && errno == EINTR)
-  {
-    tm = rem;
-  }
-}
-
 unsigned long devsdk_strtoul_dfl (const char *val, unsigned long dfl)
 {
   if (val && *val)

--- a/src/c/devutil.h
+++ b/src/c/devutil.h
@@ -33,8 +33,6 @@ extern void devsdk_free_resources (devsdk_device_resources *r);
 
 extern uint64_t edgex_parsetime (const char *spec);
 
-extern void devsdk_wait_msecs (uint64_t duration);
-
 extern unsigned long devsdk_strtoul_dfl (const char *val, unsigned long dfl);
 
 #endif

--- a/src/c/edgex-logging.c
+++ b/src/c/edgex-logging.c
@@ -20,16 +20,18 @@
 
 static const char *edgex_log_levels[] = {"", "ERROR", "WARNING", "INFO", "DEBUG", "TRACE"};
 
-void edgex_log_tostdout (struct iot_logger_t * logger, iot_loglevel_t l, time_t timestamp, const char *message)
+void edgex_log_tostdout (struct iot_logger_t * logger, iot_loglevel_t l, uint64_t timestamp, const char *message)
 {
+  time_t ts;
   struct tm tsparts;
   char ts8601[EDGEX_TSIZE];
   const char *crlid;
   const char *lname;
 
+  ts = timestamp / 1000000U;
   crlid = edgex_device_get_crlid ();
   lname = logger->name ? logger->name : "(default)";
-  gmtime_r (&timestamp, &tsparts);
+  gmtime_r (&ts, &tsparts);
   strftime (ts8601, EDGEX_TSIZE, "%FT%TZ", &tsparts);
 
   printf ("level=%s ts=%s app=%s%s%s msg=\"%s\"\n", edgex_logger_levelname (l), ts8601, lname, crlid ? " correlation-id=" : "", crlid ? crlid : "", message);

--- a/src/c/edgex-logging.c
+++ b/src/c/edgex-logging.c
@@ -44,3 +44,17 @@ const char *edgex_logger_levelname (iot_loglevel_t l)
   assert (l >= IOT_LOG_NONE && l <= IOT_LOG_TRACE);
   return edgex_log_levels[l];
 }
+
+bool edgex_logger_nametolevel (const char *lstr, iot_loglevel_t *level)
+{
+  iot_loglevel_t l;
+  for (l = IOT_LOG_ERROR; l <= IOT_LOG_TRACE; l++)
+  {
+    if (strcasecmp (lstr, edgex_log_levels[l]) == 0)
+    {
+      *level = l;
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/c/edgex-logging.h
+++ b/src/c/edgex-logging.h
@@ -13,7 +13,7 @@
 
 /* Write to stdout */
 
-extern void edgex_log_tostdout (struct iot_logger_t *logger, iot_loglevel_t l, time_t timestamp, const char *message);
+extern void edgex_log_tostdout (struct iot_logger_t *logger, iot_loglevel_t l, uint64_t timestamp, const char *message);
 
 /* Get name of log level */
 

--- a/src/c/edgex-logging.h
+++ b/src/c/edgex-logging.h
@@ -19,4 +19,8 @@ extern void edgex_log_tostdout (struct iot_logger_t *logger, iot_loglevel_t l, u
 
 extern const char * edgex_logger_levelname (iot_loglevel_t level);
 
+/* Get level for name */
+
+extern bool edgex_logger_nametolevel (const char *lstr, iot_loglevel_t *level);
+
 #endif

--- a/src/c/metadata.c
+++ b/src/c/metadata.c
@@ -328,7 +328,7 @@ void edgex_metadata_client_add_profile_jobj (iot_logger_t *lc, edgex_service_end
 {
   if (!json_object_get_string (jobj, "apiVersion"))
   {
-    json_object_set_string (jobj, "apiVersion", "2");
+    json_object_set_string (jobj, "apiVersion", "v2");
   }
   JSON_Value *reqval = edgex_wrap_request ("Profile", json_object_get_wrapping_value (jobj));
   char *json = json_serialize_to_string (reqval);
@@ -365,7 +365,7 @@ void edgex_metadata_client_add_device_jobj (iot_logger_t *lc, edgex_service_endp
   }
   if (!json_object_get_string (jobj, "apiVersion"))
   {
-    json_object_set_string (jobj, "apiVersion", "2");
+    json_object_set_string (jobj, "apiVersion", "v2");
   }
   JSON_Value *reqval = edgex_wrap_request ("Device", json_object_get_wrapping_value (jobj));
   char *json = json_serialize_to_string (reqval);

--- a/src/c/registry.c
+++ b/src/c/registry.c
@@ -142,7 +142,7 @@ bool devsdk_registry_waitfor (devsdk_registry *registry, const devsdk_timeout *t
     }
     if (timeout->interval > t2 - t1)
     {
-      devsdk_wait_msecs (timeout->interval - (t2 - t1));
+      iot_wait_msecs (timeout->interval - (t2 - t1));
     }
   }
 }

--- a/src/c/service.c
+++ b/src/c/service.c
@@ -239,7 +239,13 @@ static char *devsdk_service_confpath (const char *dir, const char *fname, const 
 devsdk_service_t *devsdk_service_new
   (const char *defaultname, const char *version, void *impldata, devsdk_callbacks *implfns, int *argc, char **argv, devsdk_error *err)
 {
-  iot_logger_t *logger = iot_logger_alloc_custom (defaultname, IOT_LOG_TRACE, "", edgex_log_tostdout, NULL, true);
+  iot_loglevel_t ll = IOT_LOG_INFO;
+  const char *llstr = getenv ("WRITABLE_LOGLEVEL");
+  if (llstr)
+  {
+    edgex_logger_nametolevel (llstr, &ll);
+  }
+  iot_logger_t *logger = iot_logger_alloc_custom (defaultname, ll, "", edgex_log_tostdout, NULL, true);
   if (impldata == NULL)
   {
     iot_log_error (logger, "devsdk_service_new: no implementation object");
@@ -263,6 +269,7 @@ devsdk_service_t *devsdk_service_new
   devsdk_service_t *result = malloc (sizeof (devsdk_service_t));
   memset (result, 0, sizeof (devsdk_service_t));
   result->logger = logger;
+  result->config.loglevel = ll;
 
   if (!processCmdLine (argc, argv, result))
   {

--- a/src/c/service.c
+++ b/src/c/service.c
@@ -367,7 +367,7 @@ static bool ping_client (iot_logger_t *lc, const char *sname, edgex_device_servi
     }
     if (timeout->interval > t2 - t1)
     {
-      devsdk_wait_msecs (timeout->interval - (t2 - t1));
+      iot_wait_msecs (timeout->interval - (t2 - t1));
     }
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Initial log level is set to TRACE resulting in much output during startup

## Issue Number: #370 


## What is the new behavior?
Initial log level defaults to INFO. The service reads the override variable for log level early, so detailed startup logs may still be obtained.
This PR also brings the latest version of the utils dependency

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
