### PR TITLE
fix: properly free edgex_event_cooked

### DIFF
--- a/src/c/data.c
+++ b/src/c/data.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023
+ * Copyright (c) 2018-2025
  * IoTech Ltd
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -118,7 +118,6 @@ edgex_event_cooked *edgex_data_process_event
 
   eventId = edgex_device_genuuid ();
   result = malloc (sizeof (edgex_event_cooked));
-  atomic_store (&result->refs, 1);
   result->nrdgs = commandinfo->nreqs;
 
   result->path = malloc (strlen (commandinfo->profile->name) + strlen (device_name) + strlen (commandinfo->name) + 3);
@@ -191,11 +190,6 @@ void edgex_data_client_add_event (edgex_bus_t *client, edgex_event_cooked *ev, d
   free (topic);
 }
 
-void edgex_event_cooked_add_ref (edgex_event_cooked *e)
-{
-  atomic_fetch_add (&e->refs, 1);
-}
-
 size_t edgex_event_cooked_size (edgex_event_cooked *e)
 {
   size_t result;
@@ -238,13 +232,11 @@ void edgex_event_cooked_write (edgex_event_cooked *e, devsdk_http_reply *reply)
     }
   }
   reply->code = MHD_HTTP_OK;
-  free (e->path);
-  free (e);
 }
 
 void edgex_event_cooked_free (edgex_event_cooked *e)
 {
-  if (e && (atomic_fetch_add (&e->refs, -1) == 1))
+  if (e)
   {
     iot_data_free (e->value);
     free (e->path);

--- a/src/c/data.h
+++ b/src/c/data.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023
+ * Copyright (c) 2018-2025
  * IoTech Ltd
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -22,14 +22,12 @@ typedef enum { JSON, CBOR} edgex_event_encoding;
 
 typedef struct edgex_event_cooked
 {
-  atomic_uint_fast32_t refs;
   unsigned nrdgs;
   char *path;
   edgex_event_encoding encoding;
   iot_data_t *value;
 } edgex_event_cooked;
 
-void edgex_event_cooked_add_ref (edgex_event_cooked *e);
 size_t edgex_event_cooked_size (edgex_event_cooked *e);
 void edgex_event_cooked_write (edgex_event_cooked *e, devsdk_http_reply *rep);
 void edgex_event_cooked_free (edgex_event_cooked *e);

--- a/src/c/device.c
+++ b/src/c/device.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023
+ * Copyright (c) 2018-2025
  * IoTech Ltd
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -510,7 +510,6 @@ static void edgex_device_v2impl (devsdk_service_t *svc, edgex_device *dev, const
         {
           if (retv)
           {
-            edgex_event_cooked_add_ref (event);
             edgex_data_client_add_event (svc->msgbus, event, &svc->metrics);
             edgex_event_cooked_write (event, reply);
           }
@@ -520,6 +519,7 @@ static void edgex_device_v2impl (devsdk_service_t *svc, edgex_device *dev, const
             edgex_baseresponse_populate (&br, EDGEX_API_VERSION, MHD_HTTP_OK, "Event generated successfully");
             edgex_baseresponse_write (&br, reply);
           }
+          edgex_event_cooked_free (event);
         }
         else
         {
@@ -529,10 +529,10 @@ static void edgex_device_v2impl (devsdk_service_t *svc, edgex_device *dev, const
           }
           else
           {
-            edgex_event_cooked_free (event);
             edgex_baseresponse_populate (&br, EDGEX_API_VERSION, MHD_HTTP_OK, "Reading performed successfully");
             edgex_baseresponse_write (&br, reply);
           }
+          edgex_event_cooked_free (event);
         }
       }
     }


### PR DESCRIPTION
fix: #547 #546 

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Run the [device-random example](https://github.com/edgexfoundry/device-sdk-c/tree/main/src/c/examples/random) with [Valgrind](https://valgrind.org/) to check for memory leaks:
```
valgrind --leak-check=full ./device-random -cp=keeper.http://localhost:59890 -r
```
2. Issue core commands:
```
curl 'http://localhost:59882/api/v3/device/name/RandomDevice1/SensorOne?ds-pushevent=false&ds-returnevent=false'
curl 'http://localhost:59882/api/v3/device/name/RandomDevice1/SensorOne?ds-pushevent=true&ds-returnevent=false'
curl 'http://localhost:59882/api/v3/device/name/RandomDevice1/SensorOne?ds-pushevent=false&ds-returnevent=true'
curl 'http://localhost:59882/api/v3/device/name/RandomDevice1/SensorOne?ds-pushevent=true&ds-returnevent=true'
```
3. Verify Valgrind output. The expected output should indicate that all heap blocks were freed and no memory leaks occurred:
```
==379868== 
==379868== HEAP SUMMARY:
==379868==     in use at exit: 0 bytes in 0 blocks
==379868==   total heap usage: 13,511 allocs, 13,511 frees, 1,498,698 bytes allocated
==379868== 
==379868== All heap blocks were freed -- no leaks are possible
==379868== 
==379868== For lists of detected and suppressed errors, rerun with: -s
==379868== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
