### PR TITLE
feat: add ProtocolProperties validation (#402)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ This is the C SDK for EdgeX device services.
 
 Changes for 2.2.0 "Kamakura":
 
+- Implement ProtocolProperties validation
 - Implement secure Consul access using tokens from Vault
 - Add CORS support
 - Implement secure messagebus connections

--- a/docs/servicewritersguide.md
+++ b/docs/servicewritersguide.md
@@ -71,3 +71,5 @@ An implementation may also implement the ae_starter and ae_stopper callbacks, in
 If the Registry is in use, then dynamic updates to configuration are possible. If the reconfiguration callback is registered, then when an element of the driver-specific configuration is changed, this callback will be invoked with the new configuration settings passed through.
 
 An implementation may also implement the discover callback. When this is called, the implementation should perform a scan for reachable devices, and register them using the devsdk_add_discovered_devices function.
+
+An implementation may also implement the validate_address callback. This is called when a device is added to the system. The function should check that the protocol properties given for a device are valid, and if not, return an exception (in which case the device addition will be aborted).

--- a/include/devsdk/devsdk.h
+++ b/include/devsdk/devsdk.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020
+ * Copyright (c) 2020-2022
  * IoTech Ltd
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -85,6 +85,15 @@ typedef devsdk_address_t (*devsdk_create_address) (void *impl, const devsdk_prot
  */
 
 typedef void (*devsdk_free_address) (void *impl, devsdk_address_t address);
+
+/**
+ * @brief Callback issued for validating device addresses.
+ * @param impl The context data passed in when the service was created.
+ * @param protocols The protocol properties for the device.
+ * @param exception Set this to an IOT_DATA_STRING to give details if the protocol properties are invalid
+ */
+
+typedef void (*devsdk_validate_address) (void *impl, const devsdk_protocols *protocols, iot_data_t **exception);
 
 /**
  * @brief Callback issued for parsing device resource attributes. 
@@ -264,6 +273,12 @@ void devsdk_callbacks_set_listeners
  */
 
 void devsdk_callbacks_set_autoevent_handlers (devsdk_callbacks *cb, devsdk_autoevent_start_handler ae_starter, devsdk_autoevent_stop_handler ae_stopper);
+
+/**
+ * @brief Populate optional device address validation function
+ */
+
+extern void devsdk_callbacks_set_validate_addr (devsdk_callbacks *cb, devsdk_validate_address validate_addr);
 
 /**
  * @brief Create a new device service.

--- a/src/c/api.h
+++ b/src/c/api.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020
+ * Copyright (c) 2020-2022
  * IoTech Ltd
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -25,6 +25,7 @@
 #define EDGEX_DEV_API2_CALLBACK_WATCHER "/api/v2/callback/watcher"
 #define EDGEX_DEV_API2_CALLBACK_WATCHER_NAME "/api/v2/callback/watcher/name/{name}"
 #define EDGEX_DEV_API2_CALLBACK_SERVICE "/api/v2/callback/service"
+#define EDGEX_DEV_API2_VALIDATE_ADDR "/api/v2/validate/device"
 
 /* Query parameters */
 

--- a/src/c/devsdk-base.c
+++ b/src/c/devsdk-base.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021
+ * Copyright (c) 2020-2022
  * IoTech Ltd
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -189,6 +189,11 @@ void devsdk_callbacks_set_autoevent_handlers (devsdk_callbacks *cb, devsdk_autoe
 {
   cb->ae_starter = ae_starter;
   cb->ae_stopper = ae_stopper;
+}
+
+void devsdk_callbacks_set_validate_addr (devsdk_callbacks *cb, devsdk_validate_address validate_addr)
+{
+  cb->validate_addr = validate_addr;
 }
 
 struct sfx_struct

--- a/src/c/edgex-rest.c
+++ b/src/c/edgex-rest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020
+ * Copyright (c) 2018-2022
  * IoTech Ltd
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -1499,26 +1499,6 @@ void edgex_errorresponse_free (edgex_errorresponse *e)
     free ((char *)e->message);
     free (e);
   }
-}
-
-char *edgex_id_from_response (const char *response)
-{
-  char *result = NULL;
-  JSON_Value *val = json_parse_string (response);
-  if (val)
-  {
-    JSON_Array *arr = json_array (val);
-    if (arr)
-    {
-      JSON_Object *obj = json_array_get_object (arr, 0);
-      if (obj)
-      {
-        result = SAFE_STRDUP (json_object_get_string (obj, "id"));
-      }
-    }
-    json_value_free (val);
-  }
-  return result;
 }
 
 static JSON_Value *pingresponse_write (const edgex_pingresponse *pr)

--- a/src/c/edgex-rest.h
+++ b/src/c/edgex-rest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020
+ * Copyright (c) 2018-2022
  * IoTech Ltd
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -59,8 +59,6 @@ void edgex_pingresponse_write (const edgex_pingresponse *pr, devsdk_http_reply *
 void edgex_configresponse_write (const edgex_configresponse *cr, devsdk_http_reply *reply);
 void edgex_configresponse_free (edgex_configresponse *cr);
 void edgex_metricsresponse_write (const edgex_metricsresponse *mr, devsdk_http_reply *reply);
-
-char *edgex_id_from_response (const char *response);
 
 char *edgex_createDSreq_write (const edgex_deviceservice *ds);
 char *edgex_updateDSreq_write (const char *name, const char *baseaddr);

--- a/src/c/metrics.c
+++ b/src/c/metrics.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019
+ * Copyright (c) 2019-2022
  * IoTech Ltd
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -28,7 +28,11 @@ static void edgex_metrics_populate (edgex_metricsresponse *m, uint64_t starttime
   struct rusage rstats;
 #ifdef __GNU_LIBRARY__
   double loads[1];
+#if (__GLIBC__ * 100 + __GLIBC_MINOR__) >= 233
+  struct mallinfo2 mi = mallinfo2 ();
+#else
   struct mallinfo mi = mallinfo ();
+#endif
   m->alloc = mi.uordblks;
   m->totalloc = mi.arena + mi.hblkhd;
   if (getloadavg (loads, 1) == 1)

--- a/src/c/service.c
+++ b/src/c/service.c
@@ -13,6 +13,7 @@
 #include "discovery.h"
 #include "callback2.h"
 #include "metrics.h"
+#include "validate.h"
 #include "errorlist.h"
 #include "rest-server.h"
 #include "profiles.h"
@@ -686,6 +687,8 @@ static void startConfigured (devsdk_service_t *svc, const devsdk_timeout *deadli
   }
 
   edgex_rest_server_register_handler (svc->daemon, EDGEX_DEV_API2_CALLBACK_DEVICE, DevSDK_Put | DevSDK_Post, svc, edgex_device_handler_callback_device);
+
+  edgex_rest_server_register_handler (svc->daemon, EDGEX_DEV_API2_VALIDATE_ADDR, DevSDK_Post, svc, edgex_device_handler_validate_addr);
 
   /* Load Devices from files and register in metadata */
 

--- a/src/c/service.h
+++ b/src/c/service.h
@@ -39,6 +39,7 @@ struct devsdk_callbacks
   devsdk_remove_device_callback device_removed;
   devsdk_autoevent_start_handler ae_starter;
   devsdk_autoevent_stop_handler ae_stopper;
+  devsdk_validate_address validate_addr;
 };
 
 struct devsdk_service_t

--- a/src/c/validate.c
+++ b/src/c/validate.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022
+ * IoTech Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#include "validate.h"
+#include "service.h"
+#include "edgex-rest.h"
+
+#include <microhttpd.h>
+
+void edgex_device_handler_validate_addr (void *ctx, const devsdk_http_request *req, devsdk_http_reply *reply)
+{
+  devsdk_service_t *svc = (devsdk_service_t *) ctx;
+
+  edgex_device *d = edgex_createdevicereq_read (req->data.bytes);
+  if (d)
+  {
+    iot_data_t *e = NULL;
+    if (svc->userfns.validate_addr)
+    {
+      svc->userfns.validate_addr (svc->userdata, d->protocols, &e);
+    }
+    if (e)
+    {
+      char *msg = iot_data_to_json (e);
+      edgex_error_response (svc->logger, reply, MHD_HTTP_INTERNAL_SERVER_ERROR, "device %s invalid: %s", d->name, msg);
+      free (msg);
+      iot_data_free (e);
+    }
+    else
+    {
+      edgex_baseresponse br;
+      edgex_baseresponse_populate (&br, "v2", MHD_HTTP_OK, "Device protocols validated");
+      edgex_baseresponse_write (&br, reply);
+    }
+    edgex_device_free (svc, d);
+  }
+  else
+  {
+    edgex_error_response (svc->logger, reply, MHD_HTTP_BAD_REQUEST, "callback: device: unable to parse %s", req->data.bytes);
+  }
+}

--- a/src/c/validate.h
+++ b/src/c/validate.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2022
+ * IoTech Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#ifndef _EDGEX_DEVICE_VALIDATE_H_
+#define _EDGEX_DEVICE_VALIDATE_H_ 1
+
+#include "rest-server.h"
+
+extern void edgex_device_handler_validate_addr (void *ctx, const devsdk_http_request *req, devsdk_http_reply *reply);
+
+#endif


### PR DESCRIPTION
refac: use new mallinfo() replacement if available
fix: parse multi-status return from device create

Signed-off-by: Iain Anderson <iain@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Add a function `template_validate_pps (void *impl, const devsdk_protocols *protocols, iot_data_t **exception)` to the template example and register it using `devsdk_callbacks_set_validate_addr (templateImpls, template_validate_pps);`
Verify that when a device is added (eg at startup) the function is called, and if it sets an exception the device addition fails

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->