### PR TITLE
feat!: Use JSON object in message envelope payload instead of base64 string

### DIFF
--- a/src/c/bus-impl.h
+++ b/src/c/bus-impl.h
@@ -26,6 +26,7 @@ struct edgex_bus_t
   char *prefix;
   char *svcname;
   pthread_mutex_t mtx;
+  bool msgb64payload;
 };
 
 void edgex_bus_init (edgex_bus_t *bus, const char *svcname, const iot_data_t *cfg);


### PR DESCRIPTION
BREAKING CHANGE: Use JSON object in message envelope payload instead of base64 string

Add a new flag `msgb64payload` to the `edgex_bus_t` structure to support optional Base64 payload. This flag is configurable via the environment variable `EDGEX_MSG_BASE64_PAYLOAD` and defaults to `false`.

fix: #538 

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Run device-random and make sure Events, System Events, and Metrics all work fine.
