### PR TITLE
fix(sdk-c): correct device command topic ordering for v3 handler

### DIFF
--- a/src/c/service.c
+++ b/src/c/service.c
@@ -767,7 +767,7 @@ static void startConfigured (devsdk_service_t *svc, const devsdk_timeout *deadli
 
   /* Register MessageBus handlers */
 
-  topic = edgex_bus_mktopic (svc->msgbus, EDGEX_DEV_TOPIC_DEVICE, "{device}/{op}/{cmd}");
+  topic = edgex_bus_mktopic (svc->msgbus, EDGEX_DEV_TOPIC_DEVICE, "{device}/{cmd}/{op}");
   edgex_bus_register_handler (svc->msgbus, topic, svc, edgex_device_handler_devicev3);
   free (topic);
 


### PR DESCRIPTION
The device service SDK was constructing the message bus topic with
"{device}/{op}/{cmd}", but the v3 device handler expects the topic
to follow the standard "{device}/{cmd}/{op}" format.

This mismatch caused the `op` and `cmd` path parameters to be swapped,
leading to invalid parsing of command requests. The fix aligns the
topic with the handler logic and core-command specification.