### PR TITLE
feat: add metrics publication

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,7 +2,8 @@ This is the C SDK for EdgeX device services.
 
 Changes for 2.3.0 "Levski":
 
-- Implement device commands via redis MessageQueue
+- Publish metrics on pub/sub (redis only)
+- Implement device commands on pub/sub (redis only)
 - Implement MaxEventSize configuration
 
 Changes for 2.2.0 "Kamakura":

--- a/src/c/autoevent.c
+++ b/src/c/autoevent.c
@@ -88,7 +88,7 @@ static void *ae_runner (void *p)
             }
             else
             {
-              edgex_data_client_add_event (ai->svc->dataclient, event);
+              edgex_data_client_add_event (ai->svc->dataclient, event, &ai->svc->metrics);
             }
             if (ai->onChange)
             {

--- a/src/c/config.h
+++ b/src/c/config.h
@@ -16,6 +16,12 @@
 
 #include <stdatomic.h>
 
+#define EX_METRIC_EVSENT 0x1
+#define EX_METRIC_RDGSENT 0x2
+#define EX_METRIC_RDCMDS 0x4
+#define EX_METRIC_SECREQ 0x8
+#define EX_METRIC_SECSTO 0x10
+
 typedef struct edgex_device_serviceinfo
 {
   const char *host;
@@ -39,6 +45,13 @@ typedef struct edgex_service_endpoints
   edgex_device_service_endpoint data;
   edgex_device_service_endpoint metadata;
 } edgex_service_endpoints;
+
+typedef struct edgex_device_metricinfo
+{
+  uint64_t flags;
+  const char *interval;
+  const char *topic;
+} edgex_device_metricinfo;
 
 typedef struct edgex_device_deviceinfo
 {
@@ -68,6 +81,7 @@ typedef struct edgex_device_config
   edgex_device_serviceinfo service;
   edgex_service_endpoints endpoints;
   edgex_device_deviceinfo device;
+  edgex_device_metricinfo metrics;
   iot_loglevel_t loglevel;
   iot_data_t *driverconf;
   iot_data_t *sdkconf;

--- a/src/c/data-mqtt.c
+++ b/src/c/data-mqtt.c
@@ -252,6 +252,7 @@ edgex_data_client_t *edgex_data_client_new_mqtt (devsdk_service_t *svc, const de
   result->queue = queue;
   result->pf = edc_mqtt_postfn;
   result->ff = edc_mqtt_freefn;
+  result->mf = NULL;
   result->address = cinfo;
 
   cinfo->qos = iot_data_ui16 (iot_data_string_map_get (allconf, EX_MQ_QOS));

--- a/src/c/data-rest.c
+++ b/src/c/data-rest.c
@@ -50,6 +50,7 @@ edgex_data_client_t *edgex_data_client_new_rest (const edgex_device_service_endp
   result->queue = queue;
   result->pf = edc_rest_postfn;
   result->ff = edc_rest_freefn;
+  result->mf = NULL;
   char *url = malloc (URL_BUF_SIZE);
   snprintf (url, URL_BUF_SIZE - 1, "http://%s:%u/api/v2/event/", e->host, e->port);
   result->address = url;

--- a/src/c/data.h
+++ b/src/c/data.h
@@ -10,6 +10,8 @@
 #define _EDGEX_DATA_H_ 1
 
 #include "devsdk/devsdk.h"
+#include "metrics.h"
+#include "config.h"
 #include "parson.h"
 #include "cmdinfo.h"
 #include "rest-server.h"
@@ -38,6 +40,7 @@ typedef enum { JSON, CBOR} edgex_event_encoding;
 typedef struct edgex_event_cooked
 {
   atomic_uint_fast32_t refs;
+  unsigned nrdgs;
   char *path;
   edgex_event_encoding encoding;
   union
@@ -66,6 +69,7 @@ edgex_event_cooked *edgex_data_process_event
 
 typedef void (*edc_freefn) (iot_logger_t *lc, void *address);
 typedef void (*edc_postfn) (iot_logger_t *lc, void *address, edgex_event_cooked *event);
+typedef void (*edc_metfn) (void *address, const char *mname, const iot_data_t *envelope);
 
 typedef struct edgex_data_client_t
 {
@@ -74,6 +78,7 @@ typedef struct edgex_data_client_t
   iot_threadpool_t *queue;
   edc_postfn pf;
   edc_freefn ff;
+  edc_metfn mf;
 } edgex_data_client_t;
 
 typedef struct edgex_device_service_endpoint edgex_device_service_endpoint;
@@ -82,9 +87,11 @@ edgex_data_client_t *edgex_data_client_new_rest (const edgex_device_service_endp
 
 void edgex_data_client_free (edgex_data_client_t *client);
 
-void edgex_data_client_add_event (edgex_data_client_t *client, edgex_event_cooked *eventval);
+void edgex_data_client_add_event (edgex_data_client_t *client, edgex_event_cooked *eventval, devsdk_metrics_t *metrics);
 
-void edgex_data_client_add_event_now (edgex_data_client_t *client, edgex_event_cooked *eventval);
+void edgex_data_client_add_event_now (edgex_data_client_t *client, edgex_event_cooked *eventval, devsdk_metrics_t *metrics);
+
+void edgex_data_client_publish_metrics (edgex_data_client_t *client, const devsdk_metrics_t *metrics, const edgex_device_metricinfo *cfg);
 
 void devsdk_commandresult_free (devsdk_commandresult *res, int n);
 

--- a/src/c/device.c
+++ b/src/c/device.c
@@ -708,6 +708,7 @@ static edgex_event_cooked *edgex_device_runget2
       edgex_error_response
         (svc->logger, reply, MHD_HTTP_INTERNAL_SERVER_ERROR, "Driver for %s failed on GET: ", dev->name, e ? iot_data_to_json (e) : "(unknown)");
     }
+    atomic_fetch_add (&svc->metrics.rcexe, 1);
   }
   else
   {
@@ -778,12 +779,12 @@ static void edgex_device_v2impl (devsdk_service_t *svc, edgex_device *dev, const
           if (retv)
           {
             edgex_event_cooked_add_ref (event);
-            edgex_data_client_add_event_now (svc->dataclient, event);
+            edgex_data_client_add_event_now (svc->dataclient, event, &svc->metrics);
             edgex_event_cooked_write (event, reply);
           }
           else
           {
-            edgex_data_client_add_event (svc->dataclient, event);
+            edgex_data_client_add_event (svc->dataclient, event, &svc->metrics);
             edgex_baseresponse_populate (&br, "v2", MHD_HTTP_OK, "Event generated successfully");
             edgex_baseresponse_write (&br, reply);
           }

--- a/src/c/metrics.h
+++ b/src/c/metrics.h
@@ -9,8 +9,18 @@
 #ifndef _EDGEX_DEVICE_METRICS_H_
 #define _EDGEX_DEVICE_METRICS_H_ 1
 
+#include <stdatomic.h>
 #include "rest-server.h"
 
 extern void edgex_device_handler_metricsv2 (void *ctx, const devsdk_http_request *req, devsdk_http_reply *reply);
+
+typedef struct devsdk_metrics_t
+{
+  atomic_uint_fast64_t esent;
+  atomic_uint_fast64_t rsent;
+  atomic_uint_fast64_t rcexe;
+  atomic_uint_fast64_t secrq;
+  atomic_uint_fast64_t secsto;
+} devsdk_metrics_t;
 
 #endif

--- a/src/c/secrets.h
+++ b/src/c/secrets.h
@@ -11,6 +11,7 @@
 
 #include "rest.h"
 #include "rest-server.h"
+#include "metrics.h"
 #include "iot/scheduler.h"
 
 typedef struct edgex_secret_provider_t edgex_secret_provider_t;
@@ -18,7 +19,8 @@ typedef struct edgex_secret_provider_t edgex_secret_provider_t;
 edgex_secret_provider_t *edgex_secrets_get_insecure (void);
 edgex_secret_provider_t *edgex_secrets_get_vault (void);
 
-bool edgex_secrets_init (edgex_secret_provider_t *sp, iot_logger_t *lc, iot_scheduler_t *sched, iot_threadpool_t *pool, const char *svcname, iot_data_t *config);
+bool edgex_secrets_init
+  (edgex_secret_provider_t *sp, iot_logger_t *lc, iot_scheduler_t *sched, iot_threadpool_t *pool, const char *svcname, iot_data_t *config, devsdk_metrics_t *m);
 void edgex_secrets_reconfigure (edgex_secret_provider_t *sp, iot_data_t *config);
 iot_data_t *edgex_secrets_get (edgex_secret_provider_t *sp, const char *path);
 void edgex_secrets_getregtoken (edgex_secret_provider_t *sp, edgex_ctx *ctx);

--- a/src/c/service.h
+++ b/src/c/service.h
@@ -10,6 +10,7 @@
 #define _EDGEX_DEVICE_SERVICE_H_ 1
 
 #include "devsdk/devsdk.h"
+#include "metrics.h"
 #include "registry.h"
 #include "config.h"
 #include "data.h"
@@ -63,6 +64,8 @@ struct devsdk_service_t
   devsdk_registry_t *registry;
   edgex_device_adminstate adminstate;
   uint64_t starttime;
+  devsdk_metrics_t metrics;
+  iot_schedule_t *metricschedule;
   bool overwriteconfig;
 
   edgex_devmap_t *devices;
@@ -71,5 +74,7 @@ struct devsdk_service_t
   iot_threadpool_t *eventq;
   iot_scheduler_t *scheduler;
 };
+
+extern void devsdk_schedule_metrics (devsdk_service_t *svc);
 
 #endif


### PR DESCRIPTION
closes #415

Signed-off-by: Iain Anderson <iain@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Configure the template example for Redis MessageQueue, and enable some metrics, eg
```
 [Writable.Telemetry.Metrics]
    EventsSent = true
    ReadingsSent = true
```
Observe publications using `redis-cli monitor`

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->