### PR TITLE
feat: Add support for listening to common config changes from core-keeper

### DIFF
--- a/src/c/keeper.c
+++ b/src/c/keeper.c
@@ -18,7 +18,10 @@ typedef struct keeper_impl_t
     uint16_t port;
     char *key_root;
     char *topic_root;
-    devsdk_registry_updatefn updater;
+    char *common_config_key_root;
+    char *common_config_topic_root;
+    devsdk_registry_updatefn private_config_updater;
+    devsdk_registry_updatefn common_config_updater;
     void *updatectx;
 } keeper_impl_t;
 
@@ -47,7 +50,15 @@ static void edgex_keeper_client_free (void *impl)
     }
     if (keeper->topic_root)
     {
-        free(keeper->topic_root);
+        free (keeper->topic_root);
+    }
+    if (keeper->common_config_key_root)
+    {
+        free (keeper->common_config_key_root);
+    }
+    if (keeper->common_config_topic_root)
+    {
+        free (keeper->common_config_topic_root);
     }
     free (impl);
   }
@@ -55,32 +66,42 @@ static void edgex_keeper_client_free (void *impl)
 
 static void *delayed_message_bus_connect(void *impl)
 {
-    keeper_impl_t *keeper = (keeper_impl_t *)impl;
+  keeper_impl_t *keeper = (keeper_impl_t *)impl;
 
-    iot_log_debug(keeper->lc, "Message bus wait thread starting");
-    while (true)
+  iot_log_debug (keeper->lc, "Message bus wait thread starting");
+  while (true)
+  {
+    if (keeper->service && keeper->service->msgbus)
     {
-        if (keeper->service && keeper->service->msgbus)
+      char *all_svcs_topic = malloc (strlen (keeper->common_config_topic_root) + strlen (ALL_SVCS_NODE) + 1);
+      char *dev_svcs_topic = malloc (strlen (keeper->common_config_topic_root) + strlen (DEV_SVCS_NODE) + 1);
+      sprintf (all_svcs_topic, "%s%s", keeper->common_config_topic_root, ALL_SVCS_NODE);
+      sprintf (dev_svcs_topic, "%s%s", keeper->common_config_topic_root, DEV_SVCS_NODE);
+      const char *topics[] = { keeper->topic_root, all_svcs_topic, dev_svcs_topic };
+      for (int i = 0; i < 3; i++)
+      {
+        char *tree = malloc (strlen (topics[i]) + 3);
+        strcpy (tree, topics[i]);
+        if (tree [strlen (tree) - 1] == '/')
         {
-            char *tree = malloc(strlen(keeper->topic_root) + 3);
-            strcpy(tree, keeper->topic_root);
-            if (tree[strlen(tree) - 1] == '/')
-            {
-                tree[strlen(tree) - 1] = '\0';
-            }
-            strcat(tree, "/#");
-            iot_log_info(keeper->lc, "Subscribing to Keeper notifications on message bus at %s", tree);
-            edgex_bus_register_handler(keeper->service->msgbus, tree, impl, edgex_keeper_client_notify);
-            free(tree);
-            break;
+          tree [strlen (tree) - 1] = '\0';
         }
-        if (keeper->service && keeper->service->stopconfig && ((*keeper->service->stopconfig)))
-        {
-            break;
-        }
-        sleep(1);
+        strcat (tree, "/#");
+        iot_log_info (keeper->lc, "Subscribing to Keeper notifications on message bus at %s", tree);
+        edgex_bus_register_handler (keeper->service->msgbus, tree, impl, edgex_keeper_client_notify);
+        free(tree);
+      }
+      free (all_svcs_topic);
+      free (dev_svcs_topic);
+      break;
     }
-    return NULL;
+    if (keeper->service && keeper->service->stopconfig && ((*keeper->service->stopconfig)))
+    {
+      break;
+    }
+    sleep (1);
+  }
+  return NULL;
 }
 
 static bool edgex_keeper_client_init (void *impl, iot_logger_t *logger, iot_threadpool_t *pool, edgex_secret_provider_t *sp, const char *url)
@@ -125,13 +146,18 @@ static bool edgex_keeper_client_init (void *impl, iot_logger_t *logger, iot_thre
         return false;
     }
 
-    // iot_log_info(logger, "At key-root alloc, service->name %p", keeper->service->name);
     keeper->key_root = calloc(URL_BUF_SIZE, 1);
     snprintf(keeper->key_root, URL_BUF_SIZE-1, "edgex/v4/%s", keeper->service->name);
     keeper->key_root[URL_BUF_SIZE-1] = '\0';
     keeper->topic_root = calloc(URL_BUF_SIZE, 1);
     snprintf(keeper->topic_root, URL_BUF_SIZE-1, KEEPER_PUBLISH_PREFIX "%s", keeper->key_root);
     keeper->topic_root[URL_BUF_SIZE-1] = '\0';
+    keeper->common_config_key_root = calloc(URL_BUF_SIZE, 1);
+    snprintf(keeper->common_config_key_root, URL_BUF_SIZE-1, "edgex/v4/core-common-config-bootstrapper/");
+    keeper->common_config_key_root[URL_BUF_SIZE-1] = '\0';
+    keeper->common_config_topic_root = calloc(URL_BUF_SIZE, 1);
+    snprintf(keeper->common_config_topic_root, URL_BUF_SIZE-1, KEEPER_PUBLISH_PREFIX "edgex/v4/core-common-config-bootstrapper/");
+    keeper->common_config_topic_root[URL_BUF_SIZE-1] = '\0';
 
     // Can't yet subscribe to the message bus because it's not set up yet, because we
     // don't have its config yet, because we might be reading config from Keeper.
@@ -291,7 +317,7 @@ static devsdk_nvpairs *edgex_keeper_client_get_config
   keeper_impl_t *keeper = (keeper_impl_t *)impl;
   /* updatedone not used, only kept for prototype compatibility */
   (void) updatedone;
-  keeper->updater = updater;
+  keeper->private_config_updater = updater;
   keeper->updatectx = updatectx;
   return edgex_keeper_get_tree(impl, keeper->key_root, err);
 }
@@ -311,7 +337,7 @@ static devsdk_nvpairs *edgex_keeper_client_get_common_config
   devsdk_nvpairs *ccReady = NULL;
   /* updatedone not used, only kept for prototype compatibility */
   (void) updatedone;
-  keeper->updater = updater;
+  keeper->common_config_updater = updater;
   keeper->updatectx = updatectx;
 
   uint64_t t1, t2;
@@ -384,54 +410,70 @@ static devsdk_nvpairs *edgex_keeper_client_get_common_config
   return result;
 }
 
+static void process_notification(keeper_impl_t *keeper, const iot_data_t *request, const char *key, const char *key_root, devsdk_registry_updatefn updater)
+{
+  const char *key_suffix = key + strlen (key_root);
+  if (*key_suffix == '/')
+  {
+    key_suffix++;
+  }
+  const char *str_val = iot_data_string_map_get_string (request, "value");
+  if (!str_val)
+  {
+    iot_log_warn (keeper->lc, "Notified of change but object missing 'value' member");
+    return;
+  }
+  iot_log_info (keeper->lc, "Notified of config change at key '%s' to value '%s'", key_suffix, str_val);
+  const char *prefix_all_svcs = "all-services/";
+  const char *prefix_dev_svcs = "device-services/";
+  if (strncmp (key_suffix, prefix_all_svcs, strlen (prefix_all_svcs)) == 0)
+  {
+    key_suffix += strlen(prefix_all_svcs);
+  }
+  else if (strncmp(key_suffix, prefix_dev_svcs, strlen (prefix_dev_svcs)) == 0)
+  {
+    key_suffix += strlen (prefix_dev_svcs);
+  }
+  devsdk_nvpairs *result = devsdk_nvpairs_new (key_suffix, str_val, NULL);
+  if (result)
+  {
+    updater (keeper->updatectx, result);
+    devsdk_nvpairs_free (result);
+  }
+}
 
 static int32_t edgex_keeper_client_notify(void *impl, const iot_data_t *request, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply)
 {
   keeper_impl_t *keeper = (keeper_impl_t *)impl;
-  devsdk_nvpairs *result = NULL;
   if ((!keeper) || (!request) || (iot_data_type(request) != IOT_DATA_MAP))
   {
-    iot_log_warn(keeper->lc, "Received notification from Keeper but request is not a map, ignoring");
+    iot_log_warn (keeper->lc, "Received notification from Keeper but request is not a map, ignoring");
     return 0;
   }
-  if (!keeper->updater)
+  if (!keeper->private_config_updater || !keeper->common_config_updater)
   {
-    iot_log_info(keeper->lc, "Notified of config change but this service has not registered for these, ignoring");
+    iot_log_info (keeper->lc, "Notified of config change but this service has not registered for these, ignoring");
     return 0;
   }
-  const iot_data_t *raw_key = iot_data_string_map_get(request, "key");
+  const iot_data_t *raw_key = iot_data_string_map_get (request, "key");
   if (!raw_key)
   {
-    iot_log_warn(keeper->lc, "Notified of change but object missing 'key' member");
+    iot_log_warn (keeper->lc, "Notified of change but object missing 'key' member");
     return 0;
   }
   const char *key = iot_data_string(raw_key);
-  const char *prefix = strstr(key, keeper->key_root);
-  if (prefix != key)
+  if (strstr (key, keeper->key_root) == key)
   {
-    iot_log_warn(keeper->lc, "Received key %s does not begin with our prefix %s, ignoring", key, keeper->key_root);
-    return 0;
+    process_notification (keeper, request, key, keeper->key_root, keeper->private_config_updater);
+  }
+  else if (strstr (key, keeper->common_config_key_root) == key)
+  {
+    process_notification (keeper, request, key, keeper->common_config_key_root, keeper->common_config_updater);
   }
   else
   {
-    const char *key_suffix = key + strlen(keeper->key_root);
-    if (*key_suffix == '/')
-    {
-        key_suffix++;
-    }
-    const char *str_val = iot_data_string_map_get_string(request, "value");
-    if (!str_val)
-    {
-        iot_log_warn(keeper->lc, "Notified of change but object missing 'value' member");
-        return 0;
-    }
-    iot_log_info(keeper->lc, "Notified of config change at key '%s' to value '%s'", key_suffix, str_val);
-    result = devsdk_nvpairs_new(key_suffix, str_val, NULL);
-    if (result)
-    {
-        (keeper->updater)(keeper->updatectx, result);
-        devsdk_nvpairs_free(result);
-    }
+    iot_log_warn (keeper->lc, "Received key %s does not begin with our prefix %s or common config prefix %s, ignoring",
+                  key, keeper->key_root, keeper->common_config_key_root);
   }
   return 0;
 }


### PR DESCRIPTION
fix: #529 
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Run device-random https://github.com/edgexfoundry/device-sdk-c/tree/main/src/c/examples/random
2. Update common config (all-services) via the core-keeper REST API
```
curl -X 'PUT'   'http://localhost:59890/api/v3/kvs/key/edgex/v4/core-common-config-bootstrapper/all-services/Writable/Telemetry/Interval?flatten=false'   -H 'accept: application/json'   -H 'Content-Type: application/json'   -d '{
  "value": "5s"
}'
```
3. Update common config (device-services) via the core-keeper REST API
```
curl -X 'PUT'   'http://localhost:59890/api/v3/kvs/key/edgex/v4/core-common-config-bootstrapper/device-services/Writable/Telemetry/Metrics/EventsSent?flatten=false'   -H 'accept: application/json'   -H 'Content-Type: application/json'   -d '{
  "value": "true"
}'
```
4. Verify through logs that the associated updater function is triggered and the updated config takes effect.
```
level=INFO ts=2024-12-17T15:16:21Z app=device-random correlation-id=08151b28-e7d3-4295-b1aa-6a90bed53d08 msg="Notified of config change at key 'all-services/Writable/Telemetry/Interval' to value '10s'"
level=INFO ts=2024-12-17T15:16:21Z app=device-random correlation-id=08151b28-e7d3-4295-b1aa-6a90bed53d08 msg="Reconfiguring"
level=DEBUG ts=2024-12-17T15:16:21Z app=device-random msg="Publishing metrics"
level=INFO ts=2024-12-17T15:16:26Z app=device-random correlation-id=f3f189f2-bf94-4d25-a6c6-5ff8e1f13a40 msg="AutoEvent: RandomDevice1/SensorTwo"
level=INFO ts=2024-12-17T15:16:31Z app=device-random correlation-id=68b07cb2-ce34-4b94-8a61-31e52d73038a msg="AutoEvent: RandomDevice1/SensorOne"
level=DEBUG ts=2024-12-17T15:16:31Z app=device-random msg="Publishing metrics"
level=INFO ts=2024-12-17T15:17:11Z app=device-random correlation-id=9949a72d-8e5d-4440-8b85-d17fb06b6d03 msg="Notified of config change at key 'device-services/Writable/Telemetry/Metrics/EventsSent' to value 'true'"
level=INFO ts=2024-12-17T16:17:11Z app=device-random correlation-id=9949a72d-8e5d-4440-8b85-d17fb06b6d03 msg="Reconfiguring"
```
5. Verify that the functionality for listening to private config changes still works properly.
```
curl -X 'PUT'   'http://localhost:59890/api/v3/kvs/key/edgex/v4/device-random/Writable/LogLevel?flatten=false'   -H 'accept: application/json'   -H 'Content-Type: application/json'   -d '{
  "value": "DEBUG"
}'
```
```
level=INFO ts=2024-12-17T16:37:51Z app=device-random correlation-id=99405528-b708-4ff9-a598-22363870c492 msg="Notified of config change at key 'Writable/LogLevel' to value 'DEBUG'"
level=INFO ts=2024-12-17T16:37:51Z app=device-random correlation-id=99405528-b708-4ff9-a598-22363870c492 msg="Reconfiguring"
level=INFO ts=2024-12-17T16:37:51Z app=device-random correlation-id=99405528-b708-4ff9-a598-22363870c492 msg="Setting LogLevel to DEBUG"
```