### PR TITLE
Fix: Remove trailing null from MQTT message envelope (383)

### DIFF
--- a/src/c/data-mqtt.c
+++ b/src/c/data-mqtt.c
@@ -135,7 +135,7 @@ static void edc_mqtt_postfn (iot_logger_t *lc, void *address, edgex_event_cooked
 
   json = json_serialize_to_string (val);
   pubmsg.payload = json;
-  pubmsg.payloadlen = strlen (json) + 1;
+  pubmsg.payloadlen = strlen (json);
   pubmsg.qos = cinfo->qos;
   pubmsg.retained = cinfo->retained;
   opts.context = cinfo;


### PR DESCRIPTION
MQTT library appears to include entire payload length including trailing
null. The events are being rejected by core-data with unmarshal errors.

Signed-off-by: Corey Mutter <CoreyMutter@eaton.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [*] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [*] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) (seems too trivial)
- [*] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) (no doc change)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->