### PR TITLE
feat: Add Redis subscriber for commands

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ This is the C SDK for EdgeX device services.
 
 Changes for 2.3.0 "Levski":
 
+- Implement device commands via redis MessageQueue
 - Implement MaxEventSize configuration
 
 Changes for 2.2.0 "Kamakura":

--- a/src/c/config.c
+++ b/src/c/config.c
@@ -84,7 +84,7 @@ iot_data_t *edgex_config_defaults (const iot_data_t *driverconf, const char *svc
   iot_data_string_map_add (result, "Device/EventQLength", iot_data_alloc_ui32 (0));
 
   iot_data_string_map_add (result, EX_MQ_TYPE, iot_data_alloc_string ("", IOT_DATA_REF));
-  edgex_mqtt_config_defaults (result);
+  edgex_mqtt_config_defaults (result, svcname);
   // NB redis-streams uses a subset of the mqtt options
 
   iot_data_string_map_add (result, "SecretStore/Type", iot_data_alloc_string ("vault", IOT_DATA_REF));

--- a/src/c/data-mqtt.c
+++ b/src/c/data-mqtt.c
@@ -13,8 +13,13 @@
 #include "iot/time.h"
 #include <MQTTAsync.h>
 
-void edgex_mqtt_config_defaults (iot_data_t *allconf)
+#define DEFAULTREQTOPIC "edgex/device/command/request/%s/#"
+
+void edgex_mqtt_config_defaults (iot_data_t *allconf, const char *svcname)
 {
+  char *reqt = malloc (sizeof (DEFAULTREQTOPIC) + strlen (svcname));
+  sprintf (reqt, DEFAULTREQTOPIC, svcname);
+
   iot_data_string_map_add (allconf, EX_MQ_PROTOCOL, iot_data_alloc_string ("", IOT_DATA_REF));
   iot_data_string_map_add (allconf, EX_MQ_HOST, iot_data_alloc_string ("localhost", IOT_DATA_REF));
   iot_data_string_map_add (allconf, EX_MQ_PORT, iot_data_alloc_ui16 (0));
@@ -29,6 +34,9 @@ void edgex_mqtt_config_defaults (iot_data_t *allconf)
   iot_data_string_map_add (allconf, EX_MQ_CERTFILE, iot_data_alloc_string ("", IOT_DATA_REF));
   iot_data_string_map_add (allconf, EX_MQ_KEYFILE, iot_data_alloc_string ("", IOT_DATA_REF));
   iot_data_string_map_add (allconf, EX_MQ_SKIPVERIFY, iot_data_alloc_bool (false));
+
+  iot_data_string_map_add (allconf, EX_MQ_TOPIC_CMDREQ, iot_data_alloc_string (reqt, IOT_DATA_TAKE));
+  iot_data_string_map_add (allconf, EX_MQ_TOPIC_CMDRESP, iot_data_alloc_string ("edgex/device/command/response", IOT_DATA_REF));
 }
 
 JSON_Value *edgex_mqtt_config_json (const iot_data_t *allconf)
@@ -51,8 +59,14 @@ JSON_Value *edgex_mqtt_config_json (const iot_data_t *allconf)
   json_object_set_string (optobj, "CertFile", iot_data_string_map_get_string (allconf, EX_MQ_CERTFILE));
   json_object_set_string (optobj, "KeyFile", iot_data_string_map_get_string (allconf, EX_MQ_KEYFILE));
   json_object_set_boolean (optobj, "SkipCertVerify", iot_data_bool (iot_data_string_map_get (allconf, EX_MQ_SKIPVERIFY)));
-
   json_object_set_value (mqobj, "Optional", optval);
+
+  JSON_Value *topicval = json_value_init_object ();
+  JSON_Object *topicobj = json_value_get_object (topicval);
+  json_object_set_string (topicobj, "CommandRequestTopic", iot_data_string_map_get_string (allconf, EX_MQ_TOPIC_CMDREQ));
+  json_object_set_string (topicobj, "CommandResponseTopicPrefix", iot_data_string_map_get_string (allconf, EX_MQ_TOPIC_CMDRESP));
+  json_object_set_value (mqobj, "Topics", topicval);
+
   return mqval;
 }
 

--- a/src/c/data-mqtt.c
+++ b/src/c/data-mqtt.c
@@ -13,7 +13,9 @@
 #include "iot/time.h"
 #include <MQTTAsync.h>
 
+#define DEFAULTPUBTOPIC "edgex/events/device"
 #define DEFAULTREQTOPIC "edgex/device/command/request/%s/#"
+#define DEFAULTRESPTOPIC "edgex/device/command/response"
 
 void edgex_mqtt_config_defaults (iot_data_t *allconf, const char *svcname)
 {
@@ -23,7 +25,7 @@ void edgex_mqtt_config_defaults (iot_data_t *allconf, const char *svcname)
   iot_data_string_map_add (allconf, EX_MQ_PROTOCOL, iot_data_alloc_string ("", IOT_DATA_REF));
   iot_data_string_map_add (allconf, EX_MQ_HOST, iot_data_alloc_string ("localhost", IOT_DATA_REF));
   iot_data_string_map_add (allconf, EX_MQ_PORT, iot_data_alloc_ui16 (0));
-  iot_data_string_map_add (allconf, EX_MQ_TOPIC, iot_data_alloc_string ("edgex/events/device", IOT_DATA_REF));
+  iot_data_string_map_add (allconf, EX_MQ_TOPIC, iot_data_alloc_string (DEFAULTPUBTOPIC, IOT_DATA_REF));
   iot_data_string_map_add (allconf, EX_MQ_AUTHMODE, iot_data_alloc_string ("none", IOT_DATA_REF));
   iot_data_string_map_add (allconf, EX_MQ_SECRETNAME, iot_data_alloc_string ("", IOT_DATA_REF));
 
@@ -36,7 +38,7 @@ void edgex_mqtt_config_defaults (iot_data_t *allconf, const char *svcname)
   iot_data_string_map_add (allconf, EX_MQ_SKIPVERIFY, iot_data_alloc_bool (false));
 
   iot_data_string_map_add (allconf, EX_MQ_TOPIC_CMDREQ, iot_data_alloc_string (reqt, IOT_DATA_TAKE));
-  iot_data_string_map_add (allconf, EX_MQ_TOPIC_CMDRESP, iot_data_alloc_string ("edgex/device/command/response", IOT_DATA_REF));
+  iot_data_string_map_add (allconf, EX_MQ_TOPIC_CMDRESP, iot_data_alloc_string (DEFAULTRESPTOPIC, IOT_DATA_REF));
 }
 
 JSON_Value *edgex_mqtt_config_json (const iot_data_t *allconf)

--- a/src/c/data-mqtt.h
+++ b/src/c/data-mqtt.h
@@ -13,7 +13,7 @@
 #include "data.h"
 #include "devutil.h"
 
-void edgex_mqtt_config_defaults (iot_data_t *allconf);
+void edgex_mqtt_config_defaults (iot_data_t *allconf, const char *svcname);
 
 JSON_Value *edgex_mqtt_config_json (const iot_data_t *allconf);
 

--- a/src/c/data-redstr.c
+++ b/src/c/data-redstr.c
@@ -9,9 +9,12 @@
 #include "data-redstr.h"
 #include "correlation.h"
 #include "service.h"
+#include "device.h"
 #include "iot/base64.h"
 #include "iot/time.h"
+#include "iot/thread.h"
 #include <hiredis/hiredis.h>
+#include <microhttpd.h>
 
 JSON_Value *edgex_redstr_config_json (const iot_data_t *allconf)
 {
@@ -21,26 +24,45 @@ JSON_Value *edgex_redstr_config_json (const iot_data_t *allconf)
   json_object_set_uint (mqobj, "Port", iot_data_ui16 (iot_data_string_map_get (allconf, EX_MQ_PORT)));
   json_object_set_string (mqobj, "Topic", iot_data_string_map_get_string (allconf, EX_MQ_TOPIC));
 
+  JSON_Value *topicval = json_value_init_object ();
+  JSON_Object *topicobj = json_value_get_object (topicval);
+  json_object_set_string (topicobj, "CommandRequestTopic", iot_data_string_map_get_string (allconf, EX_MQ_TOPIC_CMDREQ));
+  json_object_set_string (topicobj, "CommandResponseTopicPrefix", iot_data_string_map_get_string (allconf, EX_MQ_TOPIC_CMDRESP));
+  json_object_set_value (mqobj, "Topics", topicval);
+
   return mqval;
 }
 
 typedef struct edc_redstr_conninfo
 {
+  devsdk_service_t *svc;
+  iot_logger_t *lc;
   redisContext *ctx;
+  redisContext *ctx_rd;
   char *topicbase;
+  char *pubsub_topicbase;
   pthread_mutex_t mtx;
+  pthread_t thread;
+  ssize_t offset;
+  bool running;
 } edc_redstr_conninfo;
 
 static void edc_redstr_freefn (iot_logger_t *lc, void *address)
 {
   edc_redstr_conninfo *cinfo = (edc_redstr_conninfo *)address;
   redisFree (cinfo->ctx);
+  redisFree (cinfo->ctx_rd);
   free (cinfo->topicbase);
+  free (cinfo->pubsub_topicbase);
   pthread_mutex_destroy (&cinfo->mtx);
+  if (cinfo->running)
+  {
+    pthread_cancel (cinfo->thread);
+  }
   free (cinfo);
 }
 
-static void remapslash (char *c)
+static void edc_redstr_remapslash (char *c)
 {
   while ((c = strchr (c, '/')))
   {
@@ -48,23 +70,59 @@ static void remapslash (char *c)
   }
 }
 
+static void edc_redstr_remaphash (char *c)
+{
+  char *e = c + strlen (c) - 1;
+  if (*e == '#')
+  {
+    *e = '*';
+  }
+}
+
+static void edc_redstr_send (edc_redstr_conninfo *cinfo, const char *topic, const iot_data_t *msg)
+{
+  char *json = iot_data_to_json (msg);
+  pthread_mutex_lock (&cinfo->mtx);
+  redisReply *reply = redisCommand (cinfo->ctx, "PUBLISH %s %s", topic, json);
+
+  if (reply == NULL)
+  {
+    iot_log_error (cinfo->lc, "Error posting Event via Redis: %s", cinfo->ctx->errstr);
+    if (redisReconnect (cinfo->ctx) == REDIS_ERR)
+    {
+      iot_log_error (cinfo->lc, "Redis reconnection failed: %s", cinfo->ctx->errstr);
+    }
+  }
+
+  freeReplyObject (reply);
+  pthread_mutex_unlock (&cinfo->mtx);
+  free (json);
+}
+
+static char *edc_redstr_b64 (devsdk_http_data src)
+{
+  size_t encsz;
+  char *result;
+
+  encsz = iot_b64_encodesize (src.size);
+  result = malloc (encsz);
+  iot_b64_encode (src.bytes, src.size, result, encsz);
+  return result;
+}
+
 static void edc_redstr_postfn (iot_logger_t *lc, void *address, edgex_event_cooked *event)
 {
   devsdk_http_reply h;
   const char *crl;
   bool freecrl = false;
-  size_t payloadsz;
-  char *payload;
-  char *json;
   char *topic;
-  void *reply;
   edc_redstr_conninfo *cinfo = (edc_redstr_conninfo *)address;
 
   topic = malloc (strlen (cinfo->topicbase) + strlen (event->path) + 2);
   strcpy (topic, cinfo->topicbase);
   strcat (topic, ".");
   strcat (topic, event->path);
-  remapslash (topic);
+  edc_redstr_remapslash (topic);
   edgex_event_cooked_write (event, &h);
 
   crl = edgex_device_get_crlid ();
@@ -75,41 +133,177 @@ static void edc_redstr_postfn (iot_logger_t *lc, void *address, edgex_event_cook
     crl = edgex_device_get_crlid ();
   }
 
-  payloadsz = iot_b64_encodesize (h.data.size);
-  payload = malloc (payloadsz);
-  iot_b64_encode (h.data.bytes, h.data.size, payload, payloadsz);
+  iot_data_t *msg = iot_data_alloc_map (IOT_DATA_STRING);
+  iot_data_string_map_add (msg, "CorrelationID", iot_data_alloc_string (crl, IOT_DATA_REF));
+  iot_data_string_map_add (msg, "Payload", iot_data_alloc_string (edc_redstr_b64 (h.data), IOT_DATA_TAKE));
+  iot_data_string_map_add (msg, "ContentType", iot_data_alloc_string (h.content_type, IOT_DATA_REF));
 
-  JSON_Value *val = json_value_init_object ();
-  JSON_Object *obj = json_value_get_object (val);
-  json_object_set_string (obj, "CorrelationID", crl);
-  json_object_set_string (obj, "Payload", payload);
-  json_object_set_string (obj, "ContentType", h.content_type);
+  edc_redstr_send (cinfo, topic, msg);
 
-  json = json_serialize_to_string (val);
-
-  pthread_mutex_lock (&cinfo->mtx);
-  reply = redisCommand (cinfo->ctx, "PUBLISH %s %s", topic, json);
-
-  if (reply == NULL)
-  {
-    iot_log_error (lc, "Error posting Event via Redis: %s", cinfo->ctx->errstr);
-    if (redisReconnect (cinfo->ctx) == REDIS_ERR)
-    {
-      iot_log_error (lc, "Redis reconnection failed: %s", cinfo->ctx->errstr);
-    }
-  }
-
-  freeReplyObject (reply);
-  pthread_mutex_unlock (&cinfo->mtx);
   free (h.data.bytes);
-  free (payload);
-  json_free_serialized_string (json);
+  iot_data_free (msg);
   free (topic);
-  json_value_free (val);
   if (freecrl)
   {
     edgex_device_free_crlid ();
   }
+}
+
+static redisContext *edc_redstr_connect (iot_logger_t *lc, const char *host, uint16_t port, struct timeval tv)
+{
+  redisContext *result = redisConnectWithTimeout (host, port, tv);
+  if (result)
+  {
+    if (result->err)
+    {
+      iot_log_error (lc, "Failed to create Redis Streams client: %s", result->errstr);
+      redisFree (result);
+      result = NULL;
+    }
+  }
+  else
+  {
+    iot_log_error (lc, "Can't allocate redis context");
+  }
+  return result;
+}
+
+static bool edc_redis_subscribe (iot_logger_t *lc, redisContext *ctx, const char *topic)
+{
+  bool result = true;
+  char *s_topic = strdup (topic);
+  edc_redstr_remapslash (s_topic);
+  edc_redstr_remaphash (s_topic);
+
+  redisReply *readreply = redisCommand (ctx, "psubscribe %s", s_topic);
+  if (!readreply || ctx->err)
+  {
+    iot_log_error (lc, "Redis: Can't subscribe to topic");
+    result = false;
+  }
+  freeReplyObject (readreply);
+  free (s_topic);
+  return result;
+}
+
+static char *edc_redstr_stripright (char *t)
+{
+  char *c = strrchr (t, '.');
+  if (c)
+  {
+    *c = 0;
+    return c + 1;
+  }
+  else
+  {
+    return NULL;
+  }
+}
+
+static void *edc_redstr_listener (void *p)
+{
+  redisReply *rep;
+  edc_redstr_conninfo *cinfo = (edc_redstr_conninfo *)p;
+  while (redisGetReply (cinfo->ctx_rd, (void*)&rep) == REDIS_OK)
+  {
+    if (rep->type == REDIS_REPLY_ARRAY && rep->elements == 4 && rep->element[2]->type == REDIS_REPLY_STRING && rep->element[3]->type == REDIS_REPLY_STRING)
+    {
+      char *topic = strdup (rep->element[2]->str);
+      char *op = edc_redstr_stripright (topic);
+      char *cmd = edc_redstr_stripright (topic);
+      char *dev = edc_redstr_stripright (topic);
+      iot_data_t *envelope = iot_data_from_json (rep->element[3]->str);
+      if (envelope && strcmp (iot_data_string_map_get_string (envelope, "ApiVersion"), "v2") == 0)
+      {
+        devsdk_http_request hreq;
+        devsdk_http_reply hreply;  // V3: make the handlers take more generic parameters
+        iot_data_t *reply;
+
+        char *rtopic = malloc (strlen (rep->element[2]->str) + cinfo->offset);
+        sprintf (rtopic, "%s.%s.%s.%s", cinfo->pubsub_topicbase, dev, cmd, op);
+        memset (&hreply, 0, sizeof (hreply));
+        memset (&hreq, 0, sizeof (hreq));
+        reply = iot_data_alloc_map (IOT_DATA_STRING);
+        iot_data_string_map_add (reply, "CorrelationID", iot_data_add_ref (iot_data_string_map_get (envelope, "CorrelationID")));
+        iot_data_string_map_add (reply, "RequestID", iot_data_add_ref (iot_data_string_map_get (envelope, "RequestID")));
+        iot_data_string_map_add (reply, "ApiVersion", iot_data_add_ref (iot_data_string_map_get (envelope, "ApiVersion")));
+
+        if (strcmp (op, "get") == 0)
+        {
+          hreq.method = DevSDK_Get;
+        }
+        else if (strcmp (op, "set") == 0)
+        {
+          hreq.method = DevSDK_Put;
+        }
+        else
+        {
+          hreq.method = DevSDK_Unknown;
+        }
+
+        if (hreq.method != DevSDK_Unknown)
+        {
+          const char *payload;
+          hreq.params = devsdk_nvpairs_new ("cmd", cmd, devsdk_nvpairs_new ("name", dev, NULL));
+          hreq.qparams = iot_data_add_ref (iot_data_string_map_get (envelope, "QueryParams"));
+          hreq.content_type = iot_data_string_map_get_string (envelope, "ContentType");
+          payload = iot_data_string_map_get_string (envelope, "Payload");
+          if (payload)
+          {
+            hreq.data.size = iot_b64_maxdecodesize (payload);
+            hreq.data.bytes = malloc (hreq.data.size + 1);
+            iot_b64_decode (payload, hreq.data.bytes, &hreq.data.size);
+            ((char *)hreq.data.bytes)[hreq.data.size] = '\0';
+          }
+
+          edgex_device_handler_device_namev2 (cinfo->svc, &hreq, &hreply);
+
+          devsdk_nvpairs_free ((devsdk_nvpairs *)hreq.params);
+          iot_data_free (hreq.qparams);
+          free (hreq.data.bytes);
+        }
+        else
+        {
+          edgex_error_response (cinfo->lc, &hreply, MHD_HTTP_METHOD_NOT_ALLOWED, "redis: only get and set operations allowed");
+        }
+
+        iot_data_string_map_add (reply, "ContentType", iot_data_alloc_string (hreply.content_type, IOT_DATA_REF));
+        iot_data_string_map_add (reply, "ErrorCode", iot_data_alloc_ui8 (hreply.code / 100 == 2 ? 0 : 1));
+        iot_data_string_map_add (reply, "Payload", iot_data_alloc_string (edc_redstr_b64 (hreply.data), IOT_DATA_TAKE));
+
+        edc_redstr_send (cinfo, rtopic, reply);
+
+        free (rtopic);
+        iot_data_free (reply);
+        free (hreply.data.bytes);
+      }
+      else
+      {
+        iot_log_error (cinfo->lc, "redis: unrecognized format in request");
+      }
+      free (topic);
+      iot_data_free (envelope);
+    }
+    else
+    {
+      iot_log_error (cinfo->lc, "redis: unexpected message format");
+    }
+    freeReplyObject (rep);
+  }
+  return NULL;
+}
+
+static bool edc_redstr_auth (iot_logger_t *lc, redisContext *ctx, const char *user, const char *pass)
+{
+  bool result = true;
+  redisReply *reply = (redisReply *)redisCommand (ctx, "AUTH %s %s", user ? user : "", pass);
+  if (reply == NULL || reply->type == REDIS_REPLY_ERROR)
+  {
+    result = false;
+    iot_log_error (lc, "Error authenticating with Redis: %s", reply ? reply->str : ctx->errstr);
+  }
+  freeReplyObject (reply);
+  return result;
 }
 
 edgex_data_client_t *edgex_data_client_new_redstr (devsdk_service_t *svc, const devsdk_timeout *tm, iot_threadpool_t *queue)
@@ -117,8 +311,11 @@ edgex_data_client_t *edgex_data_client_new_redstr (devsdk_service_t *svc, const 
   struct timeval tv;
   iot_logger_t *lc = svc->logger;
   const iot_data_t *allconf = svc->config.sdkconf;
-  edgex_data_client_t *result = malloc (sizeof (edgex_data_client_t));
-  edc_redstr_conninfo *cinfo = malloc (sizeof (edc_redstr_conninfo));
+  edgex_data_client_t *result = NULL;
+  const char *cmdtopic;
+  const char *reptopic;
+  edc_redstr_conninfo *cinfo = calloc (1, sizeof (edc_redstr_conninfo));
+  pthread_mutex_init (&cinfo->mtx, NULL);
 
   const char *host = iot_data_string_map_get_string (allconf, EX_MQ_HOST);
   uint16_t port = iot_data_ui16 (iot_data_string_map_get (allconf, EX_MQ_PORT));
@@ -129,12 +326,6 @@ edgex_data_client_t *edgex_data_client_new_redstr (devsdk_service_t *svc, const 
 
   iot_log_info (lc, "Event data will be sent through Redis streams at %s:%u", host, port);
 
-  result->lc = lc;
-  result->queue = queue;
-  result->pf = edc_redstr_postfn;
-  result->ff = edc_redstr_freefn;
-  result->address = cinfo;
-
   tv.tv_sec = tm->interval / 1000;
   tv.tv_usec = (tm->interval % 1000) * 1000;
 
@@ -142,63 +333,78 @@ edgex_data_client_t *edgex_data_client_new_redstr (devsdk_service_t *svc, const 
   {
     uint64_t t1, t2;
     t1 = iot_time_msecs ();
-    cinfo->ctx = redisConnectWithTimeout (host, port, tv);
-    if (cinfo->ctx && (cinfo->ctx->err == 0))
+    if (cinfo->ctx == NULL)
     {
-      break;
+      cinfo->ctx = edc_redstr_connect (lc, host, port, tv);
     }
-    if (cinfo->ctx)
+    if (cinfo->ctx_rd == NULL)
     {
-      iot_log_error (lc, "Failed to create Redis Streams client: %s", cinfo->ctx->errstr);
-      redisFree (cinfo->ctx);
-    }
-    else
-    {
-      iot_log_error (lc, "Can't allocate redis context");
+      cinfo->ctx_rd = edc_redstr_connect (lc, host, port, tv);
     }
     t2 = iot_time_msecs ();
-    if (t2 > tm->deadline - tm->interval)
+    if ((cinfo->ctx && cinfo->ctx_rd) || t2 > tm->deadline - tm->interval)
     {
-      return false;
+      break;
     }
     if (tm->interval > t2 - t1)
     {
       iot_wait_msecs (tm->interval - (t2 - t1));
     }
   }
-  if (cinfo->ctx == NULL || cinfo->ctx->err)
+  if (cinfo->ctx == NULL || cinfo->ctx_rd == NULL)
   {
-    free (cinfo);
-    free (result);
+    edc_redstr_freefn (lc, cinfo);
     return NULL;
   }
 
   if (strcmp (iot_data_string_map_get_string (allconf, EX_MQ_AUTHMODE), "usernamepassword") == 0)
   {
+    bool auth = true;
     iot_data_t *secrets = devsdk_get_secrets (svc, iot_data_string_map_get_string (allconf, EX_MQ_SECRETNAME));
-    const char *user = iot_data_string_map_get_string (secrets, "username");
     const char *pass = iot_data_string_map_get_string (secrets, "password");
     if (pass)
     {
-      redisReply *reply = (redisReply *)redisCommand (cinfo->ctx, "AUTH %s %s", user ? user : "", pass);
-      if (reply == NULL || reply->type == REDIS_REPLY_ERROR)
-      {
-        iot_log_error (lc, "Error authenticating with Redis: %s", reply ? reply->str : cinfo->ctx->errstr);
-        redisFree (cinfo->ctx);
-        freeReplyObject (reply);
-        free (cinfo);
-        free (result);
-        iot_data_free (secrets);
-        return NULL;
-      }
-      freeReplyObject (reply);
+      const char *user = iot_data_string_map_get_string (secrets, "username");
+      auth = edc_redstr_auth (lc, cinfo->ctx, user, pass) && edc_redstr_auth (lc, cinfo->ctx_rd, user, pass);
     }
     iot_data_free (secrets);
+    if (!auth)
+    {
+      edc_redstr_freefn (lc, cinfo);
+      return NULL;
+    }
   }
 
-  cinfo->topicbase = strdup (iot_data_string_map_get_string (allconf, EX_MQ_TOPIC));
-  remapslash (cinfo->topicbase);
+  cmdtopic = iot_data_string_map_get_string (allconf, EX_MQ_TOPIC_CMDREQ);
+  if (!edc_redis_subscribe (lc, cinfo->ctx_rd, cmdtopic))
+  {
+    edc_redstr_freefn (lc, cinfo);
+    return NULL;
+  }
 
-  pthread_mutex_init (&cinfo->mtx, NULL);
+  reptopic = iot_data_string_map_get_string (allconf, EX_MQ_TOPIC_CMDRESP);
+  cinfo->topicbase = strdup (iot_data_string_map_get_string (allconf, EX_MQ_TOPIC));
+  cinfo->pubsub_topicbase = malloc (strlen (reptopic) + strlen (svc->name) + 2);
+  sprintf (cinfo->pubsub_topicbase, "%s.%s", reptopic, svc->name);
+  edc_redstr_remapslash (cinfo->topicbase);
+  edc_redstr_remapslash (cinfo->pubsub_topicbase);
+  cinfo->offset = strlen (cinfo->pubsub_topicbase) - strlen (cmdtopic) + sizeof ("/#");
+
+  cinfo->svc = svc;
+  cinfo->lc = lc;
+
+  if (!iot_thread_create (&cinfo->thread, edc_redstr_listener, cinfo, IOT_THREAD_NO_PRIORITY, IOT_THREAD_NO_AFFINITY, lc))
+  {
+    edc_redstr_freefn (lc, cinfo);
+    return NULL;
+  }
+
+  cinfo->running = true;
+  result = malloc (sizeof (edgex_data_client_t));
+  result->lc = lc;
+  result->queue = queue;
+  result->pf = edc_redstr_postfn;
+  result->ff = edc_redstr_freefn;
+  result->address = cinfo;
   return result;
 }

--- a/src/c/data.h
+++ b/src/c/data.h
@@ -30,6 +30,8 @@
 #define EX_MQ_CERTFILE "MessageQueue/Optional/CertFile"
 #define EX_MQ_KEYFILE "MessageQueue/Optional/KeyFile"
 #define EX_MQ_SKIPVERIFY "MessageQueue/Optional/SkipCertVerify"
+#define EX_MQ_TOPIC_CMDREQ "MessageQueue/Topics/CommandRequestTopic"
+#define EX_MQ_TOPIC_CMDRESP "MessageQueue/Topics/CommandResponseTopicPrefix"
 
 typedef enum { JSON, CBOR} edgex_event_encoding;
 


### PR DESCRIPTION
Closes #374


<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) - existing feature in Go SDK
  <link to docs PR>

## Testing Instructions
Enable MessageBus in the example (Device/UseMessageBus = true, MessageQueue/Type = "redis") and send requests via core-command


## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->