### PR TITLE
fix: Add support for additional MQTT protocol aliases

### DIFF
--- a/src/c/bus-mqtt.c
+++ b/src/c/bus-mqtt.c
@@ -170,10 +170,23 @@ edgex_bus_t *edgex_bus_create_mqtt (iot_logger_t *lc, const char *svcname, const
   const char *certfile = iot_data_string_map_get_string (cfg, EX_BUS_CERTFILE);
   const char *keyfile = iot_data_string_map_get_string (cfg, EX_BUS_KEYFILE);
   uint16_t port = iot_data_ui16 (iot_data_string_map_get (cfg, EX_BUS_PORT));
-  if (*prot == '\0')
+  if (*prot == '\0' || strcmp (prot, "mqtt") == 0 || strcmp (prot, "tcp") == 0)
   {
     prot = "tcp";
   }
+  else if (strcmp (prot, "ssl") == 0 || strcmp (prot, "tls") == 0 ||
+           strcmp (prot, "mqtts") == 0 || strcmp (prot, "mqtt+ssl") == 0 ||
+           strcmp (prot, "tcps") == 0)
+  {
+    prot = "ssl";
+  }
+  else
+  {
+    iot_log_error (lc, "mqtt: unsupported protocol: %s", prot);
+    free (cinfo);
+    return NULL;
+  }
+
   if (port == 0)
   {
     if (strcmp (prot, "ssl") == 0)


### PR DESCRIPTION
fix: #522 

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Tested with the latest [edgex-compose](https://github.com/edgexfoundry/edgex-compose), where the message bus protocol is set to `mqtt`.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->