### PR TITLE
fix: Only 20 devices end up in devmap (#555)

### DIFF
--- a/src/c/metadata.c
+++ b/src/c/metadata.c
@@ -302,7 +302,7 @@ edgex_device *edgex_metadata_client_get_devices
   (
     url,
     URL_BUF_SIZE - 1,
-    "http://%s:%u/api/" EDGEX_API_VERSION "/device/service/name/%s",
+    "http://%s:%u/api/" EDGEX_API_VERSION "/device/service/name/%s?offset=0&limit=-1",
     endpoints->metadata.host,
     endpoints->metadata.port,
     ename


### PR DESCRIPTION
Fetch the entire list of devices from core-metadata at startup.

Fixes: #555

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) (none yet)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) N/A
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
This one comes from my team and has been in place locally for a year now, with no ill effects even on systems with 10K+ devices on one service.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->