### PR TITLE
feat(sdk-c): add support for CBOR encoding of all messages

### DIFF
--- a/src/c/bus-impl.h
+++ b/src/c/bus-impl.h
@@ -13,7 +13,7 @@
 #include <pthread.h>
 
 typedef void (*edgex_bus_freefn) (void *ctx);
-typedef void (*edgex_bus_postfn) (void *ctx, const char *path, const iot_data_t *envelope);
+typedef void (*edgex_bus_postfn) (void *ctx, const char *path, const iot_data_t *envelope, bool use_cbor);
 typedef void (*edgex_bus_subsfn) (void *ctx, const char *path);
 
 struct edgex_bus_t
@@ -27,9 +27,10 @@ struct edgex_bus_t
   char *svcname;
   pthread_mutex_t mtx;
   bool msgb64payload;
+  bool cbor;
 };
 
 void edgex_bus_init (edgex_bus_t *bus, const char *svcname, const iot_data_t *cfg);
-void edgex_bus_handle_request (edgex_bus_t *bus, const char *path, const char *envelope);
+void edgex_bus_handle_request (edgex_bus_t *bus, const char *path, const char *envelope, uint32_t len);
 
 #endif

--- a/src/c/bus-mqtt.c
+++ b/src/c/bus-mqtt.c
@@ -83,15 +83,27 @@ static void edgex_bus_mqtt_subscribe (void *ctx, const char *topic)
   }
 }
 
-static void edgex_bus_mqtt_post (void *ctx, const char *topic, const iot_data_t *envelope)
+static void edgex_bus_mqtt_post (void *ctx, const char *topic, const iot_data_t *envelope, bool use_cbor)
 {
   edgex_bus_mqtt_t *cinfo = (edgex_bus_mqtt_t *)ctx;
   int result;
   MQTTAsync_message pubmsg = MQTTAsync_message_initializer;
   MQTTAsync_responseOptions opts = MQTTAsync_responseOptions_initializer;
-  char *json = iot_data_to_json (envelope);
-  pubmsg.payload = json;
-  pubmsg.payloadlen = strlen (json);
+  char *data = NULL;
+  uint32_t datasz = 0;
+  iot_data_t *cbor = NULL;
+  if (use_cbor)
+  {
+    cbor = iot_data_to_cbor (envelope);
+    data = iot_data_binary_take(cbor, &datasz);
+  }
+  else
+  {
+    data = iot_data_to_json (envelope);
+    datasz = strlen (data);
+  }
+  pubmsg.payload = data;
+  pubmsg.payloadlen = datasz;
   pubmsg.qos = cinfo->qos;
   pubmsg.retained = cinfo->retained;
   opts.context = cinfo;
@@ -103,7 +115,11 @@ static void edgex_bus_mqtt_post (void *ctx, const char *topic, const iot_data_t 
   {
     iot_log_error (cinfo->lc, "mqtt: failed to post event, error %d", result);
   }
-  free (json);
+  if (cbor)
+  {
+    iot_data_free (cbor);
+  }
+  free(data);
 }
 
 static void edgex_bus_mqtt_onconnect(void *context, MQTTAsync_successData *response)
@@ -133,26 +149,17 @@ static int edgex_bus_mqtt_msgarrvd (void *context, char *topicName, int topicLen
 {
   edgex_bus_t *bus = (edgex_bus_t *)context;
   char *topic = topicName;
-  char *msg = message->payload;
 
   if (topicLen != 0) // Indicates topic string not terminated
   {
     topic = strndup (topicName, topicLen);
   }
-  if (msg[message->payloadlen - 1] != '\0')
-  {
-    msg = strndup (message->payload, message->payloadlen);
-  }
 
-  edgex_bus_handle_request (bus, topic, msg);
+  edgex_bus_handle_request (bus, topic, message->payload, message->payloadlen);
 
   if (topic != topicName)
   {
     free(topic);
-  }
-  if (msg != message->payload)
-  {
-    free(msg);
   }
   MQTTAsync_freeMessage (&message);
   MQTTAsync_free (topicName);

--- a/src/c/bus-mqtt.c
+++ b/src/c/bus-mqtt.c
@@ -115,10 +115,7 @@ static void edgex_bus_mqtt_post (void *ctx, const char *topic, const iot_data_t 
   {
     iot_log_error (cinfo->lc, "mqtt: failed to post event, error %d", result);
   }
-  if (cbor)
-  {
-    iot_data_free (cbor);
-  }
+  iot_data_free (cbor);
   free(data);
 }
 

--- a/src/c/bus.c
+++ b/src/c/bus.c
@@ -113,10 +113,7 @@ static char *edgex_data_to_b64 (const iot_data_t *src, bool use_cbor)
   size_t encsz = iot_b64_encodesize (sz);
   char *result = malloc (encsz);
   iot_b64_encode (data, sz, result, encsz);
-  if (cbor)
-  {
-    iot_data_free (cbor);
-  }
+  iot_data_free (cbor);
   free (data);
   return result;
 }

--- a/src/c/bus.c
+++ b/src/c/bus.c
@@ -92,18 +92,36 @@ static void edgex_bus_endpoint_free (void *p)
   free (ep);
 }
 
-static char *edgex_data_to_b64 (const iot_data_t *src)
+static char *edgex_data_to_b64 (const iot_data_t *src, bool use_cbor)
 {
-  char *json = iot_data_to_json (src);
-  size_t sz = strlen (json); // ignore the last null character, which causes an unmarshal error in core-data
+  char *data = NULL;
+  uint32_t sz = 0;
+  iot_data_t *cbor = NULL;
+  if (use_cbor)
+  {
+    cbor = iot_data_to_cbor (src);
+    if (cbor)
+    {
+      data = iot_data_binary_take(cbor, &sz);
+    }
+  }
+  else
+  {
+    data = iot_data_to_json (src);
+    sz = strlen (data); // ignore the last null character, which causes an unmarshal error in core-data
+  }
   size_t encsz = iot_b64_encodesize (sz);
   char *result = malloc (encsz);
-  iot_b64_encode (json, sz, result, encsz);
-  free (json);
+  iot_b64_encode (data, sz, result, encsz);
+  if (cbor)
+  {
+    iot_data_free (cbor);
+  }
+  free (data);
   return result;
 }
 
-void edgex_bus_post (edgex_bus_t *bus, const char *path, const iot_data_t *payload)
+void edgex_bus_post (edgex_bus_t *bus, const char *path, const iot_data_t *payload, bool event_is_cbor)
 {
   iot_data_t *envelope = iot_data_alloc_map (IOT_DATA_STRING);
   if (edgex_device_get_crlid ())
@@ -112,17 +130,26 @@ void edgex_bus_post (edgex_bus_t *bus, const char *path, const iot_data_t *paylo
   }
   iot_data_string_map_add (envelope, "apiVersion", iot_data_alloc_string (EDGEX_API_VERSION, IOT_DATA_REF));
   iot_data_string_map_add (envelope, "errorCode", iot_data_alloc_ui32 (0));
-  iot_data_string_map_add (envelope, "contentType", iot_data_alloc_string ("application/json", IOT_DATA_REF));
-  if (bus->msgb64payload)
+  if (event_is_cbor || bus->cbor)
   {
-    iot_data_string_map_add (envelope, "payload", iot_data_alloc_string (edgex_data_to_b64 (payload), IOT_DATA_TAKE));
+    iot_data_string_map_add (envelope, "contentType", iot_data_alloc_string ("application/cbor", IOT_DATA_REF));
+  }
+  else
+  {
+    iot_data_string_map_add (envelope, "contentType", iot_data_alloc_string ("application/json", IOT_DATA_REF));
+  }
+  // Like Go SDK's behavior: if envelope is CBOR, payload will not be base64-encoded, either way.
+  // If envelope is JSON and the event is a binary reading, payload will be base64-encoded CBOR, either way.
+  if ((!bus->cbor) && (bus->msgb64payload || event_is_cbor))
+  {
+    iot_data_string_map_add (envelope, "payload", iot_data_alloc_string (edgex_data_to_b64 (payload, event_is_cbor), IOT_DATA_TAKE));
   }
   else
   {
     iot_data_string_map_add (envelope, "payload", iot_data_add_ref (payload));
   }
 
-  bus->postfn (bus->ctx, path, envelope);
+  bus->postfn (bus->ctx, path, envelope, bus->cbor);
   iot_data_free (envelope);
 }
 
@@ -134,7 +161,7 @@ int edgex_bus_rmi (edgex_bus_t *bus, const char *path, const char *svcname, cons
   return -1;
 }
 
-void edgex_bus_handle_request (edgex_bus_t *bus, const char *path, const char *envelope)
+void edgex_bus_handle_request (edgex_bus_t *bus, const char *path, const char *envelope, uint32_t len)
 {
   void *ctx = NULL;
   iot_data_t *pathparams = iot_data_alloc_map (IOT_DATA_STRING);
@@ -146,17 +173,51 @@ void edgex_bus_handle_request (edgex_bus_t *bus, const char *path, const char *e
     const iot_data_t *crl = NULL;
     iot_data_t *req = NULL;
     iot_data_t *reply = NULL;
-    iot_data_t *envdata = iot_data_from_json (envelope);
-    if (bus->msgb64payload)
+    iot_data_t *envdata = NULL;
+    bool envelope_is_json = false;
+    bool payload_is_cbor = false;
+    if (bus->cbor)
+    {
+      envdata = iot_data_from_cbor ((const uint8_t *)envelope, len);
+    }
+    else
+    {
+      envelope_is_json = true;
+      if (envelope[len - 1] != '\0')
+      {
+        char *nullterm = strndup (envelope, len);
+        envdata = iot_data_from_json (nullterm);
+        free (nullterm);
+      }
+      else
+      {
+        envdata = iot_data_from_json (envelope);
+      }
+    }
+    const char *contentType = iot_data_string_map_get_string (envdata, "contentType");
+    if (strcmp (contentType, "application/cbor") == 0)
+    {
+      payload_is_cbor = true;
+    }
+
+    if ((bus->msgb64payload) || (envelope_is_json && payload_is_cbor))
     {
       const char *payload = iot_data_string_map_get_string (envdata, "payload");
-      if (payload) {
+      if (payload) 
+      {
         size_t sz = iot_b64_maxdecodesize(payload);
-        char *json = malloc(sz + 1);
-        iot_b64_decode(payload, json, &sz);
-        json[sz] = '\0';
-        req = iot_data_from_json(json);
-        free(json);
+        char *data = malloc(sz + 1);
+        iot_b64_decode(payload, data, &sz);
+        data[sz] = '\0';
+        if (payload_is_cbor)
+        {
+          req = iot_data_from_cbor ((const uint8_t *)data, sz);
+        }
+        else
+        {
+          req = iot_data_from_json (data);
+        }
+        free(data);
       }
     }
     else
@@ -174,9 +235,8 @@ void edgex_bus_handle_request (edgex_bus_t *bus, const char *path, const char *e
     {
       edgex_device_alloc_crlid (iot_data_string (crl));
     }
-
-    status = h (ctx, req, pathparams, iot_data_string_map_get (envdata, "queryParams"), &reply);
-
+    bool event_is_cbor = false;
+    status = h (ctx, req, pathparams, iot_data_string_map_get (envdata, "queryParams"), &reply, &event_is_cbor);
     if (reply)
     {
       char *rpath;
@@ -184,11 +244,17 @@ void edgex_bus_handle_request (edgex_bus_t *bus, const char *path, const char *e
       const iot_data_t *id;
       iot_data_t *renv = iot_data_alloc_map (IOT_DATA_STRING);
       iot_data_string_map_add (renv, "errorCode", iot_data_alloc_i32 (status));
-      iot_data_string_map_add (renv, "contentType", iot_data_alloc_string ("application/json", IOT_DATA_REF));
-      // XXX and if it's CBOR? - metadata on the reply should say so
-      if (bus->msgb64payload)
+      if (bus->cbor || event_is_cbor)
       {
-        iot_data_string_map_add (renv, "payload", iot_data_alloc_string (edgex_data_to_b64 (reply), IOT_DATA_TAKE));
+        iot_data_string_map_add (renv, "contentType", iot_data_alloc_string ("application/cbor", IOT_DATA_REF));
+      }
+      else
+      {
+        iot_data_string_map_add (renv, "contentType", iot_data_alloc_string ("application/json", IOT_DATA_REF));
+      }
+      if ((!bus->cbor) && (bus->msgb64payload || event_is_cbor))
+      {
+        iot_data_string_map_add (renv, "payload", iot_data_alloc_string (edgex_data_to_b64 (reply, event_is_cbor), IOT_DATA_TAKE));
       }
       else
       {
@@ -198,11 +264,22 @@ void edgex_bus_handle_request (edgex_bus_t *bus, const char *path, const char *e
       iot_data_string_map_add (renv, "correlationID", iot_data_add_ref (crl));
       iot_data_string_map_add (renv, "apiVersion", iot_data_alloc_string (EDGEX_API_VERSION, IOT_DATA_REF));
       id = iot_data_string_map_get (envdata, "requestID");
-      idstr = iot_data_string (id);
-      // iot_data_string_map_add (renv, "requestID", iot_data_add_ref (id));
-      rpath = edgex_bus_mktopic (bus, EDGEX_DEV_TOPIC_RESPONSE, idstr);
-      bus->postfn (bus->ctx, rpath, renv);
-      free (rpath);
+      if (!id)
+      {
+        id = iot_data_string_map_get (envdata, "requestId");
+      }
+      if (id)
+      {
+        idstr = iot_data_string (id);
+        // iot_data_string_map_add (renv, "requestID", iot_data_add_ref (id));
+        rpath = edgex_bus_mktopic (bus, EDGEX_DEV_TOPIC_RESPONSE, idstr);
+        bus->postfn (bus->ctx, rpath, renv, bus->cbor);
+        free (rpath);
+      }
+      else
+      {
+        iot_log_error(iot_logger_default (), "edgex_bus_handle_request: no request ID in envelope, cannot send reply");
+      }
       iot_data_free (renv);
     }
     if (crl)
@@ -214,6 +291,7 @@ void edgex_bus_handle_request (edgex_bus_t *bus, const char *path, const char *e
   }
   iot_data_free (pathparams);
 }
+
 
 char *edgex_bus_mktopic (edgex_bus_t *bus, const char *type, const char *param)
 {
@@ -247,6 +325,12 @@ void edgex_bus_init (edgex_bus_t *bus, const char *svcname, const iot_data_t *cf
   if (msgb64payload && strcmp (msgb64payload, "true") == 0)
   {
     bus->msgb64payload = true;
+  }
+  bus->cbor = false;
+  const char *msgcbor = getenv("EDGEX_MSG_CBOR_ENCODE");
+  if (msgcbor && strcmp (msgcbor, "true") == 0)
+  {
+    bus->cbor = true;
   }
 }
 

--- a/src/c/bus.h
+++ b/src/c/bus.h
@@ -34,7 +34,7 @@
 
 typedef struct edgex_bus_t edgex_bus_t;
 
-typedef int32_t (*edgex_handler_fn) (void *ctx, const iot_data_t *request, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply);
+typedef int32_t (*edgex_handler_fn) (void *ctx, const iot_data_t *request, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply, bool *event_is_cbor);
 
 void edgex_bus_config_defaults (iot_data_t *allconf, const char *svcname);
 JSON_Value *edgex_bus_config_json (const iot_data_t *allconf);
@@ -44,7 +44,7 @@ edgex_bus_t *edgex_bus_create_mqtt
 
 void edgex_bus_register_handler (edgex_bus_t *bus, const char *path, void *ctx, edgex_handler_fn handler);
 char *edgex_bus_mktopic (edgex_bus_t *bus, const char *type, const char *param);
-void edgex_bus_post (edgex_bus_t *bus, const char *path, const iot_data_t *payload);
+void edgex_bus_post (edgex_bus_t *bus, const char *path, const iot_data_t *payload, bool event_is_cbor);
 int edgex_bus_rmi (edgex_bus_t *bus, const char *path, const char *svcname, const iot_data_t *request, iot_data_t **reply);
 
 void edgex_bus_free (edgex_bus_t *bus);

--- a/src/c/callback3.c
+++ b/src/c/callback3.c
@@ -15,7 +15,7 @@
 #include "autoevent.h"
 #include <microhttpd.h>
 
-int32_t edgex_callback_add_device (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply)
+int32_t edgex_callback_add_device (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply, bool *event_is_cbor)
 {
   devsdk_service_t *svc = (devsdk_service_t *) ctx;
   devsdk_error e;
@@ -42,7 +42,7 @@ int32_t edgex_callback_add_device (void *ctx, const iot_data_t *req, const iot_d
   return 0;
 }
 
-int32_t edgex_callback_delete_device (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply)
+int32_t edgex_callback_delete_device (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply, bool *event_is_cbor)
 {
   devsdk_service_t *svc = (devsdk_service_t *) ctx;
   bool found = false;
@@ -73,7 +73,7 @@ int32_t edgex_callback_delete_device (void *ctx, const iot_data_t *req, const io
   return 0;
 }
 
-int32_t edgex_callback_update_device (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply)
+int32_t edgex_callback_update_device (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply, bool *event_is_cbor)
 {
   devsdk_service_t *svc = (devsdk_service_t *) ctx;
   devsdk_error e;
@@ -103,7 +103,7 @@ int32_t edgex_callback_update_device (void *ctx, const iot_data_t *req, const io
   return 0;
 }
 
-int32_t edgex_callback_update_deviceservice (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply)
+int32_t edgex_callback_update_deviceservice (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply, bool *event_is_cbor)
 {
   devsdk_service_t *svc = (devsdk_service_t *) ctx;
 
@@ -121,7 +121,7 @@ int32_t edgex_callback_update_deviceservice (void *ctx, const iot_data_t *req, c
   return 0;
 }
 
-int32_t edgex_callback_add_pw (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply)
+int32_t edgex_callback_add_pw (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply, bool *event_is_cbor)
 {
   devsdk_service_t *svc = (devsdk_service_t *) ctx;
 
@@ -135,7 +135,7 @@ int32_t edgex_callback_add_pw (void *ctx, const iot_data_t *req, const iot_data_
   return 0;
 }
 
-int32_t edgex_callback_update_pw (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply)
+int32_t edgex_callback_update_pw (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply, bool *event_is_cbor)
 {
   devsdk_service_t *svc = (devsdk_service_t *) ctx;
 
@@ -146,7 +146,7 @@ int32_t edgex_callback_update_pw (void *ctx, const iot_data_t *req, const iot_da
   return 0;
 }
 
-int32_t edgex_callback_delete_pw (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply)
+int32_t edgex_callback_delete_pw (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply, bool *event_is_cbor)
 {
   devsdk_service_t *svc = (devsdk_service_t *) ctx;
 
@@ -161,7 +161,7 @@ int32_t edgex_callback_delete_pw (void *ctx, const iot_data_t *req, const iot_da
   return 0;
 }
 
-extern int32_t edgex_callback_update_profile (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply)
+extern int32_t edgex_callback_update_profile (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply, bool *event_is_cbor)
 {
   devsdk_service_t *svc = (devsdk_service_t *) ctx;
 

--- a/src/c/callback3.h
+++ b/src/c/callback3.h
@@ -11,16 +11,16 @@
 
 #include <iot/data.h>
 
-extern int32_t edgex_callback_add_device (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply);
-extern int32_t edgex_callback_delete_device (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply);
-extern int32_t edgex_callback_update_device (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply);
+extern int32_t edgex_callback_add_device (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply, bool *event_is_cbor);
+extern int32_t edgex_callback_delete_device (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply, bool *event_is_cbor);
+extern int32_t edgex_callback_update_device (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply, bool *event_is_cbor);
 
-extern int32_t edgex_callback_add_pw (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply);
-extern int32_t edgex_callback_delete_pw (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply);
-extern int32_t edgex_callback_update_pw (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply);
+extern int32_t edgex_callback_add_pw (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply, bool *event_is_cbor);
+extern int32_t edgex_callback_delete_pw (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply, bool *event_is_cbor);
+extern int32_t edgex_callback_update_pw (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply, bool *event_is_cbor);
 
-extern int32_t edgex_callback_update_deviceservice (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply);
+extern int32_t edgex_callback_update_deviceservice (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply, bool *event_is_cbor);
 
-extern int32_t edgex_callback_update_profile (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply);
+extern int32_t edgex_callback_update_profile (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply, bool *event_is_cbor);
 
 #endif

--- a/src/c/data.c
+++ b/src/c/data.c
@@ -197,7 +197,7 @@ void edgex_data_client_add_event (edgex_bus_t *client, edgex_event_cooked *ev, d
 {
   char *topic = edgex_bus_mktopic (client, EDGEX_DEV_TOPIC_EVENT, ev->path);
   edc_update_metrics (metrics, ev);
-  edgex_bus_post (client, topic, ev->value);
+  edgex_bus_post (client, topic, ev->value, (ev->encoding == CBOR));
   free (topic);
 }
 
@@ -236,7 +236,7 @@ void edgex_event_cooked_write (edgex_event_cooked *e, devsdk_http_reply *reply)
       iot_data_t *cbor = iot_data_to_cbor (e->value);
       reply->data.size = iot_data_array_size (cbor);
       reply->data.bytes = malloc (reply->data.size);
-      memcpy (reply->data.bytes, iot_data_address (e->value), reply->data.size);
+      memcpy (reply->data.bytes, iot_data_address (cbor), reply->data.size);
       reply->content_type = CONTENT_CBOR;
       iot_data_free (cbor);
       break;

--- a/src/c/device.h
+++ b/src/c/device.h
@@ -16,7 +16,7 @@
 
 extern void edgex_device_handler_device_namev2 (void *ctx, const devsdk_http_request *req, devsdk_http_reply *reply);
 
-extern int32_t edgex_device_handler_devicev3 (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply);
+extern int32_t edgex_device_handler_devicev3 (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply, bool *event_is_cbor);
 
 extern const struct edgex_cmdinfo *edgex_deviceprofile_findcommand
   (devsdk_service_t *svc, const char *name, edgex_deviceprofile *prof, bool forGet);

--- a/src/c/examples/file/device-file.c
+++ b/src/c/examples/file/device-file.c
@@ -74,7 +74,19 @@ static bool file_get_handler
   iot_data_t **exception
 )
 {
-  return false;
+  const char *fname = device->address;
+  uint32_t size = 0;
+  uint8_t *data = file_readfile (fname, &size);
+  if (data)
+  {
+    readings[0].value = iot_data_alloc_binary (data, size, IOT_DATA_TAKE);
+  }
+  else
+  {
+    return false;
+  }
+
+  return true;
 }
 
 static bool file_put_handler

--- a/src/c/keeper.c
+++ b/src/c/keeper.c
@@ -26,7 +26,7 @@ typedef struct keeper_impl_t
     void *updatectx;
 } keeper_impl_t;
 
-static int32_t edgex_keeper_client_notify(void *impl, const iot_data_t *request, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply);
+static int32_t edgex_keeper_client_notify(void *impl, const iot_data_t *request, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply, bool *event_is_cbor);
 
 void *devsdk_registry_keeper_alloc(devsdk_service_t *service)
 {
@@ -428,7 +428,7 @@ static void process_notification(keeper_impl_t *keeper, const iot_data_t *reques
   }
 }
 
-static int32_t edgex_keeper_client_notify(void *impl, const iot_data_t *request, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply)
+static int32_t edgex_keeper_client_notify(void *impl, const iot_data_t *request, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply, bool *event_is_cbor)
 {
   keeper_impl_t *keeper = (keeper_impl_t *)impl;
   if ((!keeper) || (!request) || (iot_data_type(request) != IOT_DATA_MAP))

--- a/src/c/service.c
+++ b/src/c/service.c
@@ -365,7 +365,7 @@ extern void devsdk_publish_system_event (devsdk_service_t *svc, const char *acti
   strcpy (t, "device/");
   strcat (t, action);
   char *topic = edgex_bus_mktopic (svc->msgbus, EDGEX_DEV_TOPIC_SYSTEM_EVENT, t);
-  edgex_bus_post (svc->msgbus, topic, event);
+  edgex_bus_post (svc->msgbus, topic, event, false);
   free (t);
   free (topic);
 }
@@ -386,7 +386,7 @@ extern void devsdk_publish_discovery_event (devsdk_service_t *svc, const char * 
   iot_data_string_map_add (event, "timestamp", iot_data_alloc_ui64 (iot_time_nsecs ()));
 
   char *topic = edgex_bus_mktopic (svc->msgbus, EDGEX_DEV_TOPIC_SYSTEM_EVENT, "device/discovery");
-  edgex_bus_post (svc->msgbus, topic, event);
+  edgex_bus_post (svc->msgbus, topic, event, false);
   free (topic);
 
   iot_data_free (event);
@@ -410,7 +410,7 @@ static void devsdk_publish_metric (devsdk_service_t *svc, const char *mname, uin
   iot_data_string_map_add (metric, "timestamp", iot_data_alloc_ui64 (iot_time_nsecs ()));
 
   char *topic = edgex_bus_mktopic (svc->msgbus, EDGEX_DEV_TOPIC_METRIC, mname);
-  edgex_bus_post (svc->msgbus, topic, metric);
+  edgex_bus_post (svc->msgbus, topic, metric, false);
   free (topic);
 
   iot_data_free (metric);

--- a/src/c/validate.c
+++ b/src/c/validate.c
@@ -32,7 +32,7 @@ static devsdk_protocols *protocols_convert (const iot_data_t *obj)
   return result;
 }
 
-int32_t edgex_device_handler_validate_addr_v3 (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply)
+int32_t edgex_device_handler_validate_addr_v3 (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply, bool *event_is_cbor)
 {
   devsdk_service_t *svc = (devsdk_service_t *) ctx;
   int32_t result = 0;

--- a/src/c/validate.h
+++ b/src/c/validate.h
@@ -11,6 +11,6 @@
 
 #include <iot/data.h>
 
-int32_t edgex_device_handler_validate_addr_v3 (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply);
+int32_t edgex_device_handler_validate_addr_v3 (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply, bool *event_is_cbor);
 
 #endif


### PR DESCRIPTION
Add support for environment variable EDGEX_MSG_CBOR_ENCODE. When set to "true", messages we send on the bus will have CBOR envelopes. The payload is not base64 encoded, regardless of the EDGEX_MSG_BASE64_PAYLOAD value, which is the same behavior as the Go SDK.

Also fix behavior of bus messages (pushed events and GET request from the message bus) for Binary value types, those messages will have CBOR payloads regardless of the environment variables, and if EDGEX_MSG_CBOR_ENCODE is not true, the payload will be base64 encoded regardless of the environment variables, which is the same behavior as the Go SDK.

Add a GET handler to the device-file example, to facilitate testing.

Closes: #575

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) (none yet)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) N/A
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

Monitored the message bus while trying GET requests through REST and through the message bus, for all combinations of these conditions:
- device-virtual (an integer and a binary resource), device-file (a binary resource), device-random (an integer resource)
- EDGEX_MSG_CBOR_ENCODE values "false" and "true"
- EDGEX_MSG_BASE64_PAYLOAD values "false" and "true"

In all cases, device-file and device-random produced events and responses in the same format as device-virtual.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->