### PR TITLE
fix(mqtt): destroy MQTTAsync client on failed connection setup

### DIFF
--- a/src/c/bus-mqtt.c
+++ b/src/c/bus-mqtt.c
@@ -310,6 +310,7 @@ edgex_bus_t *edgex_bus_create_mqtt (iot_logger_t *lc, const char *svcname, const
   }
   else
   {
+    MQTTAsync_destroy (&cinfo->client);
     free (cinfo->uri);
     free (cinfo);
     free (result);


### PR DESCRIPTION
Ensure that MQTTAsync_destroy() is called in the failure path of edgex_bus_create_mqtt when the connection fails. This prevents resource leaks caused by the uncleaned MQTT client instance.

Previously, only free() was called on cinfo without destroying the client.