### PR TITLE
fix: invalid pointer operation in edgex_bus_mqtt_msgarrvd

### DIFF
--- a/src/c/bus-mqtt.c
+++ b/src/c/bus-mqtt.c
@@ -129,20 +129,25 @@ static int edgex_bus_mqtt_msgarrvd (void *context, char *topicName, int topicLen
 
   if (topicLen != 0) // Indicates topic string not terminated
   {
-    topic = realloc (topic, topicLen + 1);
-    topic[topicLen] = '\0';
+    topic = strndup (topicName, topicLen);
   }
   if (msg[message->payloadlen - 1] != '\0')
   {
-    message->payload = realloc (message->payload, message->payloadlen + 1);
-    msg = message->payload;
-    msg[message->payloadlen] = '\0';
+    msg = strndup (message->payload, message->payloadlen);
   }
 
   edgex_bus_handle_request (bus, topic, msg);
 
+  if (topic != topicName)
+  {
+    free(topic);
+  }
+  if (msg != message->payload)
+  {
+    free(msg);
+  }
   MQTTAsync_freeMessage (&message);
-  MQTTAsync_free (topic);
+  MQTTAsync_free (topicName);
   return 1;
 }
 


### PR DESCRIPTION
The allocated block in the pointers *topicName and *message passed by MQTT library cannot be re-allocated.

fix: #468 

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Download and update the [configuration file](https://docs.edgexfoundry.org/3.1/getting-started/Ch-GettingStartedSDK-C/#configuring-your-device-service) of device-example-c to use mqtt-bus
```
MessageBus:
  Protocol: tcp
  Host: localhost
  Port: 1883
  Type: mqtt
  AuthMode: "none" 
```
Run non-secure EdgeX stack with mqtt-bus
Build and run [device-example-c](https://docs.edgexfoundry.org/3.1/getting-started/Ch-GettingStartedSDK-C/#run-your-device-service)
Device RandNum-Device01 should be created successfully

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->