### PR TITLE
fix: Make device resource attributes optional

### DIFF
--- a/src/c/device.c
+++ b/src/c/device.c
@@ -174,15 +174,12 @@ static edgex_cmdinfo *infoForDevRes (devsdk_service_t *svc, edgex_deviceprofile 
   if (devres->parsed_attrs == NULL)
   {
     devres->parsed_attrs = svc->userfns.create_res (svc->userdata, devres->attributes, &exception);
-    if (devres->parsed_attrs == NULL)
+    if (exception)
     {
-      if (exception)
-      {
-        char *exstr = iot_data_to_json (exception);
-        iot_log_error (svc->logger, "%s", exstr ? exstr : "Error: exstr reported NULL");
-        free (exstr);
-        iot_data_free (exception);
-      }
+      char *exstr = iot_data_to_json (exception);
+      iot_log_error (svc->logger, "%s", exstr ? exstr : "Error: exstr reported NULL");
+      free (exstr);
+      iot_data_free (exception);
       iot_log_error (svc->logger, "Unable to parse attributes for device resource %s: it will not be available", devres->name);
       return NULL;
     }


### PR DESCRIPTION
fix: #561 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Test using the [device-bitfields example](https://github.com/edgexfoundry/device-sdk-c/tree/main/src/c/examples/bitfields) in the sdk to confirm that core commands execute correctly.
