### PR TITLE
fix:If the put request's json payload is string type, The slash of a string cannot be removed using json_serialize_to_string.

### DIFF
--- a/src/c/reqdata.c
+++ b/src/c/reqdata.c
@@ -103,8 +103,16 @@ extern const char *edgex_reqdata_get (const edgex_reqdata_t *data, const char *n
   if (data->json)
   {
     JSON_Value *value = json_object_get_value(data->json, name);
-    if (value) {
-      result = json_serialize_to_string(value);
+    if (value) 
+    {
+      if(json_value_get_type(value) == JSONString)
+      {
+        result = json_value_get_string(value);
+      }
+      else
+      {
+        result = json_serialize_to_string(value);
+      }
     }
   }
   else


### PR DESCRIPTION
fix:If the put request's json payload is string type, The slash of a string cannot be removed using json_serialize_to_string.
example: {"command": "open"} → {\"command\": \"open\"} → \open\