### PR TITLE
feat: Add command line/environment flag for commonConfig 

### DIFF
--- a/src/c/api.h
+++ b/src/c/api.h
@@ -47,4 +47,9 @@
 
 #define DS_PARAMLIST { DS_PUSH, DS_RETURN }
 
+/* Path segments */
+
+#define ALL_SVCS_NODE "all-services"
+#define DEV_SVCS_NODE "device-services"
+
 #endif

--- a/src/c/consul.c
+++ b/src/c/consul.c
@@ -18,9 +18,6 @@
 
 #define CONF_PREFIX "edgex/v3/"
 
-#define ALL_SVCS_NODE "all-services"
-#define DEV_SVCS_NODE "device-services"
-
 typedef struct consul_impl_t
 {
   iot_logger_t *lc;

--- a/src/c/examples/commonconfiguration.yaml
+++ b/src/c/examples/commonconfiguration.yaml
@@ -1,0 +1,105 @@
+all-services:
+  Writable:
+    InsecureSecrets:
+      DB:
+        path: "redisdb"
+        Secrets:
+          username: ""
+          password: ""
+        SecretName: "redisdb"
+        SecretData:
+          username: ""
+          password: ""
+
+    Telemetry:
+      Interval: "30s"
+      Metrics:
+        # Common Security Service Metrics
+        SecuritySecretsRequested: false
+        SecuritySecretsStored: false
+        SecurityConsulTokensRequested: false
+        SecurityConsulTokenDuration: false
+      #     Tags: # Contains the service level tags to be attached to all the service's metrics
+      #  Gateway: "my-iot-gateway" # Tag must be added here or via Consul Env Override can only change existing value, not added new ones.
+
+  Service:
+    HealthCheckInterval: "10s"
+    Host: "localhost"
+    ServerBindAddr: "" # Leave blank so default to Host value unless different value is needed.
+    MaxResultCount: 1024
+    MaxRequestSize: 0 # Not currently used. Defines the maximum size of http request body in bytes
+    RequestTimeout: "5s"
+    CORSConfiguration:
+      EnableCORS: false
+      CORSAllowCredentials: false
+      CORSAllowedOrigin: "https://localhost"
+      CORSAllowedMethods: "GET, POST, PUT, PATCH, DELETE"
+      CORSAllowedHeaders: "Authorization, Accept, Accept-Language, Content-Language, Content-Type, X-Correlation-ID"
+      CORSExposeHeaders: "Cache-Control, Content-Language, Content-Length, Content-Type, Expires, Last-Modified, Pragma, X-Correlation-ID"
+      CORSMaxAge: 3600
+
+  Registry:
+    Host: "localhost"
+    Port: 8500
+    Type: "consul"
+
+  Database:
+    Host: "localhost"
+    Port: 6379
+    Timeout: 5000
+    Type: "redisdb"
+
+  MessageBus:
+    Protocol: "redis"
+    Host: "localhost"
+    Port: 6379
+    Type: "redis"
+    AuthMode: "usernamepassword"  # required for redis MessageBus (secure or insecure).
+    SecretName: "redisdb"
+    BaseTopicPrefix: "edgex" # prepended to all topics as "edgex/<additional topic levels>
+    Optional:
+      # Default MQTT Specific options that need to be here to enable environment variable overrides of them
+      Qos:  "0" # Quality of Service values are 0 (At most once), 1 (At least once) or 2 (Exactly once)
+      KeepAlive: "10" # Seconds (must be 2 or greater)
+      Retained: "false"
+      AutoReconnect: "true"
+      ConnectTimeout: "5" # Seconds
+      SkipCertVerify: "false"
+      # Additional Default NATS Specific options that need to be here to enable environment variable overrides of them
+      Format: "nats"
+      RetryOnFailedConnect: "true"
+      QueueGroup: ""
+      Durable: ""
+      AutoProvision: "true"
+      Deliver: "new"
+      DefaultPubRetryAttempts: "2"
+      Subject: "edgex/#" # Required for NATS JetStream only for stream auto-provisioning
+
+device-services:
+  MaxEventSize: 0 # value 0 represents unlimited  maximum event size that can be sent to message bus or core-data
+  Writable:
+    Reading:
+      ReadingUnits: true
+    Telemetry:
+      Metrics:
+        EventsSent: false
+        ReadingsSent: false
+  Clients:
+    core-metadata:
+      Protocol: "http"
+      Host: "localhost"
+      Port: 59881
+  Device:
+    DataTransform: true
+    MaxCmdOps: 128
+    MaxCmdValueLen: 256
+    ProfilesDir: "./res/profiles"
+    DevicesDir: "./res/devices"
+    # ProvisionWatchersDir is omitted here since most Device Services don't use it.
+    # Those that do will have it in their private config
+    EnableAsyncReadings: true
+    AsyncBufferSize: 16
+    Labels: []
+    Discovery:
+      Enabled: false
+      Interval: "30s"

--- a/src/c/service.h
+++ b/src/c/service.h
@@ -51,6 +51,7 @@ struct devsdk_service_t
   const char *profile;
   const char *confdir;
   const char *conffile;
+  const char *commonconffile;
   char *confpath;
   void *userdata;
   devsdk_callbacks userfns;


### PR DESCRIPTION
fix: #485 

Hold until https://github.com/edgexfoundry/device-sdk-c/pull/484 is merged


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
**Non-secure mode testing**

1. From the latest compose builder run `make run no-secty`.
2. Set the environment variable for non-secure testing `export EDGEX_SECURITY_SECRET_STORE=false`
3. Run device-random example (/src/c/examples/random) with `-cc=../commonconfiguration.yaml` argument.
4. The device-random service should bootstrap successfully without having the following error
```
level=ERROR ts=2023-10-06T04:34:11Z app=device-random msg="Unable to load common config file: Unable to open configuration file"
Error: 1: Unable to open configuration file
```
5. The configuration can also be verified through the REST API: http://localhost:59999/api/v3/config

**Secure mode testing**

1. From the latest compose builder, modify add-security.yml to add secret store token and registry ACL role for device-random, and then run `make run`.
2. Set the environment variable for secure testing `export EDGEX_SECURITY_SECRET_STORE=true`
3. Run device-random example (/src/c/examples/random) with `-cc=../commonconfiguration.yaml` argument.
4. The device-random service should bootstrap successfully without the following error
```
level=ERROR ts=2023-10-06T04:34:11Z app=device-random msg="Unable to load common config file: Unable to open configuration file"
Error: 1: Unable to open configuration file
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->