### PR TITLE
feat!: Add profile management support in order to get notification at the service side in case there is some update on associated device profile

### DIFF
--- a/include/devsdk/devsdk.h
+++ b/include/devsdk/devsdk.h
@@ -240,6 +240,14 @@ typedef void (*devsdk_update_device_callback) (void *impl, const char *devname, 
 
 typedef void (*devsdk_remove_device_callback) (void *impl, const char *devname, const devsdk_protocols *protocols);
 
+/**
+ * @brief Callback function indicating that an associated device profile has been modified.
+ * @param impl The context data passed in when the service was created.
+ * @param profname The name of the updated device profile.
+ */
+
+typedef void (*devsdk_update_profile_callback) ( void *impl, const char *profname );
+
 typedef struct devsdk_callbacks devsdk_callbacks;
 
 /**
@@ -282,6 +290,11 @@ void devsdk_callbacks_set_reconfiguration (devsdk_callbacks *cb, devsdk_reconfig
 
 void devsdk_callbacks_set_listeners
   (devsdk_callbacks *cb, devsdk_add_device_callback device_added, devsdk_update_device_callback device_updated, devsdk_remove_device_callback device_removed);
+
+/**
+ * @brief Populate optional associated device profile update notification function
+ */
+void devsdk_callbacks_set_profile_listener( devsdk_callbacks *cb, devsdk_update_profile_callback profile_updated );
 
 /**
  * @brief Populate optional autoevent management functions

--- a/src/c/callback3.c
+++ b/src/c/callback3.c
@@ -159,5 +159,12 @@ extern int32_t edgex_callback_update_profile (void *ctx, const iot_data_t *req, 
   edgex_deviceprofile *p = edgex_profile_read (iot_data_string_map_get (req, "details"));
   edgex_devmap_update_profile (svc, p);
   iot_log_info (svc->logger, "callback: Updated device profile %s", p->name);
+  // For now jst checking if listener defined, then call the listener
+  // To be improved: Check and call the listener only for specific conditions (device resource/command update) only
+  if ( svc->userfns.profile_updated )
+  {
+    iot_log_info( svc->logger, "service listener callback trigger: device profile %s", p->name );
+    svc->userfns.profile_updated( svc->userdata, p->name );
+  }
   return 0;
 }

--- a/src/c/devsdk-base.c
+++ b/src/c/devsdk-base.c
@@ -190,6 +190,11 @@ void devsdk_callbacks_set_listeners
   cb->device_removed = device_removed;
 }
 
+void devsdk_callbacks_set_profile_listener( devsdk_callbacks *cb, devsdk_update_profile_callback profile_updated )
+{
+  cb->profile_updated = profile_updated;
+}
+
 void devsdk_callbacks_set_autoevent_handlers (devsdk_callbacks *cb, devsdk_autoevent_start_handler ae_starter, devsdk_autoevent_stop_handler ae_stopper)
 {
   cb->ae_starter = ae_starter;

--- a/src/c/service.h
+++ b/src/c/service.h
@@ -39,6 +39,7 @@ struct devsdk_callbacks
   devsdk_add_device_callback device_added;
   devsdk_update_device_callback device_updated;
   devsdk_remove_device_callback device_removed;
+  devsdk_update_profile_callback profile_updated;
   devsdk_autoevent_start_handler ae_starter;
   devsdk_autoevent_stop_handler ae_stopper;
   devsdk_validate_address validate_addr;


### PR DESCRIPTION
There are certain use cases where profile entries are important at the service side and hence any modification is required to be notified to the service. For current initial phase, listener callback would only have info about the profile name so that developers can atleast use the function "edgex_get_deviceprofile_byname" on profile update listener callback trigger at the service side to get the updated profile details and take action accordingly from the service point of view.

Checking entire parameters w.r.t. device-resources/commands under the updated device profile seems to be a tricky part to get the profile update listener callback triggerred. Hence, going now with a simpler approach of only passing updated profile name as info for the callback so that the service gets to know that the device profile got updated and further actions can be taken and handled accordingly. Further investigation for improvement of this entire logic would be taken ahead later.

Signed-off-by: Tuhin_Dasgupta [TuhinDasgupta@eaton.com](mailto:TuhinDasgupta@eaton.com)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
Register  the profile update listener callback from your service to the sdk, put info level logs inside the registered service callback function, then update an associated device's profile, you would get the notification triggered and watch the logs to appear.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->