### PR TITLE
fix: retry attempts to resolve service endpoints from registry (#394)

### DIFF
--- a/src/c/registry.h
+++ b/src/c/registry.h
@@ -315,6 +315,7 @@ void devsdk_registry_query_service
   const char *servicename,
   char **hostname,
   uint16_t *port,
+  const devsdk_timeout *timeout,
   devsdk_error *err
 );
 


### PR DESCRIPTION
Signed-off-by: Iain Anderson <iain@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)   - No unit tests in CSDK
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)  - no doc change required
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Run the template example with --registry flag and with consul running but no core-data/core-metadata. Service startup should time out. Then try again but manually start core-data and core-metadata during the retry window (by default, a minute)
## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->