### PR TITLE
fix: stop device autoevents before releasing memory

### DIFF
--- a/scripts/Dockerfile.alpine-base
+++ b/scripts/Dockerfile.alpine-base
@@ -51,5 +51,4 @@ RUN apk add --update --no-cache build-base wget git gcc cmake make yaml curl lib
 COPY --from=builder /usr/local/include/iot /usr/local/include/iot
 COPY --from=builder /usr/local/include/edgex /usr/local/include/edgex
 COPY --from=builder /usr/local/lib /usr/local/lib
-COPY --from=builder /usr/local/lib64 /usr/local/lib64
 COPY --from=builder /usr/local/share/device-sdk-c /usr/local/share/device-sdk-c

--- a/src/c/autoevent.h
+++ b/src/c/autoevent.h
@@ -14,6 +14,5 @@
 void edgex_device_autoevent_start (devsdk_service_t *svc, edgex_device *dev);
 
 void edgex_device_autoevent_stop (edgex_device *dev);
-void edgex_device_autoevent_stop_now (edgex_device *dev);
 
 #endif

--- a/src/c/edgex-rest.c
+++ b/src/c/edgex-rest.c
@@ -432,16 +432,20 @@ static edgex_deviceresource *deviceresource_read
 static edgex_deviceresource *edgex_deviceresource_dup (const edgex_deviceresource *e)
 {
   edgex_deviceresource *result = NULL;
-  if (e)
+  edgex_deviceresource **current = &result;
+  while (e)
   {
-    result = malloc (sizeof (edgex_deviceresource));
-    result->name = strdup (e->name);
-    result->description = strdup (e->description);
-    result->tag = strdup (e->tag);
-    result->properties = propertyvalue_dup (e->properties);
-    result->attributes = iot_data_copy (e->attributes);
-    result->parsed_attrs = NULL;
-    result->next = edgex_deviceresource_dup (e->next);
+    edgex_deviceresource *elem = malloc (sizeof (edgex_deviceresource));
+    elem->name = strdup (e->name);
+    elem->description = strdup (e->description);
+    elem->tag = strdup (e->tag);
+    elem->properties = propertyvalue_dup (e->properties);
+    elem->attributes = iot_data_copy (e->attributes);
+    elem->parsed_attrs = NULL;
+    elem->next = NULL;
+    *current = elem;
+    current = &(elem->next);
+    e = e->next;
   }
   return result;
 }
@@ -478,17 +482,20 @@ static edgex_resourceoperation *resourceoperation_read (const JSON_Object *obj)
   return result;
 }
 
-static edgex_resourceoperation *resourceoperation_dup
-  (const edgex_resourceoperation *ro)
+static edgex_resourceoperation *resourceoperation_dup (const edgex_resourceoperation *ro)
 {
   edgex_resourceoperation *result = NULL;
-  if (ro)
+  edgex_resourceoperation **current = &result;
+  while (ro)
   {
-    result = malloc (sizeof (edgex_resourceoperation));
-    result->deviceResource = strdup (ro->deviceResource);
-    result->defaultValue = strdup (ro->defaultValue);
-    result->mappings = devsdk_nvpairs_dup (ro->mappings);
-    result->next = resourceoperation_dup (ro->next);
+    edgex_resourceoperation *elem = malloc (sizeof (edgex_resourceoperation));
+    elem->deviceResource = strdup (ro->deviceResource);
+    elem->defaultValue = strdup (ro->defaultValue);
+    elem->mappings = devsdk_nvpairs_dup (ro->mappings);
+    elem->next = NULL;
+    *current = elem;
+    current = &(elem->next);
+    ro = ro->next;
   }
   return result;
 }
@@ -533,14 +540,18 @@ static edgex_devicecommand *devicecommand_read (const JSON_Object *obj)
 static edgex_devicecommand *devicecommand_dup (const edgex_devicecommand *pr)
 {
   edgex_devicecommand *result = NULL;
-  if (pr)
+  edgex_devicecommand **current = &result;
+  while (pr)
   {
-    result = malloc (sizeof (edgex_devicecommand));
-    result->name = strdup (pr->name);
-    result->readable = pr->readable;
-    result->writable = pr->writable;
-    result->resourceOperations = resourceoperation_dup (pr->resourceOperations);
-    result->next = devicecommand_dup (pr->next);
+    edgex_devicecommand *elem = malloc (sizeof (edgex_devicecommand));
+    elem->name = strdup (pr->name);
+    elem->readable = pr->readable;
+    elem->writable = pr->writable;
+    elem->resourceOperations = resourceoperation_dup (pr->resourceOperations);
+    elem->next = NULL;
+    *current = elem;
+    current = &(elem->next);
+    pr = pr->next;
   }
   return result;
 }
@@ -656,9 +667,9 @@ edgex_deviceprofile *edgex_deviceprofile_read (iot_logger_t *lc, const char *jso
 
 static void cmdinfo_free (edgex_cmdinfo *inf)
 {
-  if (inf)
+  while (inf)
   {
-    cmdinfo_free (inf->next);
+    edgex_cmdinfo *next = inf->next;
     for (unsigned i = 0; i < inf->nreqs; i++)
     {
       free (inf->reqs[i].resource);
@@ -668,6 +679,7 @@ static void cmdinfo_free (edgex_cmdinfo *inf)
     free (inf->maps);
     free (inf->dfls);
     free (inf);
+    inf = next;
   }
 }
 
@@ -703,26 +715,31 @@ static edgex_device_autoevents *autoevents_dup
   (const edgex_device_autoevents *e)
 {
   edgex_device_autoevents *result = NULL;
-  if (e)
+  edgex_device_autoevents **current = &result;
+  while (e)
   {
-    result = malloc (sizeof (edgex_device_autoevents));
-    result->resource = strdup (e->resource);
-    result->interval = strdup (e->interval);
-    result->onChange = e->onChange;
-    result->impl = NULL;
-    result->next = autoevents_dup (e->next);
+    edgex_device_autoevents *elem = malloc (sizeof (edgex_device_autoevents));
+    elem->resource = strdup (e->resource);
+    elem->interval = strdup (e->interval);
+    elem->onChange = e->onChange;
+    elem->impl = NULL;
+    elem->next = NULL;
+    *current = elem;
+    current = &(elem->next);
+    e = e->next;
   }
   return result;
 }
 
 void edgex_device_autoevents_free (edgex_device_autoevents *e)
 {
-  if (e)
+  while (e)
   {
+    edgex_device_autoevents *next = e->next;
     free (e->resource);
     free (e->interval);
-    edgex_device_autoevents_free (e->next);
     free (e);
+    e = next;
   }
 }
 
@@ -770,12 +787,13 @@ devsdk_protocols *devsdk_protocols_dup (const devsdk_protocols *e)
 
 void devsdk_protocols_free (devsdk_protocols *e)
 {
-  if (e)
+  while (e)
   {
+    devsdk_protocols *next = e->next;
     free (e->name);
     iot_data_free (e->properties);
-    devsdk_protocols_free (e->next);
     free (e);
+    e = next;
   }
 }
 


### PR DESCRIPTION
refac: eliminate recursion from dup/free list functions



<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Invalid reads may be observed in the main branch by running the template example under valgrind and removing Device1

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->