### PR TITLE
fix: support for any JSON data type in device command value

### DIFF
--- a/src/c/reqdata.c
+++ b/src/c/reqdata.c
@@ -102,7 +102,10 @@ extern const char *edgex_reqdata_get (const edgex_reqdata_t *data, const char *n
   const char *result = NULL;
   if (data->json)
   {
-    result = json_object_get_string (data->json, name);
+    JSON_Value *value = json_object_get_value(data->json, name);
+    if (value) {
+      result = json_serialize_to_string(value);
+    }
   }
   else
   {


### PR DESCRIPTION
fix: #479 

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
From the latest compose builder run `make run no-secty`
Run the [Random generator example](https://github.com/edgexfoundry/device-sdk-c/tree/main/src/c/examples/random) with the following device profile:
```
{
  "name": "ExampleSensor",
  "manufacturer": "IoTechSystems",
  "model": "IoT3",
  "description": "Random Example Sensor",
  "labels": ["sensor"],
  "apiVersion": "v3",

  "deviceResources":
  [
    {
      "name": "SensorOne",
       "description": "A Sensor generating values between 0 & 100",
       "attributes": { "SensorID": "Sen1" , "SensorType": 1 },
       "properties": { "valueType": "Uint64", "readWrite": "R", "units": "Random" }
    },
    {
       "name": "SensorTwo",
       "description": "A Sensor generating values between 1 & 1000",
       "attributes": { "SensorID": "Sen2", "SensorType": 2 },
       "properties": { "valueType": "Uint64", "readWrite": "R", "units": "Random" }
    },
    {
       "name": "Switch",
       "description": "A generic switch",
       "attributes": { "SwitchID": "Switch1" },
       "properties": { "valueType": "Bool", "readWrite": "RW", "units": "State" }
    }
  ],
  "deviceCommands": [
    {
      "name": "Switch",
      "readWrite": "RW",
      "resourceOperations": [
        {
          "deviceResource": "Switch"
        }
      ]
    }
  ]
}

```
Issue a device command:
```
curl -X PUT 'http://0:59999/api/v3/device/name/RandomDevice1/Switch' -d '{"Switch": true}'
```
Verify the response contains the following message:
```
{"apiVersion":"v3","requestId":"fec37887-22a0-4012-bb4c-2679424fc64f","statusCode":200,"message":"Data written successfully"}
```
Verify the Switch value has been set to true:
```
{"apiVersion":"v3","event":{"apiVersion":"v3","deviceName":"RandomDevice1","id":"0a12e61c-d45d-4349-b3f0-1c8728fbfb2b","origin":1693387122547996130,"profileName":"ExampleSensor","readings":[{"apiVersion":"v3","deviceName":"RandomDevice1","id":"bcef5fe4-e7a6-4f35-adbf-508a5d49c256","origin":1693387122547996130,"profileName":"ExampleSensor","resourceName":"Switch","value":"true","valueType":"Bool"}],"sourceName":"Switch"},"statusCode":200}
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->