### PR TITLE
fix: Update infoForRes func to allow device resource attributes to be undefined

### DIFF
--- a/src/c/device.c
+++ b/src/c/device.c
@@ -125,9 +125,9 @@ static edgex_cmdinfo *infoForRes (devsdk_service_t *svc, edgex_deviceprofile *pr
           iot_log_error (svc->logger, "%s", exstr ? exstr : "Error: exstr reported NULL");
           free (exstr);
           iot_data_free (exception);
+          iot_log_error (svc->logger, "Unable to parse attributes for device resource %s: device command %s will not be available", devres->name, cmd->name);
+          return NULL;
         }
-        iot_log_error (svc->logger, "Unable to parse attributes for device resource %s: device command %s will not be available", devres->name, cmd->name);
-        return NULL;
       }
     }
   }


### PR DESCRIPTION
This is the missing piece from PR https://github.com/edgexfoundry/device-sdk-c/pull/562

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Testing with device-coap, verify that the log does not contain the following error messages:
```
level=ERROR ts=2025-03-24T09:04:59Z app=device-coap correlation-id=8990efb7-be8e-49ba-90ac-bf6f2f3a2150 msg="Unable to parse attributes for device resource int: device command cmd will not be available"
level=ERROR ts=2025-03-24T09:04:59Z app=device-coap correlation-id=8990efb7-be8e-49ba-90ac-bf6f2f3a2150 msg="Unable to parse attributes for device resource int: device command cmd will not be available"
```