### PR TITLE
fix: update devsdk_post_readings to alloc and free correction id

### DIFF
--- a/src/c/examples/file/README.md
+++ b/src/c/examples/file/README.md
@@ -12,12 +12,12 @@ deliver events asynchronously.
 The environment variable CSDK_DIR should be set to a directory containing the
 C SDK include files and libraries.
 
-Set LD_LIBRARY_PATH to $CSDK_DIR/lib
+Set LD_LIBRARY_PATH to $CSDK_DIR/lib:/opt/iotech/iot/1.5/lib
 
 ### Building
 
 ```
-gcc -I$CSDK_DIR/include -L$CSDK_DIR/lib -o device-file device-file.c -lcsdk
+gcc -I$CSDK_DIR/include -I/opt/iotech/iot/1.5/include -L$CSDK_DIR/lib -L/opt/iotech/iot/1.5/lib -o device-file device-file.c -lcsdk -liot
 ```
 
 ### Device Profile

--- a/src/c/service.c
+++ b/src/c/service.c
@@ -1047,6 +1047,7 @@ void devsdk_post_readings
 
     if (event)
     {
+      edgex_device_alloc_crlid (NULL);
       if (svc->config.device.maxeventsize && edgex_event_cooked_size (event) > svc->config.device.maxeventsize * 1024)
       {
         iot_log_error (svc->logger, "Post readings: Event size (%d KiB) exceeds configured MaxEventSize", edgex_event_cooked_size (event) / 1024);
@@ -1062,6 +1063,7 @@ void devsdk_post_readings
         devsdk_error err = EDGEX_OK;
         edgex_metadata_client_update_lastconnected (svc->logger, &svc->config.endpoints, svc->secretstore, devname, &err);
       }
+      edgex_device_free_crlid();
     }
   }
   else


### PR DESCRIPTION
fix #464

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Run EdgeX stack
Build and run the file monitor example (src/c/examples/file/device-example-c)
