### PR TITLE
fix: Update HTTP callback expectations and responses to v2 API. (#419…

### DIFF
--- a/src/c/callback2.c
+++ b/src/c/callback2.c
@@ -22,7 +22,7 @@ void edgex_device_handler_callback_service (void *ctx, const devsdk_http_request
 {
   devsdk_service_t *svc = (devsdk_service_t *) ctx;
 
-  edgex_deviceservice *ds = edgex_deviceservice_read (req->data.bytes);
+  edgex_deviceservice *ds = edgex_getDSresponse_read (req->data.bytes);
   if (ds)
   {
     if (svc->adminstate != ds->adminState)
@@ -31,7 +31,9 @@ void edgex_device_handler_callback_service (void *ctx, const devsdk_http_request
       iot_log_info (svc->logger, "Service AdminState now %s", svc->adminstate == LOCKED ? "LOCKED" : "UNLOCKED");
     }
     edgex_deviceservice_free (ds);
-    reply->code = MHD_HTTP_NO_CONTENT;
+    edgex_baseresponse br;
+    edgex_baseresponse_populate (&br, "v2", MHD_HTTP_OK, "");
+    edgex_baseresponse_write (&br, reply);
   }
   else
   {
@@ -43,12 +45,14 @@ void edgex_device_handler_callback_profile (void *ctx, const devsdk_http_request
 {
   devsdk_service_t *svc = (devsdk_service_t *) ctx;
 
-  edgex_deviceprofile *p = edgex_deviceprofile_read (svc->logger, req->data.bytes);
+  edgex_deviceprofile *p = edgex_getprofileresponse_read (svc->logger, req->data.bytes);
   if (p)
   {
     edgex_devmap_update_profile (svc, p);
     iot_log_info (svc->logger, "callback: Updated device profile %s", p->name);
-    reply->code = MHD_HTTP_NO_CONTENT;
+    edgex_baseresponse br;
+    edgex_baseresponse_populate (&br, "v2", MHD_HTTP_OK, "");
+    edgex_baseresponse_write (&br, reply);
   }
   else
   {
@@ -169,7 +173,9 @@ void edgex_device_handler_callback_device_name (void *ctx, const devsdk_http_req
 
   if (found)
   {
-    reply->code = MHD_HTTP_NO_CONTENT;
+    edgex_baseresponse br;
+    edgex_baseresponse_populate (&br, "v2", MHD_HTTP_OK, "");
+    edgex_baseresponse_write (&br, reply);
   }
   else
   {
@@ -186,7 +192,9 @@ void edgex_device_handler_callback_watcher_name (void *ctx, const devsdk_http_re
 
   if (edgex_watchlist_remove_watcher (svc->watchlist, name))
   {
-    reply->code = MHD_HTTP_NO_CONTENT;
+    edgex_baseresponse br;
+    edgex_baseresponse_populate (&br, "v2", MHD_HTTP_OK, "");
+    edgex_baseresponse_write (&br, reply);
   }
   else
   {


### PR DESCRIPTION
…) (#420)

The service-update and profile-update callbacks were silently failing to
do anything. The callbacks returning "No Content" caused nuisance error
messages in core-metadata's logs.

Closes: #419, #420

Signed-off-by: Corey Mutter <CoreyMutter@eaton.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) None before
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

With included device-random hooked up to an EdgeX 2.0 installation, if you set the service adminState from the UI you will see an info-log message from the service with the new state (previously: none at all), if you update a device profile you will see the name of the profile appear in the info-log message from the service (previously: name appeared as empty string, internal profile map never got updated). 

Also there are now no "unexpected end of JSON input" error messages in core-metadata's log due to this service.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->