### PR TITLE
fix: assert failures on null/empty maps (Closes #504)

### DIFF
--- a/src/c/dto-read.c
+++ b/src/c/dto-read.c
@@ -35,7 +35,7 @@ static edgex_device_operatingstate edgex_operatingstate_read (const iot_data_t *
 static devsdk_protocols *edgex_protocols_read (const iot_data_t *obj)
 {
   devsdk_protocols *result = NULL;
-  if (obj)
+  if (obj && (iot_data_type(obj) == IOT_DATA_MAP))
   {
     iot_data_map_iter_t iter;
     iot_data_map_iter (obj, &iter);

--- a/src/c/edgex-rest.c
+++ b/src/c/edgex-rest.c
@@ -159,11 +159,14 @@ static JSON_Value *string_map_write (const iot_data_t *map)
   JSON_Value *result = json_value_init_object ();
   JSON_Object *obj = json_value_get_object (result);
 
-  iot_data_map_iter_t iter;
-  iot_data_map_iter (map, &iter);
-  while (iot_data_map_iter_next (&iter))
-  {
-    json_object_set_string (obj, iot_data_map_iter_string_key (&iter), iot_data_map_iter_string_value (&iter));
+  if (map && (iot_data_type(map) == IOT_DATA_MAP))
+  {  
+    iot_data_map_iter_t iter;
+    iot_data_map_iter (map, &iter);
+    while (iot_data_map_iter_next (&iter))
+    {
+      json_object_set_string (obj, iot_data_map_iter_string_key (&iter), iot_data_map_iter_string_value (&iter));
+    }
   }
   return result;
 }

--- a/src/c/examples/discovery/template.c
+++ b/src/c/examples/discovery/template.c
@@ -25,7 +25,12 @@ static void dump_protocols (iot_logger_t *lc, const devsdk_protocols *prots)
 {
   iot_data_map_iter_t iter;
   iot_log_debug (lc, " [Other] protocol:");
-  iot_data_map_iter (devsdk_protocols_properties (prots, "Other"), &iter);
+  const iot_data_t *others = devsdk_protocols_properties(prots, "Other");
+  if ((!others) || (iot_data_type(others) != IOT_DATA_MAP))
+  {
+    return;
+  }
+  iot_data_map_iter (others, &iter);
   while (iot_data_map_iter_next (&iter))
   {
     iot_log_debug (lc, "    %s = %s", iot_data_map_iter_string_key (&iter), iot_data_map_iter_string_value (&iter));
@@ -35,6 +40,10 @@ static void dump_protocols (iot_logger_t *lc, const devsdk_protocols *prots)
 static void dump_attributes (iot_logger_t *lc, devsdk_resource_attr_t attrs)
 {
   iot_data_map_iter_t iter;
+  if ((!attrs) || (iot_data_type((iot_data_t *)attrs) != IOT_DATA_MAP))
+  {
+    return;
+  }
   iot_data_map_iter ((iot_data_t *)attrs, &iter);
   while (iot_data_map_iter_next (&iter))
   {
@@ -55,7 +64,7 @@ static bool template_init
 {
   template_driver *driver = (template_driver *) impl;
   iot_log_debug (lc, "Template Init. Driver Config follows:");
-  if (config)
+  if (config && (iot_data_type(config) == IOT_DATA_MAP))
   {
     iot_data_map_iter_t iter;
     iot_data_map_iter (config, &iter);
@@ -81,10 +90,13 @@ static void template_reconfigure
   iot_data_map_iter_t iter;
   template_driver *driver = (template_driver *) impl;
   iot_log_debug (driver->lc, "Template Reconfiguration. New Config follows:");
-  iot_data_map_iter (config, &iter);
-  while (iot_data_map_iter_next (&iter))
+  if (config && (iot_data_type(config) == IOT_DATA_MAP))
   {
-    iot_log_debug (driver->lc, "    %s = %s", iot_data_map_iter_string_key (&iter), iot_data_map_iter_string_value (&iter));
+    iot_data_map_iter (config, &iter);
+    while (iot_data_map_iter_next (&iter))
+    {
+      iot_log_debug (driver->lc, "    %s = %s", iot_data_map_iter_string_key (&iter), iot_data_map_iter_string_value (&iter));
+    }
   }
 }
 

--- a/src/c/examples/template.c
+++ b/src/c/examples/template.c
@@ -25,7 +25,12 @@ static void dump_protocols (iot_logger_t *lc, const devsdk_protocols *prots)
 {
   iot_data_map_iter_t iter;
   iot_log_debug (lc, " [Other] protocol:");
-  iot_data_map_iter (devsdk_protocols_properties (prots, "Other"), &iter);
+  const iot_data_t *others = devsdk_protocols_properties(prots, "Other");
+  if ((!others) || (iot_data_type(others) != IOT_DATA_MAP))
+  {
+    return;
+  }
+  iot_data_map_iter (others, &iter);
   while (iot_data_map_iter_next (&iter))
   {
     iot_log_debug (lc, "    %s = %s", iot_data_map_iter_string_key (&iter), iot_data_map_iter_string_value (&iter));
@@ -37,6 +42,10 @@ static void dump_attributes (iot_logger_t *lc, devsdk_resource_attr_t attrs)
   if (lc && lc->level >= IOT_LOG_DEBUG)
   {
     iot_data_map_iter_t iter;
+    if ((!attrs) || (iot_data_type((iot_data_t *)attrs) != IOT_DATA_MAP))
+    {
+      return;
+    }
     iot_data_map_iter ((iot_data_t *)attrs, &iter);
     while (iot_data_map_iter_next (&iter))
     {
@@ -60,7 +69,7 @@ static bool template_init
 {
   template_driver *driver = (template_driver *) impl;
   iot_log_debug (lc, "Template Init. Driver Config follows:");
-  if (config)
+  if (config && (iot_data_type(config) == IOT_DATA_MAP))
   {
     iot_data_map_iter_t iter;
     iot_data_map_iter (config, &iter);
@@ -86,10 +95,13 @@ static void template_reconfigure
   iot_data_map_iter_t iter;
   template_driver *driver = (template_driver *) impl;
   iot_log_debug (driver->lc, "Template Reconfiguration. New Config follows:");
-  iot_data_map_iter (config, &iter);
-  while (iot_data_map_iter_next (&iter))
+  if (config && (iot_data_type(config) == IOT_DATA_MAP))
   {
-    iot_log_debug (driver->lc, "    %s = %s", iot_data_map_iter_string_key (&iter), iot_data_map_iter_string_value (&iter));
+    iot_data_map_iter (config, &iter);
+    while (iot_data_map_iter_next (&iter))
+    {
+      iot_log_debug (driver->lc, "    %s = %s", iot_data_map_iter_string_key (&iter), iot_data_map_iter_string_value (&iter));
+    }
   }
 }
 

--- a/src/c/secrets-insecure.c
+++ b/src/c/secrets-insecure.c
@@ -27,6 +27,10 @@ static iot_data_t *insecure_parse_config (iot_data_t *config)
 {
   iot_data_t *result = iot_data_alloc_map (IOT_DATA_STRING);
 
+  if ((!config) || (iot_data_type(config) != IOT_DATA_MAP))
+  {
+    return result;
+  }
   iot_data_map_iter_t iter;
   iot_data_map_iter (config, &iter);
   while (iot_data_map_iter_next (&iter))

--- a/src/c/transform.c
+++ b/src/c/transform.c
@@ -147,7 +147,7 @@ void edgex_transform_outgoing (devsdk_commandresult *cres, edgex_propertyvalue *
     break;
     case IOT_DATA_STRING:
     {
-      if (mappings)
+      if (mappings && (iot_data_type(mappings) == IOT_DATA_MAP))
       {
         const iot_data_t *remap = iot_data_map_get (mappings, cres->value);
         if (remap)
@@ -213,7 +213,7 @@ void edgex_transform_incoming (iot_data_t **cres, edgex_propertyvalue *props, co
     break;
     case IOT_DATA_STRING:
     {
-      if (mappings)
+      if (mappings && (iot_data_type(mappings) == IOT_DATA_MAP))
       {
         iot_data_map_iter_t iter;
         iot_data_map_iter (mappings, &iter);

--- a/src/c/validate.c
+++ b/src/c/validate.c
@@ -17,14 +17,17 @@ static devsdk_protocols *protocols_convert (const iot_data_t *obj)
 
   devsdk_protocols *result = NULL;
   iot_data_map_iter_t iter;
-  iot_data_map_iter (obj, &iter);
-  while (iot_data_map_iter_has_next (&iter))
+  if (obj && (iot_data_type(obj) == IOT_DATA_MAP))
   {
-    devsdk_protocols *prot = malloc (sizeof (devsdk_protocols));
-    prot->name = strdup (iot_data_map_iter_string_key (&iter));
-    prot->properties = iot_data_add_ref (iot_data_map_iter_value (&iter));
-    prot->next = result;
-    result = prot;
+    iot_data_map_iter (obj, &iter);
+    while (iot_data_map_iter_has_next (&iter))
+    {
+      devsdk_protocols *prot = malloc (sizeof (devsdk_protocols));
+      prot->name = strdup (iot_data_map_iter_string_key (&iter));
+      prot->properties = iot_data_add_ref (iot_data_map_iter_value (&iter));
+      prot->next = result;
+      result = prot;
+    }
   }
   return result;
 }


### PR DESCRIPTION
Sometimes objects intended to be maps are null, or initialized but type IOT_DATA_NULL, causing map get/iterate functions to assert. Bypass these cases, treating it as an empty map.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ x ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (no existing tests in this repo)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?) (based on a different SDK version than I use, no way to test other than it builds with no warnings)
- [ ] I have opened a PR for the related docs change (if not, why?) (N/A)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->