### PR TITLE
fix: Wait for MQTT subscriptions to take effect before returning (#516)

### DIFF
--- a/src/c/bus-mqtt.c
+++ b/src/c/bus-mqtt.c
@@ -75,7 +75,11 @@ static void edgex_bus_mqtt_subscribe (void *ctx, const char *topic)
   }
   else
   {
-    MQTTAsync_waitForCompletion(cinfo->client, opts.token, 1000);
+    rc = MQTTAsync_waitForCompletion(cinfo->client, opts.token, 1000);
+    if (rc != MQTTASYNC_SUCCESS)
+    {
+      iot_log_error(cinfo->lc, "mqtt: subscribe to %s failed, error code %d", topic, rc);
+    }
   }
 }
 

--- a/src/c/bus-mqtt.c
+++ b/src/c/bus-mqtt.c
@@ -73,6 +73,10 @@ static void edgex_bus_mqtt_subscribe (void *ctx, const char *topic)
   {
     iot_log_error (cinfo->lc, "mqtt: unable to subscribe to %s, error code %d", topic, rc);
   }
+  else
+  {
+    MQTTAsync_waitForCompletion(cinfo->client, opts.token, 1000);
+  }
 }
 
 static void edgex_bus_mqtt_post (void *ctx, const char *topic, const iot_data_t *envelope)


### PR DESCRIPTION
MQTTAsync_subscribe() is async. There are some places e.g. startConfigured() where we expect the subscription to be in effect right after this call. So wait for completion before returning.

Fixes: #516 

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) (no unit tests at all yet)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) N/A
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

Before and after change, on a busy system, repeatedly have a C-based device service start and upload its devices (deleting them from core-metadata each time), to reproduce the bug in the related issue.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->