### PR TITLE
feat!: load common configuration from config provider

### DIFF
--- a/src/c/bus-redstr.c
+++ b/src/c/bus-redstr.c
@@ -127,7 +127,7 @@ static bool edgex_bus_redstr_auth (iot_logger_t *lc, redisContext *ctx, const ch
   return result;
 }
 
-edgex_bus_t *edgex_bus_create_redstr (iot_logger_t *lc, const char *svcname, const iot_data_t *cfg, edgex_secret_provider_t *secstore, iot_threadpool_t *queue, const devsdk_timeout *tm)
+edgex_bus_t *edgex_bus_create_redstr (iot_logger_t *lc, const char *svcname, const iot_data_t *cfg, edgex_secret_provider_t *secstore, iot_threadpool_t *queue, const devsdk_timeout *tm, char *secure)
 {
   struct timeval tv;
   edgex_bus_t *result = NULL;
@@ -175,7 +175,7 @@ edgex_bus_t *edgex_bus_create_redstr (iot_logger_t *lc, const char *svcname, con
     return NULL;
   }
 
-  if (strcmp (iot_data_string_map_get_string (cfg, EX_BUS_AUTHMODE), "usernamepassword") == 0)
+  if (secure && strcmp (secure, "true") == 0 && strcmp (iot_data_string_map_get_string (cfg, EX_BUS_AUTHMODE), "usernamepassword") == 0)
   {
     bool auth = true;
     iot_data_t *secrets = edgex_secrets_get (secstore, iot_data_string_map_get_string (cfg, EX_BUS_SECRETNAME));

--- a/src/c/bus-redstr.c
+++ b/src/c/bus-redstr.c
@@ -127,7 +127,7 @@ static bool edgex_bus_redstr_auth (iot_logger_t *lc, redisContext *ctx, const ch
   return result;
 }
 
-edgex_bus_t *edgex_bus_create_redstr (iot_logger_t *lc, const char *svcname, const iot_data_t *cfg, edgex_secret_provider_t *secstore, iot_threadpool_t *queue, const devsdk_timeout *tm, char *secure)
+edgex_bus_t *edgex_bus_create_redstr (iot_logger_t *lc, const char *svcname, const iot_data_t *cfg, edgex_secret_provider_t *secstore, iot_threadpool_t *queue, const devsdk_timeout *tm, bool secureMode)
 {
   struct timeval tv;
   edgex_bus_t *result = NULL;
@@ -175,7 +175,7 @@ edgex_bus_t *edgex_bus_create_redstr (iot_logger_t *lc, const char *svcname, con
     return NULL;
   }
 
-  if (secure && strcmp (secure, "true") == 0 && strcmp (iot_data_string_map_get_string (cfg, EX_BUS_AUTHMODE), "usernamepassword") == 0)
+  if (secureMode && strcmp (iot_data_string_map_get_string (cfg, EX_BUS_AUTHMODE), "usernamepassword") == 0)
   {
     bool auth = true;
     iot_data_t *secrets = edgex_secrets_get (secstore, iot_data_string_map_get_string (cfg, EX_BUS_SECRETNAME));

--- a/src/c/bus.h
+++ b/src/c/bus.h
@@ -42,7 +42,7 @@ JSON_Value *edgex_bus_config_json (const iot_data_t *allconf);
 edgex_bus_t *edgex_bus_create_mqtt
   (iot_logger_t *lc, const char *svcname, const iot_data_t *cfg, edgex_secret_provider_t *secstore, iot_threadpool_t *queue, const devsdk_timeout *tm);
 edgex_bus_t *edgex_bus_create_redstr
-  (iot_logger_t *lc, const char *svcname, const iot_data_t *cfg, edgex_secret_provider_t *secstore, iot_threadpool_t *queue, const devsdk_timeout *tm);
+  (iot_logger_t *lc, const char *svcname, const iot_data_t *cfg, edgex_secret_provider_t *secstore, iot_threadpool_t *queue, const devsdk_timeout *tm, char *secure);
 
 void edgex_bus_register_handler (edgex_bus_t *bus, const char *path, void *ctx, edgex_handler_fn handler);
 char *edgex_bus_mktopic (edgex_bus_t *bus, const char *type, const char *param);

--- a/src/c/bus.h
+++ b/src/c/bus.h
@@ -42,7 +42,7 @@ JSON_Value *edgex_bus_config_json (const iot_data_t *allconf);
 edgex_bus_t *edgex_bus_create_mqtt
   (iot_logger_t *lc, const char *svcname, const iot_data_t *cfg, edgex_secret_provider_t *secstore, iot_threadpool_t *queue, const devsdk_timeout *tm);
 edgex_bus_t *edgex_bus_create_redstr
-  (iot_logger_t *lc, const char *svcname, const iot_data_t *cfg, edgex_secret_provider_t *secstore, iot_threadpool_t *queue, const devsdk_timeout *tm, char *secure);
+  (iot_logger_t *lc, const char *svcname, const iot_data_t *cfg, edgex_secret_provider_t *secstore, iot_threadpool_t *queue, const devsdk_timeout *tm, bool secureMode);
 
 void edgex_bus_register_handler (edgex_bus_t *bus, const char *path, void *ctx, edgex_handler_fn handler);
 char *edgex_bus_mktopic (edgex_bus_t *bus, const char *type, const char *param);

--- a/src/c/config.c
+++ b/src/c/config.c
@@ -38,7 +38,7 @@
 
 #include <iot/data.h>
 
-#include "iot/time.h"
+#include <iot/time.h>
 
 #define ERRBUFSZ 1024
 #define DEFAULTREG "consul.http://localhost:8500"
@@ -552,12 +552,8 @@ void edgex_device_updateCommonConf (void *p, const devsdk_nvpairs *config)
   timeout->deadline = iot_time_secs () + 10;
   timeout->interval = 1;
   t1 = iot_time_secs ();
-  while (true)
+  while (svc->config.sdkconf == NULL)
   {
-    if (svc->config.sdkconf)
-    {
-      break;
-    }
     t2 = iot_time_secs ();
     if (t2 > timeout->deadline - timeout->interval)
     {

--- a/src/c/config.c
+++ b/src/c/config.c
@@ -26,18 +26,19 @@
 #include "edgex-rest.h"
 #include "edgex-logging.h"
 #include "devutil.h"
-#include "autoevent.h"
 #include "device.h"
-#include "edgex/devices.h"
 
 #include <microhttpd.h>
 
 #include <stdlib.h>
 #include <string.h>
-#include <errno.h>
 #include <sys/utsname.h>
 
 #include <iot/file.h>
+
+#include <iot/data.h>
+
+#include "iot/time.h"
 
 #define ERRBUFSZ 1024
 #define DEFAULTREG "consul.http://localhost:8500"
@@ -45,7 +46,7 @@
 #define DEFAULTSECCAFILE "/tmp/edgex/secrets/%s/secrets-token.json"
 #define DEFAULTMETRICSTOPIC "edgex/telemetry"
 
-iot_data_t *edgex_config_defaults (const iot_data_t *driverconf, const char *svcname)
+iot_data_t *edgex_common_config_defaults (const char *svcname)
 {
   struct utsname utsbuffer;
   uname (&utsbuffer);
@@ -56,19 +57,14 @@ iot_data_t *edgex_config_defaults (const iot_data_t *driverconf, const char *svc
 
   iot_data_t *result = iot_data_alloc_map (IOT_DATA_STRING);
 
-  iot_data_string_map_add (result, DYN_PREFIX "LogLevel", iot_data_alloc_string ("WARNING", IOT_DATA_REF));
-  iot_data_string_map_add (result, DYN_PREFIX "Device/DataTransform", iot_data_alloc_bool (true));
-  iot_data_string_map_add (result, DYN_PREFIX "Device/Discovery/Enabled", iot_data_alloc_bool (true));
-  iot_data_string_map_add (result, DYN_PREFIX "Device/Discovery/Interval", iot_data_alloc_ui32 (0));
-  iot_data_string_map_add (result, DYN_PREFIX "Device/UpdateLastConnected", iot_data_alloc_bool (false));
-  iot_data_string_map_add (result, DYN_PREFIX "Device/MaxCmdOps", iot_data_alloc_ui32 (0));
-  iot_data_string_map_add (result, DYN_PREFIX "Device/MaxEventSize", iot_data_alloc_ui32 (0));
+  iot_data_string_map_add (result, "Device/DataTransform", iot_data_alloc_bool (true));
+  iot_data_string_map_add (result, "Device/Discovery/Enabled", iot_data_alloc_bool (true));
+  iot_data_string_map_add (result, "Device/Discovery/Interval", iot_data_alloc_ui32 (0));
+  iot_data_string_map_add (result, "Device/MaxCmdOps", iot_data_alloc_ui32 (0));
 
   iot_data_string_map_add (result, DYN_PREFIX "Telemetry/Interval", iot_data_alloc_string ("30s", IOT_DATA_REF));
-  iot_data_string_map_add (result, DYN_PREFIX "Telemetry/PublishTopicPrefix", iot_data_alloc_string (DEFAULTMETRICSTOPIC, IOT_DATA_REF));
   iot_data_string_map_add (result, DYN_PREFIX "Telemetry/Metrics/EventsSent", iot_data_alloc_bool (false));
   iot_data_string_map_add (result, DYN_PREFIX "Telemetry/Metrics/ReadingsSent", iot_data_alloc_bool (false));
-  iot_data_string_map_add (result, DYN_PREFIX "Telemetry/Metrics/ReadCommandsExecuted", iot_data_alloc_bool (false));
   iot_data_string_map_add (result, DYN_PREFIX "Telemetry/Metrics/SecuritySecretsRequested", iot_data_alloc_bool (false));
   iot_data_string_map_add (result, DYN_PREFIX "Telemetry/Metrics/SecuritySecretsStored", iot_data_alloc_bool (false));
 
@@ -92,7 +88,7 @@ iot_data_t *edgex_config_defaults (const iot_data_t *driverconf, const char *svc
   iot_data_string_map_add (result, "Device/DevicesDir", iot_data_alloc_string ("", IOT_DATA_REF));
   iot_data_string_map_add (result, "Device/EventQLength", iot_data_alloc_ui32 (0));
 
-  iot_data_string_map_add (result, EX_BUS_TYPE, iot_data_alloc_string ("", IOT_DATA_REF));
+  iot_data_string_map_add (result, EX_BUS_TYPE, iot_data_alloc_string ("redis", IOT_DATA_REF));
   edgex_bus_config_defaults (result, svcname);
 
   iot_data_string_map_add (result, "SecretStore/Type", iot_data_alloc_string ("vault", IOT_DATA_REF));
@@ -106,6 +102,27 @@ iot_data_t *edgex_config_defaults (const iot_data_t *driverconf, const char *svc
   iot_data_string_map_add (result, "SecretStore/Authentication/AuthType", iot_data_alloc_string ("X-Vault-Token", IOT_DATA_REF));
   iot_data_string_map_add (result, "SecretStore/SecretsFile", iot_data_alloc_string ("", IOT_DATA_REF));
   iot_data_string_map_add (result, "SecretStore/DisableScrubSecretsFile", iot_data_alloc_bool (false));
+
+  return result;
+}
+
+iot_data_t *edgex_private_config_defaults (const iot_data_t *driverconf)
+{
+  struct utsname utsbuffer;
+  uname (&utsbuffer);
+  iot_data_t *result = iot_data_alloc_map (IOT_DATA_STRING);
+
+  iot_data_string_map_add (result, DYN_PREFIX "LogLevel", iot_data_alloc_string ("WARNING", IOT_DATA_REF));
+
+  iot_data_string_map_add (result, "Device/UpdateLastConnected", iot_data_alloc_bool (false));
+  iot_data_string_map_add (result, "MaxEventSize", iot_data_alloc_ui32 (0));
+
+  iot_data_string_map_add (result, DYN_PREFIX "Telemetry/PublishTopicPrefix", iot_data_alloc_string (DEFAULTMETRICSTOPIC, IOT_DATA_REF));
+  iot_data_string_map_add (result, DYN_PREFIX "Telemetry/Metrics/ReadCommandsExecuted", iot_data_alloc_bool (false));
+
+  iot_data_string_map_add (result, "Service/Host", iot_data_alloc_string (utsbuffer.nodename, IOT_DATA_COPY));
+  iot_data_string_map_add (result, "Service/Port", iot_data_alloc_ui16 (59999));
+  iot_data_string_map_add (result, "Service/StartupMsg", iot_data_alloc_string ("", IOT_DATA_REF));
 
   if (driverconf)
   {
@@ -434,12 +451,9 @@ void edgex_device_overrideConfig_nvpairs (iot_data_t *config, const devsdk_nvpai
   addInsecureSecretsPairs (config, pairs);
 }
 
-static void edgex_device_populateConfigFromMap (edgex_device_config *config, const iot_data_t *map)
+static void edgex_device_populateCommonConfigFromMap (edgex_device_config *config, const iot_data_t *map)
 {
-  config->service.host = iot_data_string_map_get_string (map, "Service/Host");
-  config->service.port = iot_data_ui16 (iot_data_string_map_get (map, "Service/Port"));
   config->service.timeout = edgex_parsetime (iot_data_string_map_get_string (map, "Service/RequestTimeout"));
-  config->service.startupmsg = iot_data_string_map_get_string (map, "Service/StartupMsg");
   config->service.checkinterval = iot_data_string_map_get_string (map, "Service/HealthCheckInterval");
   config->service.bindaddr = iot_data_string_map_get_string (map, "Service/ServerBindAddr");
   config->service.maxreqsz = iot_data_ui64 (iot_data_string_map_get (map, "Service/MaxRequestSize"));
@@ -470,23 +484,32 @@ static void edgex_device_populateConfigFromMap (edgex_device_config *config, con
     config->service.labels[0] = NULL;
   }
 
-  config->device.datatransform = iot_data_bool (iot_data_string_map_get (map, DYN_PREFIX "Device/DataTransform"));
-  config->device.discovery_enabled = iot_data_bool (iot_data_string_map_get (map, DYN_PREFIX "Device/Discovery/Enabled"));
-  config->device.discovery_interval = iot_data_ui32 (iot_data_string_map_get (map, DYN_PREFIX "Device/Discovery/Interval"));
-  config->device.maxcmdops = iot_data_ui32 (iot_data_string_map_get (map, DYN_PREFIX "Device/MaxCmdOps"));
-  config->device.maxeventsize = iot_data_ui32 (iot_data_string_map_get (map, DYN_PREFIX "Device/MaxEventSize"));
+  config->device.datatransform = iot_data_bool (iot_data_string_map_get (map, "Device/DataTransform"));
+  config->device.discovery_enabled = iot_data_bool (iot_data_string_map_get (map, "Device/Discovery/Enabled"));
+  config->device.discovery_interval = iot_data_ui32 (iot_data_string_map_get (map, "Device/Discovery/Interval"));
+  config->device.maxcmdops = iot_data_ui32 (iot_data_string_map_get (map, "Device/MaxCmdOps"));
+  config->device.maxeventsize = iot_data_ui32 (iot_data_string_map_get (map, "MaxEventSize"));
   config->device.profilesdir = iot_data_string_map_get_string (map, "Device/ProfilesDir");
   config->device.devicesdir = iot_data_string_map_get_string (map, "Device/DevicesDir");
-  config->device.updatelastconnected = iot_data_bool (iot_data_string_map_get (map, DYN_PREFIX "Device/UpdateLastConnected"));
-  config->device.eventqlen = iot_data_ui32 (iot_data_string_map_get (map, "Device/EventQLength"));
 
   config->metrics.interval = iot_data_string_map_get_string (map, DYN_PREFIX "Telemetry/Interval");
-  config->metrics.topic = iot_data_string_map_get_string (map, DYN_PREFIX "Telemetry/PublishTopicPrefix");
   config->metrics.flags = iot_data_bool (iot_data_string_map_get (map, DYN_PREFIX "Telemetry/Metrics/EventsSent")) ? EX_METRIC_EVSENT : 0;
   if (iot_data_bool (iot_data_string_map_get (map, DYN_PREFIX "Telemetry/Metrics/ReadingsSent"))) config->metrics.flags |= EX_METRIC_RDGSENT;
-  if (iot_data_bool (iot_data_string_map_get (map, DYN_PREFIX "Telemetry/Metrics/ReadCommandsExecuted"))) config->metrics.flags |= EX_METRIC_RDCMDS;
   if (iot_data_bool (iot_data_string_map_get (map, DYN_PREFIX "Telemetry/Metrics/SecuritySecretsRequested"))) config->metrics.flags |= EX_METRIC_SECREQ;
   if (iot_data_bool (iot_data_string_map_get (map, DYN_PREFIX "Telemetry/Metrics/SecuritySecretsStored"))) config->metrics.flags |= EX_METRIC_SECSTO;
+}
+
+static void edgex_device_populateConfigFromMap (edgex_device_config *config, const iot_data_t *map)
+{
+  config->service.host = iot_data_string_map_get_string (map, "Service/Host");
+  config->service.port = iot_data_ui16 (iot_data_string_map_get (map, "Service/Port"));
+  config->service.startupmsg = iot_data_string_map_get_string (map, "Service/StartupMsg");
+
+  config->device.updatelastconnected = iot_data_bool (iot_data_string_map_get (map, "Device/UpdateLastConnected"));
+  config->device.eventqlen = iot_data_ui32 (iot_data_string_map_get (map, "Device/EventQLength"));
+
+  config->metrics.topic = iot_data_string_map_get_string (map, DYN_PREFIX "Telemetry/PublishTopicPrefix");
+  if (iot_data_bool (iot_data_string_map_get (map, DYN_PREFIX "Telemetry/Metrics/ReadCommandsExecuted"))) config->metrics.flags |= EX_METRIC_RDCMDS;
 }
 
 void edgex_device_populateConfig (devsdk_service_t *svc, iot_data_t *config)
@@ -513,22 +536,64 @@ void edgex_device_populateConfig (devsdk_service_t *svc, iot_data_t *config)
     }
   }
 
+  edgex_device_populateCommonConfigFromMap (&svc->config, config);
   edgex_device_populateConfigFromMap (&svc->config, config);
 
   edgex_config_setloglevel (svc->logger, iot_data_string_map_get_string (config, DYN_PREFIX "LogLevel"), &svc->config.loglevel);
+}
+
+void edgex_device_updateCommonConf (void *p, const devsdk_nvpairs *config)
+{
+  bool updatemetrics = false;
+  devsdk_service_t *svc = (devsdk_service_t *)p;
+
+  devsdk_timeout *timeout = (devsdk_timeout *)malloc(sizeof(devsdk_timeout));
+  uint64_t t1, t2;
+  timeout->deadline = iot_time_secs () + 10;
+  timeout->interval = 1;
+  t1 = iot_time_secs ();
+  while (true)
+  {
+    if (svc->config.sdkconf)
+    {
+      break;
+    }
+    t2 = iot_time_secs ();
+    if (t2 > timeout->deadline - timeout->interval)
+    {
+      iot_log_error (svc->logger, "SDK configuration is not ready");
+      return;
+    }
+    if (timeout->interval > t2 - t1)
+    {
+      iot_log_warn(svc->logger, "waiting for SDK configuration to be available.");
+      iot_wait_secs (timeout->interval - (t2 - t1));
+    }
+    t1 = iot_time_secs ();
+  }
+  free (timeout);
+
+  iot_log_info (svc->logger, "Reconfiguring");
+
+  edgex_device_overrideConfig_nvpairs (svc->config.sdkconf, config);
+  updatemetrics = strcmp (svc->config.metrics.interval, iot_data_string_map_get_string (svc->config.sdkconf, DYN_PREFIX "Telemetry/Interval"));
+  edgex_device_populateCommonConfigFromMap (&svc->config, svc->config.sdkconf);
+
+  if (updatemetrics)
+  {
+    devsdk_schedule_metrics (svc);
+  }
 }
 
 void edgex_device_updateConf (void *p, const devsdk_nvpairs *config)
 {
   iot_data_map_iter_t iter;
   bool updatedriver = false;
-  bool updatemetrics = false;
   devsdk_service_t *svc = (devsdk_service_t *)p;
 
   iot_log_info (svc->logger, "Reconfiguring");
 
   edgex_device_overrideConfig_nvpairs (svc->config.sdkconf, config);
-  updatemetrics = strcmp (svc->config.metrics.interval, iot_data_string_map_get_string (svc->config.sdkconf, DYN_PREFIX "Telemetry/Interval"));
   edgex_device_populateConfigFromMap (&svc->config, svc->config.sdkconf);
 
   const char *lname = devsdk_nvpairs_value (config, DYN_PREFIX "LogLevel");
@@ -538,11 +603,6 @@ void edgex_device_updateConf (void *p, const devsdk_nvpairs *config)
   }
 
   edgex_device_periodic_discovery_configure (svc->discovery, svc->config.device.discovery_enabled, svc->config.device.discovery_interval);
-
-  if (updatemetrics)
-  {
-    devsdk_schedule_metrics (svc);
-  }
 
   if (svc->secretstore)
   {

--- a/src/c/config.h
+++ b/src/c/config.h
@@ -12,6 +12,7 @@
 #include "devsdk/devsdk.h"
 #include "rest-server.h"
 #include "map.h"
+#include "registry.h"
 
 #define EX_METRIC_EVSENT 0x1
 #define EX_METRIC_RDGSENT 0x2
@@ -86,7 +87,9 @@ typedef struct edgex_device_config
 
 iot_data_t *edgex_device_loadConfig (iot_logger_t *lc, const char *path, devsdk_error *err);
 
-iot_data_t *edgex_config_defaults (const iot_data_t *driverconf, const char *svcname);
+iot_data_t *edgex_common_config_defaults (const char *svcname);
+
+iot_data_t *edgex_private_config_defaults (const iot_data_t *driverconf);
 
 char *edgex_device_getRegURL (const iot_data_t *config);
 
@@ -99,6 +102,8 @@ void edgex_device_overrideConfig_map (iot_data_t *config, const iot_data_t *map)
 void edgex_device_overrideConfig_env (iot_logger_t *lc, iot_data_t *config);
 
 void edgex_device_overrideConfig_nvpairs (iot_data_t *config, const devsdk_nvpairs *pairs);
+
+void edgex_device_updateCommonConf (void *svc, const devsdk_nvpairs *config);
 
 void edgex_device_updateConf (void *svc, const devsdk_nvpairs *config);
 

--- a/src/c/consul.c
+++ b/src/c/consul.c
@@ -11,10 +11,10 @@
 #include "edgex-rest.h"
 #include "rest.h"
 #include "errorlist.h"
-#include "config.h"
 #include "parson.h"
 #include "api.h"
 #include "iot/base64.h"
+#include "iot/time.h"
 
 #define CONF_PREFIX "edgex/v3/"
 
@@ -196,6 +196,134 @@ static void *poll_consul (void *p)
   free (job->url);
   free (job);
   return NULL;
+}
+
+static devsdk_nvpairs *edgex_consul_client_get_common_config
+(
+  void *impl,
+  devsdk_registry_updatefn updater,
+  void *updatectx,
+  atomic_bool *updatedone,
+  devsdk_error *err,
+  const devsdk_timeout *timeout
+)
+{
+  consul_impl_t *consul = (consul_impl_t *)impl;
+  edgex_ctx ctx;
+  char url[URL_BUF_SIZE];
+  devsdk_nvpairs *result, *privateConfig, *ccReady = NULL;
+
+  memset (&ctx, 0, sizeof (edgex_ctx));
+  edgex_secrets_getregtoken (consul->sp, &ctx);
+  snprintf (url, URL_BUF_SIZE - 1, "http://%s:%u/v1/kv/" CONF_PREFIX "%s", consul->host, consul->port, "core-common-config-bootstrapper/IsCommonConfigReady");
+
+  uint64_t t1, t2;
+  while (true)
+  {
+    t1 = iot_time_msecs ();
+    *err = EDGEX_OK;
+    edgex_http_get (consul->lc, &ctx, url, edgex_http_write_cb, err);
+    edgex_secrets_releaseregtoken (consul->sp);
+    if (err->code == 0)
+    {
+      ccReady = read_pairs (consul->lc, ctx.buff, err);
+      const char *isCommonConfigReady = devsdk_nvpairs_value(ccReady, "IsCommonConfigReady");
+      if (isCommonConfigReady && strcmp(isCommonConfigReady, "true") == 0)
+      {
+        devsdk_nvpairs_free (ccReady);
+        break;
+      }
+    }
+    t2 = iot_time_msecs ();
+    if (t2 > timeout->deadline - timeout->interval)
+    {
+      *err = EDGEX_REMOTE_SERVER_DOWN;
+      devsdk_nvpairs_free (ccReady);
+      break;
+    }
+    if (timeout->interval > t2 - t1)
+    {
+      // waiting for Common Configuration to be available from config provider
+      iot_log_warn(consul->lc, "waiting for Common Configuration to be available from config provider.");
+      iot_wait_msecs (timeout->interval - (t2 - t1));
+    }
+    devsdk_nvpairs_free (ccReady);
+  }
+
+  free (ctx.buff);
+
+  snprintf (url, URL_BUF_SIZE - 1, "http://%s:%u/v1/kv/" CONF_PREFIX "%s?recurse=true", consul->host, consul->port, "core-common-config-bootstrapper/all-services");
+  edgex_http_get (consul->lc, &ctx, url, edgex_http_write_cb, err);
+  edgex_secrets_releaseregtoken (consul->sp);
+  if (err->code == 0)
+  {
+    result = read_pairs (consul->lc, ctx.buff, err);
+    if (err->code)
+    {
+      devsdk_nvpairs_free (result);
+      result = NULL;
+    }
+  }
+
+  free (ctx.buff);
+
+  devsdk_nvpairs *originalResult = result;
+  while (result)
+  {
+    char *name = result->name;
+    char *pos = strstr(name, "all-services/");
+    if (pos)
+    {
+      result->name = strdup(pos + strlen("all-services/"));
+      free(name);
+    }
+    result = result->next;
+  }
+  result = originalResult;
+
+  snprintf (url, URL_BUF_SIZE - 1, "http://%s:%u/v1/kv/" CONF_PREFIX "%s?recurse=true", consul->host, consul->port, "core-common-config-bootstrapper/device-services");
+  edgex_http_get (consul->lc, &ctx, url, edgex_http_write_cb, err);
+  edgex_secrets_releaseregtoken (consul->sp);
+  if (err->code == 0)
+  {
+      privateConfig = read_pairs (consul->lc, ctx.buff, err);
+    free (ctx.buff);
+  }
+
+  devsdk_nvpairs *originalPrivateResult = privateConfig;
+  while (privateConfig)
+  {
+    char *name = privateConfig->name;
+    char *pos = strstr(name, "device-services/");
+    if (pos)
+    {
+      result = devsdk_nvpairs_new((pos + strlen("device-services/")), privateConfig->value, result);
+    }
+      privateConfig = privateConfig->next;
+  }
+  devsdk_nvpairs_free(originalPrivateResult);
+
+  struct updatejob *job_all_service = malloc (sizeof (struct updatejob));
+  job_all_service->url = malloc (URL_BUF_SIZE);
+  snprintf (job_all_service->url, URL_BUF_SIZE - 1, "http://%s:%u/v1/kv/" CONF_PREFIX "%s/Writable?recurse=true", consul->host, consul->port, "core-common-config-bootstrapper/all-services");
+  job_all_service->lc = consul->lc;
+  job_all_service->updater = updater;
+  job_all_service->updatectx = updatectx;
+  job_all_service->updatedone = updatedone;
+  job_all_service->sp = consul->sp;
+  iot_threadpool_add_work (consul->pool, poll_consul, job_all_service, -1);
+
+  struct updatejob *job_device_service = malloc (sizeof (struct updatejob));
+  job_device_service->url = malloc (URL_BUF_SIZE);
+  snprintf (job_device_service->url, URL_BUF_SIZE - 1, "http://%s:%u/v1/kv/" CONF_PREFIX "%s/Writable?recurse=true", consul->host, consul->port, "core-common-config-bootstrapper/device-services");
+  job_device_service->lc = consul->lc;
+  job_device_service->updater = updater;
+  job_device_service->updatectx = updatectx;
+  job_device_service->updatedone = updatedone;
+  job_device_service->sp = consul->sp;
+  iot_threadpool_add_work (consul->pool, poll_consul, job_device_service, -1);
+
+  return result;
 }
 
 static devsdk_nvpairs *edgex_consul_client_get_config
@@ -496,6 +624,7 @@ const devsdk_registry_impls devsdk_registry_consul_fns =
 {
   edgex_consul_client_init,
   edgex_consul_client_ping,
+  edgex_consul_client_get_common_config,
   edgex_consul_client_get_config,
   edgex_consul_client_write_config,
   edgex_consul_client_register_service,

--- a/src/c/consul.c
+++ b/src/c/consul.c
@@ -18,6 +18,9 @@
 
 #define CONF_PREFIX "edgex/v3/"
 
+#define ALL_SVCS_NODE "all-services"
+#define DEV_SVCS_NODE "device-services"
+
 typedef struct consul_impl_t
 {
   iot_logger_t *lc;
@@ -252,7 +255,7 @@ static devsdk_nvpairs *edgex_consul_client_get_common_config
 
   free (ctx.buff);
 
-  snprintf (url, URL_BUF_SIZE - 1, "http://%s:%u/v1/kv/" CONF_PREFIX "%s?recurse=true", consul->host, consul->port, "core-common-config-bootstrapper/all-services");
+  snprintf (url, URL_BUF_SIZE - 1, "http://%s:%u/v1/kv/" CONF_PREFIX "%s?recurse=true", consul->host, consul->port, "core-common-config-bootstrapper/" ALL_SVCS_NODE);
   edgex_http_get (consul->lc, &ctx, url, edgex_http_write_cb, err);
   edgex_secrets_releaseregtoken (consul->sp);
   if (err->code == 0)
@@ -271,17 +274,17 @@ static devsdk_nvpairs *edgex_consul_client_get_common_config
   while (result)
   {
     char *name = result->name;
-    char *pos = strstr(name, "all-services/");
+    char *pos = strstr(name, ALL_SVCS_NODE "/");
     if (pos)
     {
-      result->name = strdup(pos + strlen("all-services/"));
+      result->name = strdup(pos + strlen(ALL_SVCS_NODE "/"));
       free(name);
     }
     result = result->next;
   }
   result = originalResult;
 
-  snprintf (url, URL_BUF_SIZE - 1, "http://%s:%u/v1/kv/" CONF_PREFIX "%s?recurse=true", consul->host, consul->port, "core-common-config-bootstrapper/device-services");
+  snprintf (url, URL_BUF_SIZE - 1, "http://%s:%u/v1/kv/" CONF_PREFIX "%s?recurse=true", consul->host, consul->port, "core-common-config-bootstrapper/" DEV_SVCS_NODE);
   edgex_http_get (consul->lc, &ctx, url, edgex_http_write_cb, err);
   edgex_secrets_releaseregtoken (consul->sp);
   if (err->code == 0)
@@ -294,10 +297,10 @@ static devsdk_nvpairs *edgex_consul_client_get_common_config
   while (privateConfig)
   {
     char *name = privateConfig->name;
-    char *pos = strstr(name, "device-services/");
+    char *pos = strstr(name, DEV_SVCS_NODE "/");
     if (pos)
     {
-      result = devsdk_nvpairs_new((pos + strlen("device-services/")), privateConfig->value, result);
+      result = devsdk_nvpairs_new((pos + strlen(DEV_SVCS_NODE "/")), privateConfig->value, result);
     }
       privateConfig = privateConfig->next;
   }
@@ -305,7 +308,7 @@ static devsdk_nvpairs *edgex_consul_client_get_common_config
 
   struct updatejob *job_all_service = malloc (sizeof (struct updatejob));
   job_all_service->url = malloc (URL_BUF_SIZE);
-  snprintf (job_all_service->url, URL_BUF_SIZE - 1, "http://%s:%u/v1/kv/" CONF_PREFIX "%s/Writable?recurse=true", consul->host, consul->port, "core-common-config-bootstrapper/all-services");
+  snprintf (job_all_service->url, URL_BUF_SIZE - 1, "http://%s:%u/v1/kv/" CONF_PREFIX "%s/Writable?recurse=true", consul->host, consul->port, "core-common-config-bootstrapper/" ALL_SVCS_NODE);
   job_all_service->lc = consul->lc;
   job_all_service->updater = updater;
   job_all_service->updatectx = updatectx;
@@ -315,7 +318,7 @@ static devsdk_nvpairs *edgex_consul_client_get_common_config
 
   struct updatejob *job_device_service = malloc (sizeof (struct updatejob));
   job_device_service->url = malloc (URL_BUF_SIZE);
-  snprintf (job_device_service->url, URL_BUF_SIZE - 1, "http://%s:%u/v1/kv/" CONF_PREFIX "%s/Writable?recurse=true", consul->host, consul->port, "core-common-config-bootstrapper/device-services");
+  snprintf (job_device_service->url, URL_BUF_SIZE - 1, "http://%s:%u/v1/kv/" CONF_PREFIX "%s/Writable?recurse=true", consul->host, consul->port, "core-common-config-bootstrapper/" DEV_SVCS_NODE);
   job_device_service->lc = consul->lc;
   job_device_service->updater = updater;
   job_device_service->updatectx = updatectx;

--- a/src/c/examples/bitfields/res/configuration.yaml
+++ b/src/c/examples/bitfields/res/configuration.yaml
@@ -6,21 +6,16 @@ Service:
   Port: 59999
   StartupMsg: Example bitfields device service started
 
-Clients:
-  core-metadata:
-    Host: localhost
-    Port: 59881
+# uncomment when running from command-line in hybrid mode without Config Provider
+#Clients:
+#  core-metadata:
+#    Host: localhost
+#    Port: 59881
 
 Device:
   ProfilesDir: ./res/profiles
   DevicesDir: ./res/devices
 
 MessageBus:
-  Protocol: redis
-  Host: localhost
-  Port: 6379
-  Type: redis
-  AuthMode: usernamepassword
-  SecretName: redisdb
   Optional:
     ClientId: device-bitfields

--- a/src/c/examples/counters/res/configuration.yaml
+++ b/src/c/examples/counters/res/configuration.yaml
@@ -6,21 +6,16 @@ Service:
   Port: 59999
   StartupMsg: Example counting device service started
 
-Clients:
-  core-metadata:
-    Host: localhost
-    Port: 59881
+# uncomment when running from command-line in hybrid mode without Config Provider
+#Clients:
+#  core-metadata:
+#    Host: localhost
+#    Port: 59881
 
 Device:
   ProfilesDir: ./res/profiles
   DevicesDir: ./res/devices
 
 MessageBus:
-  Protocol: redis
-  Host: localhost
-  Port: 6379
-  Type: redis
-  AuthMode: usernamepassword
-  SecretName: redisdb
   Optional:
     ClientId: device-counters

--- a/src/c/examples/discovery/res/configuration.yaml
+++ b/src/c/examples/discovery/res/configuration.yaml
@@ -9,21 +9,16 @@ Service:
   Port: 59999
   StartupMsg: Example device service with discovery started
 
-Clients:
-  core-metadata:
-    Host: localhost
-    Port: 59881
+# uncomment when running from command-line in hybrid mode without Config Provider
+#Clients:
+#  core-metadata:
+#    Host: localhost
+#    Port: 59881
 
 Device:
   ProfilesDir: ./res/profiles
   DevicesDir: ./res/devices
 
 MessageBus:
-  Protocol: redis
-  Host: localhost
-  Port: 6379
-  Type: redis
-  AuthMode: usernamepassword
-  SecretName: redisdb
   Optional:
     ClientId: device-discovery

--- a/src/c/examples/file/res/configuration.yaml
+++ b/src/c/examples/file/res/configuration.yaml
@@ -6,21 +6,16 @@ Service:
   Port: 59999
   StartupMsg: Example file device service started
 
-Clients:
-  core-metadata:
-    Host: localhost
-    Port: 59881
+# uncomment when running from command-line in hybrid mode without Config Provider
+#Clients:
+#  core-metadata:
+#    Host: localhost
+#    Port: 59881
 
 Device:
   ProfilesDir: ./res/profiles
   DevicesDir: ./res/devices
 
 MessageBus:
-  Protocol: redis
-  Host: localhost
-  Port: 6379
-  Type: redis
-  AuthMode: usernamepassword
-  SecretName: redisdb
   Optional:
     ClientId: device-file

--- a/src/c/examples/gyro/res/configuration.yaml
+++ b/src/c/examples/gyro/res/configuration.yaml
@@ -6,21 +6,16 @@ Service:
   Port: 59999
   StartupMsg: Example gyro device service started
 
-Clients:
-  core-metadata:
-    Host: localhost
-    Port: 59881
+# uncomment when running from command-line in hybrid mode without Config Provider
+#Clients:
+#  core-metadata:
+#    Host: localhost
+#    Port: 59881
 
 Device:
   ProfilesDir: ./res/profiles
   DevicesDir: ./res/devices
 
 MessageBus:
-  Protocol: redis
-  Host: localhost
-  Port: 6379
-  Type: redis
-  AuthMode: usernamepassword
-  SecretName: redisdb
   Optional:
     ClientId: device-gyro

--- a/src/c/examples/random/res/configuration.yaml
+++ b/src/c/examples/random/res/configuration.yaml
@@ -6,21 +6,16 @@ Service:
   Port: 59999
   StartupMsg: Example random device service started
 
-Clients:
-  core-metadata:
-    Host: localhost
-    Port: 59881
+# uncomment when running from command-line in hybrid mode without Config Provider
+#Clients:
+#  core-metadata:
+#    Host: localhost
+#    Port: 59881
 
 Device:
   ProfilesDir: ./res/profiles
   DevicesDir: ./res/devices
 
 MessageBus:
-  Protocol: redis
-  Host: localhost
-  Port: 6379
-  Type: redis
-  AuthMode: usernamepassword
-  SecretName: redisdb
   Optional:
     ClientId: device-random

--- a/src/c/examples/res/configuration.yaml
+++ b/src/c/examples/res/configuration.yaml
@@ -9,10 +9,11 @@ Service:
   Port: 59999
   StartupMsg: Template device started
 
-Clients:
-  core-metadata:
-    Host: "localhost"
-    Port: 59881
+# uncomment when running from command-line in hybrid mode without Config Provider
+#Clients:
+#  core-metadata:
+#    Host: localhost
+#    Port: 59881
 
 Driver:
   TestParam1: "Hello"
@@ -23,11 +24,5 @@ Device:
   DevicesDir: "./res/devices"
 
 MessageBus:
-  Protocol: redis
-  Host: localhost
-  Port: 6379
-  Type: redis
-  AuthMode: "usernamepassword"  # required for redis messagebus (secure or insecure)
-  SecretName: redisdb
   Optional:
     ClientId: device-template

--- a/src/c/examples/terminal/res/configuration.yaml
+++ b/src/c/examples/terminal/res/configuration.yaml
@@ -5,21 +5,16 @@ Service:
   Port: 59999
   StartupMsg: Example terminal device service started
 
-Clients:
-  core-metadata:
-    Host: localhost
-    Port: 59881
+# uncomment when running from command-line in hybrid mode without Config Provider
+#Clients:
+#  core-metadata:
+#    Host: localhost
+#    Port: 59881
 
 Device:
   ProfilesDir: ./res/profiles
   DevicesDir: ./res/devices
 
 MessageBus:
-  Protocol: redis
-  Host: localhost
-  Port: 6379
-  Type: redis
-  AuthMode: usernamepassword
-  SecretName: redisdb
   Optional:
     ClientId: device-terminal

--- a/src/c/registry-impl.h
+++ b/src/c/registry-impl.h
@@ -17,6 +17,9 @@ typedef bool (*devsdk_registry_init_impl) (void *impl, iot_logger_t *logger, iot
 
 typedef bool (*devsdk_registry_ping_impl) (void *impl);
 
+typedef devsdk_nvpairs *(*devsdk_registry_get_common_config_impl)
+  (void *impl, devsdk_registry_updatefn updater, void *updatectx, atomic_bool *updatedone, devsdk_error *err, const devsdk_timeout *timeout);
+
 typedef devsdk_nvpairs *(*devsdk_registry_get_config_impl)
   (void *impl, const char *servicename, devsdk_registry_updatefn updater, void *updatectx, atomic_bool *updatedone, devsdk_error *err);
 
@@ -36,6 +39,7 @@ typedef struct devsdk_registry_impls
 {
   devsdk_registry_init_impl init;
   devsdk_registry_ping_impl ping;
+  devsdk_registry_get_common_config_impl get_common_config;
   devsdk_registry_get_config_impl get_config;
   devsdk_registry_put_config_impl put_config;
   devsdk_registry_register_service_impl register_service;

--- a/src/c/registry.c
+++ b/src/c/registry.c
@@ -62,6 +62,19 @@ bool devsdk_registry_waitfor (devsdk_registry_t *registry, const devsdk_timeout 
   }
 }
 
+devsdk_nvpairs *devsdk_registry_get_common_config
+(
+  devsdk_registry_t *registry,
+  devsdk_registry_updatefn updater,
+  void *updatectx,
+  atomic_bool *updatedone,
+  devsdk_error *err,
+  const devsdk_timeout *timeout
+)
+{
+  return registry->fns.get_common_config (registry->state, updater, updatectx, updatedone, err, timeout);
+}
+
 devsdk_nvpairs *devsdk_registry_get_config
 (
   devsdk_registry_t *registry,

--- a/src/c/registry.h
+++ b/src/c/registry.h
@@ -33,6 +33,28 @@ bool devsdk_registry_init (devsdk_registry_t *registry, iot_logger_t *lc, iot_th
 bool devsdk_registry_waitfor (devsdk_registry_t *registry, const devsdk_timeout *deadline);
 
 /**
+ * @brief Retrieve common configuration values from the registry.
+ * @param registry The registry instance.
+ * @param updater A function to be called when the configuration in the registry
+ *                is updated (may be NULL).
+ * @param updatectx A parameter to be passed to the updater function.
+ * @param updatedone The registry will stop checking for updates when this flag is set.
+ * @param err Nonzero reason codes will be set here in the event of errors.
+ * @param timeout The maximum time to wait for the registry to respond.
+ * @returns Configuration retrieved for the registry.
+ */
+
+devsdk_nvpairs *devsdk_registry_get_common_config
+(
+  devsdk_registry_t *registry,
+  devsdk_registry_updatefn updater,
+  void *updatectx,
+  atomic_bool *updatedone,
+  devsdk_error *err,
+  const devsdk_timeout *timeout
+);
+
+/**
  * @brief Retrieve configuration values from the registry.
  * @param registry The registry instance.
  * @param servicename The name of this device service.

--- a/src/c/service.h
+++ b/src/c/service.h
@@ -67,6 +67,7 @@ struct devsdk_service_t
   devsdk_metrics_t metrics;
   iot_schedule_t *metricschedule;
   bool overwriteconfig;
+  bool secureMode;
 
   edgex_devmap_t *devices;
   edgex_watchlist_t *watchlist;


### PR DESCRIPTION
fix: #481 

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Non-secure mode testing
1. From the latest compose builder run `make run no-secty`.
2. Run device-random example (/src/c/examples/random) with `-cp=consul.http://localhost:8500 --registry` arguments.
3. Verify that the device-random configuration has been written to Consul K/V Store.
4. Update Writable configuration for device-random and core-common-config-bootstrapper on Consul K/V Store, and then verify if it takes effect.

Secure mode testing
1. From the latest compose builder, modify add-security.yml to add secret store token and registry ACL role for `device-random`, and then run `make run`.
2. Set environment variable `EDGEX_SECURITY_SECRET_STORE` to true and run device-random example (/src/c/examples/random) with `-cp=consul.http://localhost:8500 --registry` arguments.
3. Verify that the device-random configuration has been written to Consul K/V Store.
4. Update Writable configuration for device-random and core-common-config-bootstrapper on Consul K/V Store, and then verify if it takes effect.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->