### PR TITLE
refactor(device-sdk-c): fix Wmaybe-uninitialized warning

### DIFF
--- a/src/c/service.c
+++ b/src/c/service.c
@@ -13,6 +13,8 @@
 #include "device.h"
 #include "discovery.h"
 #include "callback3.h"
+#include "iot/data.h"
+#include "iot/logger.h"
 #include "validate.h"
 #include "errorlist.h"
 #include "rest-server.h"
@@ -1060,7 +1062,12 @@ void devsdk_service_start (devsdk_service_t *svc, iot_data_t *driverdfls, devsdk
   }
   else
   {
-    edgex_device_parseClients (svc->logger, iot_data_string_map_get (deviceservices_config, "Clients"), &svc->config.endpoints);
+    if(!(deviceservices_config ? iot_data_string_map_get (deviceservices_config, "Clients") : NULL)) 
+    {
+      iot_log_error(svc->logger, "device-service not defined in the provided configuration, exit");
+      _exit(1);
+    }
+   edgex_device_parseClients (svc->logger, iot_data_string_map_get (deviceservices_config, "Clients"), &svc->config.endpoints);
   }
 
   iot_data_free (config_file);

--- a/src/c/service.c
+++ b/src/c/service.c
@@ -1062,12 +1062,15 @@ void devsdk_service_start (devsdk_service_t *svc, iot_data_t *driverdfls, devsdk
   }
   else
   {
-    if(!(deviceservices_config ? iot_data_string_map_get (deviceservices_config, "Clients") : NULL)) 
+    if(deviceservices_config)
+    { 
+      edgex_device_parseClients (svc->logger, iot_data_string_map_get (deviceservices_config, "Clients"), &svc->config.endpoints);
+    }
+    else 
     {
       iot_log_error(svc->logger, "device-service not defined in the provided configuration, exit");
       _exit(1);
     }
-   edgex_device_parseClients (svc->logger, iot_data_string_map_get (deviceservices_config, "Clients"), &svc->config.endpoints);
   }
 
   iot_data_free (config_file);

--- a/src/c/service.c
+++ b/src/c/service.c
@@ -1069,7 +1069,8 @@ void devsdk_service_start (devsdk_service_t *svc, iot_data_t *driverdfls, devsdk
     else 
     {
       iot_log_error(svc->logger, "device-service not defined in the provided configuration, exit");
-      _exit(1);
+      *err = EDGEX_BAD_CONFIG;
+      return;
     }
   }
 

--- a/src/c/service.c
+++ b/src/c/service.c
@@ -872,7 +872,7 @@ void devsdk_service_start (devsdk_service_t *svc, iot_data_t *driverdfls, devsdk
   iot_data_t *config_file, *common_config_file = NULL;
   bool uploadConfig = false;
   iot_data_t *common_config_map, *private_config_map, *configmap;
-  const iot_data_t *deviceservices_config;
+  const iot_data_t *deviceservices_config = NULL;
 
   if (svc->starttime)
   {


### PR DESCRIPTION
closes: #566

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

Instructions are included in #566 
Test instructions are minimal since warning only appears in build process.

---
Thanks