### PR TITLE
Synchronize autoevent start and stop operation to prevent fatal segmentation faults in device services

### DIFF
--- a/src/c/autoevent.h
+++ b/src/c/autoevent.h
@@ -5,14 +5,23 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  */
+#include <semaphore.h>
 
 #ifndef _EDGEX_DEVICE_AUTOEVENT_H
 #define _EDGEX_DEVICE_AUTOEVENT_H 1
 
 #include "service.h"
 
+sem_t mstr_mutex;
+
+sem_t slv_mutex;
+
 void edgex_device_autoevent_start (devsdk_service_t *svc, edgex_device *dev);
 
 void edgex_device_autoevent_stop (edgex_device *dev);
+
+void edgex_device_autoevent_stop_to_update (edgex_device *dev);
+
+void clear_ae_signals ();
 
 #endif

--- a/src/c/devmap.c
+++ b/src/c/devmap.c
@@ -65,6 +65,7 @@ void edgex_devmap_clear (edgex_devmap_t *map)
     edgex_map_remove (&map->devices, key);
     key = next;
   }
+  clear_ae_signals ();
   pthread_rwlock_unlock (&map->lock);
 }
 
@@ -348,7 +349,7 @@ void edgex_devmap_update_profile (devsdk_service_t *svc, edgex_deviceprofile *dp
       edgex_device **dev = edgex_map_get (&svc->devices->devices, key);
       if ((*dev)->profile == old)
       {
-        edgex_device_autoevent_stop (*dev);
+        edgex_device_autoevent_stop_to_update (*dev);
         (*dev)->profile = dp;
         edgex_device_autoevent_start (svc, *dev);
       }


### PR DESCRIPTION
BREAKING CHANGE: The concept is to have a proper synchronization mechanism using two level semaphores for device autoevents stop and start operation whenever there is some device profile update... This mechanism prevents the chances of segmentation faults in device services which actually results to device service start failure and instability...

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->