### PR TITLE
fix: update edgex_get_transformArg to reflect data type changes in ResourceProperties

### DIFF
--- a/src/c/dto-read.c
+++ b/src/c/dto-read.c
@@ -146,30 +146,23 @@ static void edgex_get_readwrite (const iot_data_t *object, bool *read, bool *wri
 
 static void edgex_get_transformArg (const iot_data_t *obj, const char *name, iot_typecode_t type, edgex_transformArg *res)
 {
-  const char *str;
-  char *end = NULL;
-
   res->enabled = false;
-  str = iot_data_string_map_get_string (obj, name);
-  if (str && *str)
+  if (type.type >= IOT_DATA_INT8 && type.type <= IOT_DATA_UINT64)
   {
-    if (type.type >= IOT_DATA_INT8 && type.type <= IOT_DATA_UINT64)
+    int64_t i = 0;
+    if (iot_data_string_map_get_number(obj, name, IOT_DATA_INT64, &i))
     {
-      int64_t i = strtol (str, &end, 0);
-      if (*end == '\0')
-      {
-        res->enabled = true;
-        res->value.ival = i;
-      }
+      res->enabled = true;
+      res->value.ival = i;
     }
-    else if (type.type == IOT_DATA_FLOAT32 || type.type == IOT_DATA_FLOAT64)
+  }
+  else if (type.type == IOT_DATA_FLOAT32 || type.type == IOT_DATA_FLOAT64)
+  {
+    double d = 0;
+    if (iot_data_string_map_get_number(obj, name, IOT_DATA_FLOAT64, &d))
     {
-      double d = strtod (str, &end);
-      if (*end == '\0')
-      {
-        res->enabled = true;
-        res->value.dval = d;
-      }
+      res->enabled = true;
+      res->value.dval = d;
     }
   }
 }

--- a/src/c/examples/bitfields/README.md
+++ b/src/c/examples/bitfields/README.md
@@ -18,12 +18,12 @@ of these four values.
 The environment variable CSDK_DIR should be set to a directory containing the
 C SDK include files and libraries.
 
-Set LD_LIBRARY_PATH to $CSDK_DIR/lib
+Set LD_LIBRARY_PATH to `$CSDK_DIR/lib:/opt/iotech/iot/1.5/lib`
 
 ### Building
 
 ```
-gcc -I$CSDK_DIR/include -L$CSDK_DIR/lib -o device-bitfields device-bitfields.c -lcsdk
+gcc -I$CSDK_DIR/include -I/opt/iotech/iot/1.5/include -L$CSDK_DIR/lib -L/opt/iotech/iot/1.5/lib -o device-bitfields device-bitfields.c -lcsdk -liot
 ```
 
 ### Device Profile
@@ -54,17 +54,17 @@ The supplied configuration file `res/configuration.toml` includes a definition f
 An EdgeX system containing at least a database and the core-data and core-metadata services must be running. The configuration file must be edited to reflect the locations of the core-data and core-metadata services.
 
 ```
-./device-bitfields -c res
+./device-bitfields
 ```
 
 To read value "B" (bits 8-15):
 
 ```
-curl 0:59999/api/v2/device/name/Bitfields/B
+curl 0:59999/api/v3/device/name/Bitfields/B
 ```
 
 To write a value into "B":
 
 ```
-curl -X PUT -d '{"B":"221"}' 0:59999/api/v2/device/name/Bitfields/B
+curl -X PUT -d '{"B":"221"}' 0:59999/api/v3/device/name/Bitfields/B
 ```

--- a/src/c/examples/bitfields/res/configuration.yaml
+++ b/src/c/examples/bitfields/res/configuration.yaml
@@ -2,6 +2,7 @@ Writable:
   LogLevel: DEBUG
 
 Service:
+  Host: localhost
   Port: 59999
   StartupMsg: Example bitfields device service started
 

--- a/src/c/examples/bitfields/res/profiles/Example-Bitfields.json
+++ b/src/c/examples/bitfields/res/profiles/Example-Bitfields.json
@@ -11,22 +11,22 @@
     {
       "name": "A",
       "description": "Byte 0 (LSB)",
-      "properties": { "valueType": "Uint32", "readWrite": "RW", "mask": "0xFF", "units": "things" }
+      "properties": { "valueType": "Uint32", "readWrite": "RW", "mask": 255, "units": "things" }
     },
     {
       "name": "B",
       "description": "Byte 1",
-      "properties": { "valueType": "Uint32", "readWrite": "RW", "mask": "0xFF00", "shift": "8", "units": "things" }
+      "properties": { "valueType": "Uint32", "readWrite": "RW", "mask": 65280, "shift": 8, "units": "things" }
     },
     {
       "name": "C",
       "description": "Byte 2",
-      "properties": { "valueType": "Uint32", "readWrite": "RW", "mask": "0xFF0000", "shift": "16", "units": "things" }
+      "properties": { "valueType": "Uint32", "readWrite": "RW", "mask": 16711680, "shift": 16, "units": "things" }
     },
     {
       "name": "D",
       "description": "Byte 3 (MSB)",
-      "properties": { "valueType": "Uint32", "readWrite": "RW", "mask": "0xFF000000", "shift": "24", "units": "things" }
+      "properties": { "valueType": "Uint32", "readWrite": "RW", "mask": 4278190080, "shift": 24, "units": "things" }
     }
   ]
 }


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

fix: #475 

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
 https://github.com/edgexfoundry/edgex-docs/pull/1180

## Testing Instructions
<!-- How can the reviewers test your change? -->
Run EdgeX stack
Follow the instructions in /src/c/examples/bitfields/README.md to run the device-bitfields example
