### PR TITLE
feat: renew Vault tokens before they expire (fix #423)

### DIFF
--- a/src/c/consul.c
+++ b/src/c/consul.c
@@ -23,7 +23,6 @@ typedef struct consul_impl_t
   iot_logger_t *lc;
   iot_threadpool_t *pool;
   edgex_secret_provider_t *sp;
-  devsdk_nvpairs *token;
   char *host;
   uint16_t port;
 } consul_impl_t;
@@ -35,7 +34,6 @@ static bool edgex_consul_client_init (void *impl, iot_logger_t *logger, iot_thre
   consul->lc = logger;
   consul->pool = pool;
   consul->sp = sp;
-  consul->token = edgex_secrets_getregtoken (sp);
   char *pos = strstr (url, "://");
   if (pos)
   {
@@ -64,7 +62,6 @@ static void edgex_consul_client_free (void *impl)
 {
   consul_impl_t *consul = (consul_impl_t *)impl;
   free (consul->host);
-  devsdk_nvpairs_free (consul->token);
   free (impl);
 }
 
@@ -138,7 +135,7 @@ static devsdk_nvpairs *read_pairs (iot_logger_t *lc, const char *json, devsdk_er
 struct updatejob
 {
   char *url;
-  devsdk_nvpairs *token;
+  edgex_secret_provider_t *sp;
   iot_logger_t *lc;
   devsdk_registry_updatefn updater;
   void *updatectx;
@@ -170,7 +167,7 @@ static void *poll_consul (void *p)
     }
     free (index.value);
     index.value = NULL;
-    ctx.reqhdrs = job->token;
+    edgex_secrets_getregtoken (job->sp, &ctx);
     ctx.rsphdrs = &index;
     ctx.aborter = job->updatedone;
     edgex_http_get (job->lc, &ctx, job->url, edgex_http_write_cb, &err);
@@ -216,7 +213,7 @@ static devsdk_nvpairs *edgex_consul_client_get_config
   devsdk_nvpairs *result = NULL;
 
   memset (&ctx, 0, sizeof (edgex_ctx));
-  ctx.reqhdrs = consul->token;
+  edgex_secrets_getregtoken (consul->sp, &ctx);
   snprintf (url, URL_BUF_SIZE - 1, "http://%s:%u/v1/kv/" CONF_PREFIX "%s?recurse=true", consul->host, consul->port, servicename);
   edgex_http_get (consul->lc, &ctx, url, edgex_http_write_cb, err);
   if (err->code == 0)
@@ -238,7 +235,7 @@ static devsdk_nvpairs *edgex_consul_client_get_config
   job->updater = updater;
   job->updatectx = updatectx;
   job->updatedone = updatedone;
-  job->token = consul->token;
+  job->sp = consul->sp;
   iot_threadpool_add_work (consul->pool, poll_consul, job, -1);
 
   return result;
@@ -308,7 +305,7 @@ static void edgex_consul_client_write_config (void *impl, const char *servicenam
   char *json = json_serialize_to_string (jresult);
   json_value_free (jresult);
 
-  ctx.reqhdrs = consul->token;
+  edgex_secrets_getregtoken (consul->sp, &ctx);
   edgex_http_put (consul->lc, &ctx, url, json, edgex_http_write_cb, err);
 
   json_free_serialized_string (json);
@@ -358,7 +355,7 @@ static void edgex_consul_client_register_service
   char *json = json_serialize_to_string (params);
   json_value_free (params);
 
-  ctx.reqhdrs = consul->token;
+  edgex_secrets_getregtoken (consul->sp, &ctx);
   edgex_http_put (consul->lc, &ctx, url, json, edgex_http_write_cb, err);
 
   if (err->code)
@@ -387,7 +384,7 @@ static void edgex_consul_client_deregister_service
     consul->host, consul->port, servicename
   );
 
-  ctx.reqhdrs = consul->token;
+  edgex_secrets_getregtoken (consul->sp, &ctx);
   edgex_http_put (consul->lc, &ctx, url, NULL, edgex_http_write_cb, err);
 
   if (err->code)
@@ -420,7 +417,7 @@ static void edgex_consul_client_query_service
 
   *err = EDGEX_OK;
 
-  ctx.reqhdrs = consul->token;
+  edgex_secrets_getregtoken (consul->sp, &ctx);
   edgex_http_get (consul->lc, &ctx, url, edgex_http_write_cb, err);
 
   if (err->code == 0)
@@ -478,7 +475,7 @@ static bool edgex_consul_client_ping (void *impl)
     consul->port
   );
 
-  ctx.reqhdrs = consul->token;
+  edgex_secrets_getregtoken (consul->sp, &ctx);
   edgex_http_get (consul->lc, &ctx, url, NULL, &err);
   return (err.code == 0);
 }

--- a/src/c/consul.c
+++ b/src/c/consul.c
@@ -170,6 +170,7 @@ static void *poll_consul (void *p)
     edgex_secrets_getregtoken (job->sp, &ctx);
     ctx.rsphdrs = &index;
     ctx.aborter = job->updatedone;
+    edgex_secrets_releaseregtoken (job->sp);
     edgex_http_get (job->lc, &ctx, job->url, edgex_http_write_cb, &err);
     if (*job->updatedone)
     {
@@ -216,6 +217,7 @@ static devsdk_nvpairs *edgex_consul_client_get_config
   edgex_secrets_getregtoken (consul->sp, &ctx);
   snprintf (url, URL_BUF_SIZE - 1, "http://%s:%u/v1/kv/" CONF_PREFIX "%s?recurse=true", consul->host, consul->port, servicename);
   edgex_http_get (consul->lc, &ctx, url, edgex_http_write_cb, err);
+  edgex_secrets_releaseregtoken (consul->sp);
   if (err->code == 0)
   {
     result = read_pairs (consul->lc, ctx.buff, err);
@@ -307,6 +309,7 @@ static void edgex_consul_client_write_config (void *impl, const char *servicenam
 
   edgex_secrets_getregtoken (consul->sp, &ctx);
   edgex_http_put (consul->lc, &ctx, url, json, edgex_http_write_cb, err);
+  edgex_secrets_releaseregtoken (consul->sp);
 
   json_free_serialized_string (json);
   free (ctx.buff);
@@ -357,6 +360,7 @@ static void edgex_consul_client_register_service
 
   edgex_secrets_getregtoken (consul->sp, &ctx);
   edgex_http_put (consul->lc, &ctx, url, json, edgex_http_write_cb, err);
+  edgex_secrets_releaseregtoken (consul->sp);
 
   if (err->code)
   {
@@ -386,6 +390,7 @@ static void edgex_consul_client_deregister_service
 
   edgex_secrets_getregtoken (consul->sp, &ctx);
   edgex_http_put (consul->lc, &ctx, url, NULL, edgex_http_write_cb, err);
+  edgex_secrets_releaseregtoken (consul->sp);
 
   if (err->code)
   {
@@ -419,6 +424,7 @@ static void edgex_consul_client_query_service
 
   edgex_secrets_getregtoken (consul->sp, &ctx);
   edgex_http_get (consul->lc, &ctx, url, edgex_http_write_cb, err);
+  edgex_secrets_releaseregtoken (consul->sp);
 
   if (err->code == 0)
   {
@@ -477,6 +483,7 @@ static bool edgex_consul_client_ping (void *impl)
 
   edgex_secrets_getregtoken (consul->sp, &ctx);
   edgex_http_get (consul->lc, &ctx, url, NULL, &err);
+  edgex_secrets_releaseregtoken (consul->sp);
   return (err.code == 0);
 }
 

--- a/src/c/secrets-impl.h
+++ b/src/c/secrets-impl.h
@@ -10,13 +10,15 @@
 #define _EDGEX_SECRETS_IMPL_H_ 1
 
 #include "edgex/edgex-base.h"
+#include "iot/scheduler.h"
 #include "rest.h"
 
-typedef bool (*edgex_secret_init_fn) (void *impl, iot_logger_t *lc, const char *svcname, iot_data_t *config);
+typedef bool (*edgex_secret_init_fn) (void *impl, iot_logger_t *lc, iot_scheduler_t *sched, iot_threadpool_t *pool, const char *svcname, iot_data_t *config);
 typedef void (*edgex_secret_reconfigure_fn) (void *impl, iot_data_t *config);
 typedef iot_data_t * (*edgex_secret_get_fn) (void *impl, const char *path);
 typedef void (*edgex_secret_set_fn) (void *impl, const char *path, const iot_data_t *secrets);
 typedef void (*edgex_secret_getregtoken_fn) (void *impl, edgex_ctx *ctx);
+typedef void (*edgex_secret_releaseregtoken_fn) (void *impl);
 typedef void (*edgex_secret_fini_fn) (void *impl);
 
 typedef struct
@@ -26,6 +28,7 @@ typedef struct
   edgex_secret_get_fn get;
   edgex_secret_set_fn set;
   edgex_secret_getregtoken_fn getregtoken;
+  edgex_secret_releaseregtoken_fn releaseregtoken;
   edgex_secret_fini_fn fini;
 } edgex_secret_impls;
 

--- a/src/c/secrets-impl.h
+++ b/src/c/secrets-impl.h
@@ -10,13 +10,13 @@
 #define _EDGEX_SECRETS_IMPL_H_ 1
 
 #include "edgex/edgex-base.h"
-#include "iot/logger.h"
+#include "rest.h"
 
 typedef bool (*edgex_secret_init_fn) (void *impl, iot_logger_t *lc, const char *svcname, iot_data_t *config);
 typedef void (*edgex_secret_reconfigure_fn) (void *impl, iot_data_t *config);
 typedef iot_data_t * (*edgex_secret_get_fn) (void *impl, const char *path);
 typedef void (*edgex_secret_set_fn) (void *impl, const char *path, const iot_data_t *secrets);
-typedef devsdk_nvpairs * (*edgex_secret_getregtoken_fn) (void *impl);
+typedef void (*edgex_secret_getregtoken_fn) (void *impl, edgex_ctx *ctx);
 typedef void (*edgex_secret_fini_fn) (void *impl);
 
 typedef struct

--- a/src/c/secrets-insecure.c
+++ b/src/c/secrets-insecure.c
@@ -7,6 +7,7 @@
  */
 
 #include "secrets-insecure.h"
+#include "rest.h"
 
 #define SEC_PREFIX "Writable/InsecureSecrets/"
 #define SEC_PREFIXLEN (sizeof (SEC_PREFIX) - 1)
@@ -93,9 +94,8 @@ static void insecure_set (void *impl, const char *path, const iot_data_t *secret
   iot_log_error (insec->lc, "Storing secrets is not supported when running in insecure mode");
 }
 
-static devsdk_nvpairs *insecure_getregtoken (void *impl)
+static void insecure_getregtoken (void *impl, edgex_ctx *ctx)
 {
-  return NULL;
 }
 
 static void insecure_fini (void *impl)

--- a/src/c/secrets-insecure.c
+++ b/src/c/secrets-insecure.c
@@ -57,7 +57,7 @@ static iot_data_t *insecure_parse_config (iot_data_t *config)
   return result;
 }
 
-static bool insecure_init (void *impl, iot_logger_t *lc, const char *svcname, iot_data_t *config)
+static bool insecure_init (void *impl, iot_logger_t *lc, iot_scheduler_t *sched, iot_threadpool_t *pool, const char *svcname, iot_data_t *config)
 {
   insecure_impl_t *insec = (insecure_impl_t *)impl;
   insec->lc = lc;
@@ -98,6 +98,10 @@ static void insecure_getregtoken (void *impl, edgex_ctx *ctx)
 {
 }
 
+static void insecure_releaseregtoken (void *impl)
+{
+}
+
 static void insecure_fini (void *impl)
 {
   insecure_impl_t *insec = (insecure_impl_t *)impl;
@@ -111,4 +115,4 @@ void *edgex_secrets_insecure_alloc ()
   return calloc (1, sizeof (insecure_impl_t));
 }
 
-const edgex_secret_impls edgex_secrets_insecure_fns = { insecure_init, insecure_reconfigure, insecure_get, insecure_set, insecure_getregtoken, insecure_fini };
+const edgex_secret_impls edgex_secrets_insecure_fns = { insecure_init, insecure_reconfigure, insecure_get, insecure_set, insecure_getregtoken, insecure_releaseregtoken, insecure_fini };

--- a/src/c/secrets-vault.c
+++ b/src/c/secrets-vault.c
@@ -11,47 +11,159 @@
 #include "edgex-rest.h"
 #include "parson.h"
 #include "errorlist.h"
+#include "iot/scheduler.h"
 
 typedef struct vault_impl_t
 {
   iot_logger_t *lc;
+  iot_threadpool_t *thpool;
+  iot_scheduler_t *scheduler;
   char *token;
   char *baseurl;
   char *regurl;
+  char *tokinfourl;
+  char *tokrenewurl;
   char *capath;
   devsdk_nvpairs *regtoken;
   bool bearer;
   pthread_mutex_t mtx;
 } vault_impl_t;
 
-static bool vault_init (void *impl, iot_logger_t *lc, const char *svcname, iot_data_t *config)
+static void vault_initctx (vault_impl_t *vault, edgex_ctx *ctx)
+{
+  memset (ctx, 0, sizeof (edgex_ctx));
+  if (vault->capath)
+  {
+    ctx->cacerts_path = vault->capath;
+    ctx->verify_peer = 1;
+  }
+  if (vault->bearer)
+  {
+    ctx->jwt_token = vault->token;
+  }
+  else
+  {
+    ctx->reqhdrs = devsdk_nvpairs_new ("X-Vault-Token", vault->token, NULL);
+  }
+}
+
+static void vault_freectx (edgex_ctx *ctx)
+{
+  devsdk_nvpairs_free (ctx->reqhdrs);
+  free (ctx->buff);
+}
+
+static iot_data_t *vault_rest_get (vault_impl_t *vault, const char *url)
+{
+  devsdk_error err = EDGEX_OK;
+  iot_data_t *result = NULL;
+  edgex_ctx ctx;
+  vault_initctx (vault, &ctx);
+  edgex_http_get (vault->lc, &ctx, url, edgex_http_write_cb, &err);
+  if (err.code == 0)
+  {
+    result = iot_data_from_json (ctx.buff);
+  }
+  else
+  {
+    iot_log_error (vault->lc, "vault: GET %s failed", url);
+  }
+  vault_freectx (&ctx);
+  return result;
+}
+
+static void vault_schedule_renewal (vault_impl_t *vault);
+
+static void *vault_perform_renewal (void *v)
+{
+  vault_impl_t *vault = (vault_impl_t *)v;
+  devsdk_error err = EDGEX_OK;
+  edgex_ctx ctx;
+  vault_initctx (vault, &ctx);
+
+  pthread_mutex_lock (&vault->mtx);
+  edgex_http_put (vault->lc, &ctx, vault->tokrenewurl, "", edgex_http_write_cb, &err);
+  devsdk_nvpairs_free (vault->regtoken);
+  vault->regtoken = NULL;
+  pthread_mutex_unlock (&vault->mtx);
+
+  if (err.code == 0)
+  {
+    vault_schedule_renewal (vault);
+  }
+  else
+  {
+    iot_log_error (vault->lc, "vault: error renewing token: %s", ctx.buff);
+  }
+
+  vault_freectx (&ctx);
+  return NULL;
+}
+
+void vault_schedule_renewal (vault_impl_t *vault)
+{
+  const iot_data_t *data = NULL;
+  iot_data_t *info = vault_rest_get (vault, vault->tokinfourl);
+  if (info)
+  {
+    data = iot_data_string_map_get (info, "data");
+  }
+  if (data)
+  {
+    if (iot_data_bool (iot_data_string_map_get (data, "renewable")))
+    {
+      int64_t ttl = iot_data_i64 (iot_data_string_map_get (data, "ttl"));
+      int64_t c_ttl = iot_data_i64 (iot_data_string_map_get (data, "creation_ttl"));
+      int64_t wait = ttl - c_ttl / 10;
+      if (wait < 1)
+      {
+        vault_perform_renewal (vault);
+      }
+      else
+      {
+        iot_schedule_t *job = iot_schedule_create (vault->scheduler, vault_perform_renewal, NULL, vault, 0, IOT_SEC_TO_NS(wait), 1, vault->thpool, -1);
+        iot_schedule_add (vault->scheduler, job);
+        iot_log_info (vault->lc, "vault: scheduled token refresh in %ld seconds", wait);
+      }
+    }
+    else
+    {
+      iot_log_info (vault->lc, "vault: access token is non-renewable");
+    }
+  }
+  else
+  {
+    iot_log_error (vault->lc, "vault: could not obtain token renewal information");
+  }
+  iot_data_free (info);
+}
+
+static bool vault_init (void *impl, iot_logger_t *lc, iot_scheduler_t *sched, iot_threadpool_t *pool, const char *svcname, iot_data_t *config)
 {
   vault_impl_t *vault = (vault_impl_t *)impl;
   vault->lc = lc;
+  vault->scheduler = sched;
+  vault->thpool = pool;
 
+  char *host = malloc (URL_BUF_SIZE);
+  snprintf
+  (
+    host, URL_BUF_SIZE,
+    "%s://%s:%u",
+    iot_data_string_map_get_string (config, "SecretStore/Protocol"),
+    iot_data_string_map_get_string (config, "SecretStore/Host"),
+    iot_data_ui16 (iot_data_string_map_get (config, "SecretStore/Port"))
+  );
   const char *path = iot_data_string_map_get_string (config, "SecretStore/Path");
   vault->baseurl = malloc (URL_BUF_SIZE);
-  snprintf
-  (
-    vault->baseurl, URL_BUF_SIZE,
-    "%s://%s:%u/v1/secret/edgex%s%s%s",
-    iot_data_string_map_get_string (config, "SecretStore/Protocol"),
-    iot_data_string_map_get_string (config, "SecretStore/Host"),
-    iot_data_ui16 (iot_data_string_map_get (config, "SecretStore/Port")),
-    path[0] == '/' ? "" : "/",
-    path,
-    path[strlen (path) - 1] == '/' ? "" : "/"
-  );
+  snprintf (vault->baseurl, URL_BUF_SIZE, "%s/v1/secret/edgex%s%s%s", host, path[0] == '/' ? "" : "/", path, path[strlen (path) - 1] == '/' ? "" : "/");
   vault->regurl = malloc (URL_BUF_SIZE);
-  snprintf
-  (
-    vault->regurl, URL_BUF_SIZE,
-    "%s://%s:%u/v1/consul/creds/%s",
-    iot_data_string_map_get_string (config, "SecretStore/Protocol"),
-    iot_data_string_map_get_string (config, "SecretStore/Host"),
-    iot_data_ui16 (iot_data_string_map_get (config, "SecretStore/Port")),
-    svcname
-  );
+  snprintf (vault->regurl, URL_BUF_SIZE, "%s/v1/consul/creds/%s", host, svcname);
+  vault->tokinfourl = malloc (URL_BUF_SIZE);
+  snprintf (vault->tokinfourl, URL_BUF_SIZE, "%s/v1/auth/token/lookup-self", host);
+  vault->tokrenewurl = malloc (URL_BUF_SIZE);
+  snprintf (vault->tokrenewurl, URL_BUF_SIZE, "%s/v1/auth/token/renew-self", host);
+  free (host);
 
   const char *fname = iot_data_string_map_get_string (config, "SecretStore/TokenFile");
   JSON_Value *jval = json_parse_file (fname);
@@ -92,6 +204,8 @@ static bool vault_init (void *impl, iot_logger_t *lc, const char *svcname, iot_d
     vault->bearer = true;
   }
   // TODO: SecretStore/ServerName (unsupported in libcurl?)
+
+  vault_schedule_renewal (vault);
   return true;
 }
 
@@ -101,48 +215,27 @@ static void vault_reconfigure (void *impl, iot_data_t *config)
 
 static iot_data_t *vault_get (void *impl, const char *path)
 {
-  edgex_ctx ctx;
-  devsdk_error err = EDGEX_OK;
-  char url[URL_BUF_SIZE];
+  const iot_data_t *d = NULL;
+  iot_data_t *result;
   vault_impl_t *vault = (vault_impl_t *)impl;
-  iot_data_t *result = iot_data_alloc_map (IOT_DATA_STRING);
-
-  memset (&ctx, 0, sizeof (edgex_ctx));
+  char url[URL_BUF_SIZE];
   snprintf (url, URL_BUF_SIZE - 1, "%s%s", vault->baseurl, path);
-  if (vault->capath)
-  {
-    ctx.cacerts_path = vault->capath;
-    ctx.verify_peer = 1;
-  }
-  if (vault->bearer)
-  {
-    ctx.jwt_token = vault->token;
-  }
-  else
-  {
-    ctx.reqhdrs = devsdk_nvpairs_new ("X-Vault-Token", vault->token, NULL);
-  }
-  edgex_http_get (vault->lc, &ctx, url, edgex_http_write_cb, &err);
-  if (err.code == 0)
-  {
-    JSON_Value *jval = json_parse_string (ctx.buff);
-    JSON_Object *jobj = json_value_get_object (jval);
-    JSON_Object *data = json_object_get_object (jobj, "data");
-    size_t count = json_object_get_count (data);
-    for (size_t i = 0; i < count; i++)
-    {
-      iot_data_map_add (result, iot_data_alloc_string (json_object_get_name (data, i), IOT_DATA_COPY), iot_data_alloc_string (json_string (json_object_get_value_at (data, i)), IOT_DATA_COPY));
-    }
 
-    json_value_free (jval);
+  iot_data_t *reply = vault_rest_get (vault, url);
+  if (reply)
+  {
+    d = iot_data_string_map_get (reply, "data");
+  }
+  if (d)
+  {
+    result = iot_data_copy (d);
   }
   else
   {
     iot_log_error (vault->lc, "vault: get secrets request failed");
+    result = iot_data_alloc_map (IOT_DATA_STRING);
   }
-  devsdk_nvpairs_free (ctx.reqhdrs);
-  free (ctx.buff);
-
+  iot_data_free (reply);
   return result;
 }
 
@@ -153,12 +246,10 @@ static void vault_set (void *impl, const char *path, const iot_data_t *secrets)
   char url[URL_BUF_SIZE];
   vault_impl_t *vault = (vault_impl_t *)impl;
 
-  memset (&ctx, 0, sizeof (edgex_ctx));
+  vault_initctx (vault, &ctx);
   snprintf (url, URL_BUF_SIZE - 1, "%s%s", vault->baseurl, path);
-  ctx.jwt_token = vault->token;
 
   char *json = iot_data_to_json (secrets);
-
   edgex_http_put (vault->lc, &ctx, url, json, edgex_http_write_cb, &err);
   free (json);
 
@@ -166,56 +257,29 @@ static void vault_set (void *impl, const char *path, const iot_data_t *secrets)
   {
     iot_log_error (vault->lc, "vault:error setting secrets: %s", ctx.buff);
   }
-  free (ctx.buff);
+  vault_freectx (&ctx);
 }
 
 static void vault_fetchregtoken (vault_impl_t *vault)
 {
-  edgex_ctx ctx;
-  devsdk_error err = EDGEX_OK;
-
-  memset (&ctx, 0, sizeof (edgex_ctx));
-  if (vault->capath)
+  iot_data_t *reply = vault_rest_get (vault, vault->regurl);
+  if (reply)
   {
-    ctx.cacerts_path = vault->capath;
-    ctx.verify_peer = 1;
-  }
-  if (vault->bearer)
-  {
-    ctx.jwt_token = vault->token;
-  }
-  else
-  {
-    ctx.reqhdrs = devsdk_nvpairs_new ("X-Vault-Token", vault->token, NULL);
-  }
-  edgex_http_get (vault->lc, &ctx, vault->regurl, edgex_http_write_cb, &err);
-  if (err.code == 0)
-  {
-    iot_data_t *reply = iot_data_from_json (ctx.buff);
-    if (reply)
+    const iot_data_t *d = iot_data_string_map_get (reply, "data");
+    if (d)
     {
-      const iot_data_t *d = iot_data_string_map_get (reply, "data");
-      if (d)
+      const iot_data_t *t = iot_data_string_map_get (d, "token");
+      if (t)
       {
-        const iot_data_t *t = iot_data_string_map_get (d, "token");
-        if (t)
-        {
-          vault->regtoken = devsdk_nvpairs_new ("X-Consul-Token", iot_data_string (t), NULL);
-        }
+        vault->regtoken = devsdk_nvpairs_new ("X-Consul-Token", iot_data_string (t), NULL);
       }
-      iot_data_free (reply);
     }
-    if (vault->regtoken == NULL)
-    {
-      iot_log_error (vault->lc, "vault: no consul token found in %s", ctx.buff);
-    }
+    iot_data_free (reply);
   }
-  else
+  if (vault->regtoken == NULL)
   {
-    iot_log_error (vault->lc, "vault: unable to retrieve consul token");
+    iot_log_error (vault->lc, "vault: no consul token found");
   }
-  devsdk_nvpairs_free (ctx.reqhdrs);
-  free (ctx.buff);
 }
 
 static void vault_getregtoken (void *impl, edgex_ctx *ctx)
@@ -227,6 +291,11 @@ static void vault_getregtoken (void *impl, edgex_ctx *ctx)
     vault_fetchregtoken (vault);
   }
   ctx->reqhdrs = vault->regtoken;
+}
+
+static void vault_releaseregtoken (void *impl)
+{
+  vault_impl_t *vault = (vault_impl_t *)impl;
   pthread_mutex_unlock (&vault->mtx);
 }
 
@@ -236,6 +305,8 @@ static void vault_fini (void *impl)
   pthread_mutex_destroy (&vault->mtx);
   free (vault->baseurl);
   free (vault->regurl);
+  free (vault->tokinfourl);
+  free (vault->tokrenewurl);
   free (vault->token);
   free (vault->capath);
   devsdk_nvpairs_free (vault->regtoken);
@@ -249,4 +320,4 @@ void *edgex_secrets_vault_alloc ()
   return vault;
 }
 
-const edgex_secret_impls edgex_secrets_vault_fns = { vault_init, vault_reconfigure, vault_get, vault_set, vault_getregtoken, vault_fini };
+const edgex_secret_impls edgex_secrets_vault_fns = { vault_init, vault_reconfigure, vault_get, vault_set, vault_getregtoken, vault_releaseregtoken, vault_fini };

--- a/src/c/secrets.c
+++ b/src/c/secrets.c
@@ -23,9 +23,9 @@ typedef struct edgex_secret_provider_t
 
 static void edgex_secrets_from_file (edgex_secret_provider_t *sp, const char *filename, bool scrub);
 
-bool edgex_secrets_init (edgex_secret_provider_t *sp, iot_logger_t *lc, const char *svcname, iot_data_t *config)
+bool edgex_secrets_init (edgex_secret_provider_t *sp, iot_logger_t *lc, iot_scheduler_t *sched, iot_threadpool_t *pool, const char *svcname, iot_data_t *config)
 {
-  bool result = sp->fns.init (sp->impl, lc, svcname, config);
+  bool result = sp->fns.init (sp->impl, lc, sched, pool, svcname, config);
   if (result)
   {
     const char *secfile = iot_data_string_map_get_string (config, "SecretStore/SecretsFile");
@@ -55,6 +55,11 @@ static void edgex_secrets_set (edgex_secret_provider_t *sp, const char *path, co
 void edgex_secrets_getregtoken (edgex_secret_provider_t *sp, edgex_ctx *ctx)
 {
   return sp->fns.getregtoken (sp->impl, ctx);
+}
+
+void edgex_secrets_releaseregtoken (edgex_secret_provider_t *sp)
+{
+  return sp->fns.releaseregtoken (sp->impl);
 }
 
 void edgex_secrets_fini (edgex_secret_provider_t *sp)

--- a/src/c/secrets.c
+++ b/src/c/secrets.c
@@ -52,9 +52,9 @@ static void edgex_secrets_set (edgex_secret_provider_t *sp, const char *path, co
   sp->fns.set (sp->impl, path, secrets);
 }
 
-devsdk_nvpairs *edgex_secrets_getregtoken (edgex_secret_provider_t *sp)
+void edgex_secrets_getregtoken (edgex_secret_provider_t *sp, edgex_ctx *ctx)
 {
-  return sp->fns.getregtoken (sp->impl);
+  return sp->fns.getregtoken (sp->impl, ctx);
 }
 
 void edgex_secrets_fini (edgex_secret_provider_t *sp)

--- a/src/c/secrets.h
+++ b/src/c/secrets.h
@@ -11,16 +11,18 @@
 
 #include "rest.h"
 #include "rest-server.h"
+#include "iot/scheduler.h"
 
 typedef struct edgex_secret_provider_t edgex_secret_provider_t;
 
 edgex_secret_provider_t *edgex_secrets_get_insecure (void);
 edgex_secret_provider_t *edgex_secrets_get_vault (void);
 
-bool edgex_secrets_init (edgex_secret_provider_t *sp, iot_logger_t *lc, const char *svcname, iot_data_t *config);
+bool edgex_secrets_init (edgex_secret_provider_t *sp, iot_logger_t *lc, iot_scheduler_t *sched, iot_threadpool_t *pool, const char *svcname, iot_data_t *config);
 void edgex_secrets_reconfigure (edgex_secret_provider_t *sp, iot_data_t *config);
 iot_data_t *edgex_secrets_get (edgex_secret_provider_t *sp, const char *path);
 void edgex_secrets_getregtoken (edgex_secret_provider_t *sp, edgex_ctx *ctx);
+void edgex_secrets_releaseregtoken (edgex_secret_provider_t *sp);
 void edgex_secrets_fini (edgex_secret_provider_t *sp);
 
 void edgex_device_handler_secret (void *ctx, const devsdk_http_request *req, devsdk_http_reply *reply);

--- a/src/c/secrets.h
+++ b/src/c/secrets.h
@@ -9,6 +9,7 @@
 #ifndef _EDGEX_SECRETS_H_
 #define _EDGEX_SECRETS_H_ 1
 
+#include "rest.h"
 #include "rest-server.h"
 
 typedef struct edgex_secret_provider_t edgex_secret_provider_t;
@@ -19,7 +20,7 @@ edgex_secret_provider_t *edgex_secrets_get_vault (void);
 bool edgex_secrets_init (edgex_secret_provider_t *sp, iot_logger_t *lc, const char *svcname, iot_data_t *config);
 void edgex_secrets_reconfigure (edgex_secret_provider_t *sp, iot_data_t *config);
 iot_data_t *edgex_secrets_get (edgex_secret_provider_t *sp, const char *path);
-devsdk_nvpairs *edgex_secrets_getregtoken (edgex_secret_provider_t *sp);
+void edgex_secrets_getregtoken (edgex_secret_provider_t *sp, edgex_ctx *ctx);
 void edgex_secrets_fini (edgex_secret_provider_t *sp);
 
 void edgex_device_handler_secret (void *ctx, const devsdk_http_request *req, devsdk_http_reply *reply);

--- a/src/c/service.c
+++ b/src/c/service.c
@@ -863,7 +863,7 @@ void devsdk_service_start (devsdk_service_t *svc, iot_data_t *driverdfls, devsdk
       return;
     }
   }
-  if (!edgex_secrets_init (svc->secretstore, svc->logger, svc->name, configmap))
+  if (!edgex_secrets_init (svc->secretstore, svc->logger, svc->scheduler, svc->thpool, svc->name, configmap))
   {
     *err = EDGEX_BAD_CONFIG;
     return;


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

- Add a call to `devsdk_get_secrets()` in the template example
- Create a time-limited vault token using eg `vault token create -period=2m`
- Run the example in secure mode
- The get_secrets operation should continue to succeed after the 2 minute renewal period

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->