### PR TITLE
fix(device_update_listener): add outcome value when associated profile gets changed or autoevent gets updated for an existing device

### DIFF
--- a/src/c/devmap.c
+++ b/src/c/devmap.c
@@ -225,10 +225,12 @@ static bool update_in_place (edgex_device *dest, const edgex_device *src, edgex_
   }
   if (strcmp (dest->profile->name, src->profile->name))
   {
+    *outcome = UPDATED_DRIVER;
     return false;
   }
   if (!edgex_device_autoevents_equal (dest->autos, src->autos))
   {
+    *outcome = UPDATED_DRIVER;
     return false;
   }
   dest->operatingState = src->operatingState;


### PR DESCRIPTION
Add outcome value as UPDATED_DRIVER during associated profile name change or autoevent update for an existing device of the service so that registered device update listener callback gets triggered for the service during such scenarios as well

Previously, this wasn't getting triggered on the occurrences of these 2 mentioned scenarios. Whereas we have certain use cases at 
our end where we would need the handling for the same at the service side. Hence would need the listener to get triggered during 
the mentioned scenarios.

Signed-off-by: Tuhin Dasgupta <TuhinDasgupta@eaton.com>