### PR TITLE
fix: update edgex_data_to_b64 to ignore the last null character

### DIFF
--- a/src/c/bus.c
+++ b/src/c/bus.c
@@ -87,7 +87,7 @@ static void edgex_bus_endpoint_free (void *p)
 static char *edgex_data_to_b64 (const iot_data_t *src)
 {
   char *json = iot_data_to_json (src);
-  size_t sz = strlen (json) + 1;
+  size_t sz = strlen (json); // ignore the last null character, which causes an unmarshal error in core-data
   size_t encsz = iot_b64_encodesize (sz);
   char *result = malloc (encsz);
   iot_b64_encode (json, sz, result, encsz);


### PR DESCRIPTION
fix: #466 

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Run device-example-c https://docs.edgexfoundry.org/3.0/getting-started/Ch-GettingStartedSDK-C/#run-your-device-service and verify if events are being created successfully.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->