### PR TITLE
fix(mqtt): nullify result pointer after free in edgex_bus_create_mqtt()

### DIFF
--- a/src/c/bus-mqtt.c
+++ b/src/c/bus-mqtt.c
@@ -313,6 +313,7 @@ edgex_bus_t *edgex_bus_create_mqtt (iot_logger_t *lc, const char *svcname, const
     free (cinfo->uri);
     free (cinfo);
     free (result);
+    result = NULL;
   }
 
   return result;


### PR DESCRIPTION
### Summary
This fixes a bug in `edgex_bus_create_mqtt()` where the `result` pointer is freed but not nullified,
resulting in a dangling pointer and potential undefined behavior.

### Change
- Explicitly set `result = NULL` after `free(result)` in the error path.

### Testing
- Verified that on error path, `result` returned is `NULL`.
- Ran SDK unit tests (if any) and ensured `make checkstyle` passes.

### Signed-off-by
Signed-off-by: sudarsan N <sudarsansamy2002@gmail.com>