### PR TITLE
fix: Missing discovery delete wrapper for secure mode

### DIFF
--- a/src/c/service.c
+++ b/src/c/service.c
@@ -818,6 +818,9 @@ static void startConfigured (devsdk_service_t *svc, const devsdk_timeout *deadli
     svc->discovery_wrapper = (auth_wrapper_t){ svc, svc->secretstore, edgex_device_handler_discoveryv2};
     edgex_rest_server_register_handler (svc->daemon, EDGEX_DEV_API3_DISCOVERY, DevSDK_Post, &svc->discovery_wrapper, http_auth_wrapper);
 
+    svc->discovery_delete_wrapper = (auth_wrapper_t){ svc, svc->secretstore, edgex_device_handler_discovery_delete};
+    edgex_rest_server_register_handler (svc->daemon, EDGEX_DEV_API3_DISCOVERY_DELETE, DevSDK_Delete, &svc->discovery_delete_wrapper, http_auth_wrapper);
+
     svc->config_wrapper = (auth_wrapper_t){ svc, svc->secretstore, edgex_device_handler_configv2};
     edgex_rest_server_register_handler (svc->daemon, EDGEX_DEV_API3_CONFIG, DevSDK_Get, &svc->config_wrapper, http_auth_wrapper);
 

--- a/src/c/service.h
+++ b/src/c/service.h
@@ -82,6 +82,7 @@ struct devsdk_service_t
   auth_wrapper_t callback_watcher_name_wrapper;
   auth_wrapper_t device_name_wrapper;
   auth_wrapper_t discovery_wrapper;
+  auth_wrapper_t discovery_delete_wrapper;
   auth_wrapper_t metrics_wrapper;
   auth_wrapper_t config_wrapper;
   auth_wrapper_t secret_wrapper;


### PR DESCRIPTION
Fixes the missing discover delete setup for secure mode

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)