### PR TITLE
feat(sdk-c): add support for core command client access from the device services

### DIFF
--- a/include/devsdk/devsdk-base.h
+++ b/include/devsdk/devsdk-base.h
@@ -113,6 +113,31 @@ typedef struct devsdk_devices
 } devsdk_devices;
 
 /**
+ * @brief Linked-list structure containing information from core-command
+ */
+
+typedef struct devsdk_corecommand
+{
+  const char *name;
+  bool get;
+  bool set;
+  const char *path;
+  const char *url;
+  iot_data_t *parameters;
+  struct devsdk_corecommand *next;
+} devsdk_corecommand;
+
+typedef struct devsdk_devicecorecommand
+{
+  const char *deviceName;
+  const char *profileName;
+  struct devsdk_corecommand *corecommands;
+  struct devsdk_devicecorecommand *next;
+} devsdk_devicecorecommand;
+
+void devsdk_devicecorecommand_free(devsdk_devicecorecommand *);
+
+/**
  * @brief Finds a protocol's property set in a protocols list.
  * @param prots The protocols to search.
  * @param name The protocol to search for.

--- a/include/devsdk/devsdk-base.h
+++ b/include/devsdk/devsdk-base.h
@@ -131,7 +131,6 @@ typedef struct devsdk_devicecorecommand
   char *deviceName;
   char *profileName;
   iot_data_t *corecommands;
-  struct devsdk_devicecorecommand *next;
 } devsdk_devicecorecommand;
 
 void devsdk_devicecorecommand_free(void *);

--- a/include/devsdk/devsdk-base.h
+++ b/include/devsdk/devsdk-base.h
@@ -118,19 +118,19 @@ typedef struct devsdk_devices
 
 typedef struct devsdk_corecommand
 {
-  const char *name;
+  char *name;
   bool get;
   bool set;
-  const char *path;
-  const char *url;
+  char *path;
+  char *url;
   iot_data_t *parameters;
   struct devsdk_corecommand *next;
 } devsdk_corecommand;
 
 typedef struct devsdk_devicecorecommand
 {
-  const char *deviceName;
-  const char *profileName;
+  char *deviceName;
+  char *profileName;
   struct devsdk_corecommand *corecommands;
   struct devsdk_devicecorecommand *next;
 } devsdk_devicecorecommand;

--- a/include/devsdk/devsdk-base.h
+++ b/include/devsdk/devsdk-base.h
@@ -124,18 +124,17 @@ typedef struct devsdk_corecommand
   char *path;
   char *url;
   iot_data_t *parameters;
-  struct devsdk_corecommand *next;
 } devsdk_corecommand;
 
 typedef struct devsdk_devicecorecommand
 {
   char *deviceName;
   char *profileName;
-  struct devsdk_corecommand *corecommands;
+  iot_data_t *corecommands;
   struct devsdk_devicecorecommand *next;
 } devsdk_devicecorecommand;
 
-void devsdk_devicecorecommand_free(devsdk_devicecorecommand *);
+void devsdk_devicecorecommand_free(void *);
 
 /**
  * @brief Finds a protocol's property set in a protocols list.

--- a/include/devsdk/devsdk.h
+++ b/include/devsdk/devsdk.h
@@ -423,6 +423,51 @@ extern void devsdk_publish_discovery_event (devsdk_service_t *svc, const char * 
  */
 extern void devsdk_publish_system_event (devsdk_service_t *svc, const char *action, iot_data_t * details);
 
+/**
+ * @brief List all available core commands, paginated
+ * @param svc The device service.
+ * @param offset integer to start reading commands
+ * @param limit integer limit of commands to return
+ * @param ncommands The number of commands returned.
+ * @param commands returned commands
+ * @param err Nonzero reason codes will be set here in the event of errors.
+ */
+void devsdk_get_commands(devsdk_service_t *svc, int offset, int limit, uint32_t *ncommands, const devsdk_devicecorecommand **commands, devsdk_error *err);
+
+/**
+ * @brief List the available commands for a specified device service
+ * @param svc The device service.
+ * @param devname The requested device name.
+ * @param ncommands The number of commands returned.
+ * @param commands returned commands
+ * @param err Nonzero reason codes will be set here in the event of errors.
+ */
+void devsdk_get_commands_by_name(devsdk_service_t *svc, const char *devname, uint32_t *ncommands, const devsdk_devicecorecommand **commands, devsdk_error *err);
+
+/**
+ * @brief Send a write (put) command to another device
+ * @param svc The device service.
+ * @param devname The device name.
+ * @param resname The resource name.
+ * @param value The values to send.
+ * @param err Nonzero reason codes will be set here in the event of errors.
+ */
+void devsdk_send_command (devsdk_service_t *svc, const char *devname, const char *resname, const iot_data_t *value, devsdk_error *err);
+
+/**
+ * @brief Send a read (get) command to another device
+ * @param svc The device service.
+ * @param devname The device name.
+ * @param cmdname The command to request.
+ * @param pushevent Push the results to the message bus.
+ * @param returnevent Return the results.
+ * @param nreadings pointer to int number of returned results.
+ * @param readings returned results.
+ * @param err Nonzero reason codes will be set here in the event of errors.
+ */
+void devsdk_read_command
+     (devsdk_service_t *svc, const char *devname, const char *cmdname, bool pushevent, bool returnevent, uint32_t **nreadings, const devsdk_commandresult **readings, devsdk_error *err);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/devsdk/devsdk.h
+++ b/include/devsdk/devsdk.h
@@ -429,10 +429,10 @@ extern void devsdk_publish_system_event (devsdk_service_t *svc, const char *acti
  * @param offset integer to start reading commands
  * @param limit integer limit of commands to return
  * @param ncommands The number of commands returned.
- * @param commands returned commands
+ * @param commands returned commands, iot_data_vector containing a vector collection of pointers to devsdk_devicecorecommand
  * @param err Nonzero reason codes will be set here in the event of errors.
  */
-void devsdk_get_commands(devsdk_service_t *svc, int offset, int limit, uint32_t *ncommands, devsdk_devicecorecommand **commands, devsdk_error *err);
+void devsdk_get_commands(devsdk_service_t *svc, int offset, int limit, uint32_t *ncommands, iot_data_t **commands, devsdk_error *err);
 
 /**
  * @brief List the available commands for a specified device service

--- a/include/devsdk/devsdk.h
+++ b/include/devsdk/devsdk.h
@@ -432,7 +432,7 @@ extern void devsdk_publish_system_event (devsdk_service_t *svc, const char *acti
  * @param commands returned commands
  * @param err Nonzero reason codes will be set here in the event of errors.
  */
-void devsdk_get_commands(devsdk_service_t *svc, int offset, int limit, uint32_t *ncommands, const devsdk_devicecorecommand **commands, devsdk_error *err);
+void devsdk_get_commands(devsdk_service_t *svc, int offset, int limit, uint32_t *ncommands, devsdk_devicecorecommand **commands, devsdk_error *err);
 
 /**
  * @brief List the available commands for a specified device service
@@ -442,7 +442,7 @@ void devsdk_get_commands(devsdk_service_t *svc, int offset, int limit, uint32_t 
  * @param commands returned commands
  * @param err Nonzero reason codes will be set here in the event of errors.
  */
-void devsdk_get_commands_by_name(devsdk_service_t *svc, const char *devname, uint32_t *ncommands, const devsdk_devicecorecommand **commands, devsdk_error *err);
+void devsdk_get_commands_by_name(devsdk_service_t *svc, const char *devname, uint32_t *ncommands, devsdk_devicecorecommand **commands, devsdk_error *err);
 
 /**
  * @brief Send a write (put) command to another device
@@ -466,7 +466,7 @@ void devsdk_send_command (devsdk_service_t *svc, const char *devname, const char
  * @param err Nonzero reason codes will be set here in the event of errors.
  */
 void devsdk_read_command
-     (devsdk_service_t *svc, const char *devname, const char *cmdname, bool pushevent, bool returnevent, uint32_t **nreadings, const devsdk_commandresult **readings, devsdk_error *err);
+     (devsdk_service_t *svc, const char *devname, const char *cmdname, bool pushevent, bool returnevent, uint32_t **nreadings, devsdk_commandresult **readings, devsdk_error *err);
 
 #ifdef __cplusplus
 }

--- a/src/c/command.c
+++ b/src/c/command.c
@@ -1,0 +1,419 @@
+/*
+ * Copyright (c) 2024
+ * Eaton Corp.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#include <curl/curl.h>
+#include <errno.h>
+
+#include "api.h"
+#include "command.h"
+#include "config.h"
+#include "edgex-rest.h"
+#include "errorlist.h"
+#include "rest.h"
+#include "service.h"
+
+#include "edgex/devices.h"
+
+/** devsdk api functions, defined in devsdk.h **/
+
+void devsdk_get_commands(devsdk_service_t *svc, int offset, int limit, uint32_t *ncommands, const devsdk_devicecorecommand **commands, devsdk_error *err)
+{
+  *err = EDGEX_OK;
+  devsdk_devicecorecommand *cmds=*commands;
+  iot_data_t *device_commands=NULL;
+  iot_data_t *response_map=edgex_command_get_all_commands
+  (
+    svc->logger,
+    &svc->config.endpoints,
+    svc->secretstore,
+    offset,
+    limit,
+    err
+  );
+  if (err->code){
+    iot_log_error (svc->logger, "Failed to get commands. Reason: %s",
+      err->reason);
+      *ncommands=0;
+      memset(cmds,0,sizeof(devsdk_devicecorecommand));
+      return;
+  }
+
+  device_commands=iot_data_string_map_get_vector(response_map,"deviceCoreCommands");
+  if (!device_commands)
+  {
+    iot_log_error (svc->logger, "Failed to get commands. Can not read 'deviceCoreCommands'");
+    *ncommands=0;
+    memset(cmds,0,sizeof(devsdk_devicecorecommand));
+    return;
+  }
+
+  iot_data_vector_iter_t viter;
+  iot_data_vector_iter(device_commands,&viter);
+  devsdk_devicecorecommand *newcc=cmds;
+  devsdk_devicecorecommand **ccend=&cmds->next;
+  while (iot_data_vector_iter_next(&viter))
+  {
+    if (!newcc)
+    {
+      newcc = malloc(sizeof(devsdk_corecommand));
+      memset(cmds,0,sizeof(devsdk_devicecorecommand));
+      *ccend=newcc;
+    }
+    devsdk_devicecorecommand_populate(iot_data_vector_iter_value(&viter),ncommands,&newcc);
+    ccend=&newcc->next;
+    newcc=NULL;
+  }
+}
+
+void devsdk_get_commands_by_name(devsdk_service_t *svc, const char *devname, uint32_t *ncommands, const devsdk_devicecorecommand **commands, devsdk_error *err)
+{
+  *err = EDGEX_OK;
+  devsdk_devicecorecommand *cmdparse=*commands;
+  iot_data_t *device_commands=NULL;
+  iot_data_t *map=edgex_command_get_device_commands
+  (
+    svc->logger,
+    &svc->config.endpoints,
+    svc->secretstore,
+    devname,
+    err
+  );
+  if (err->code){
+    iot_log_error (svc->logger, "Failed to get commands for device %s. Reason: %s",
+      devname,
+      err->reason);
+      *ncommands=0;
+      cmdparse=NULL;
+      return;
+  }
+
+  device_commands=iot_data_string_map_get_map(map,"deviceCoreCommand");
+  if (!device_commands)
+  {
+    iot_log_error (svc->logger, "Failed to get commands for device %s. Reason: core-command invalid map",devname);
+    *ncommands=0;
+    memset(cmdparse,0,sizeof(devsdk_devicecorecommand));
+    return;
+  }
+  devsdk_devicecorecommand_populate(device_commands,ncommands,&cmdparse);
+}
+
+void devsdk_send_command (devsdk_service_t *svc, const char *devname, const char *resname, const iot_data_t *cmd, devsdk_error *err)
+{
+  *err = EDGEX_OK;
+  edgex_device *device;
+  device = edgex_devmap_device_byname (svc->devices, devname);
+  if (device)
+  {
+    iot_data_t* reply;
+    iot_data_t* request;
+    iot_data_t* value;
+
+    request = iot_data_alloc_map (IOT_DATA_STRING);
+    char* json = iot_data_to_json(cmd);
+    value = (iot_data_type(cmd) == IOT_DATA_STRING) ? iot_data_copy(cmd) : iot_data_alloc_string(json, IOT_DATA_REF);
+
+    iot_data_string_map_add(request, resname, value);
+
+    int32_t result = edgex_device_v3impl (svc, device, resname, false, request, NULL, &reply, false);
+    if (result != 0) *err = EDGEX_HTTP_ERROR;
+
+    iot_data_free(request);
+    free(json);
+  }
+  else
+  {
+    edgex_command_write_command
+    (
+      svc->logger,
+      &svc->config.endpoints,
+      svc->secretstore,
+      devname,
+      resname,
+      cmd,
+      err
+    );
+  }
+  if (err->code)
+  {
+    iot_log_error (svc->logger, "Unable to send command to %s device %s resource %s. Reason: %s",
+      device ? "internal" : "external",
+      devname,
+      resname,
+      err->reason);
+  }
+}
+
+void devsdk_read_command (
+  devsdk_service_t *svc,
+  const char *devname,
+  const char *cmdname,
+  bool pushevent,
+  bool returnevent,
+  uint32_t **nreadings,
+  const devsdk_commandresult **readings,
+  devsdk_error *err
+)
+{
+  *err = EDGEX_OK;
+  edgex_device *device;
+  device = edgex_devmap_device_byname (svc->devices, devname);
+
+  uint32_t *resulttotal = *nreadings;
+  devsdk_commandresult *cmdreadings=*readings;
+
+  iot_data_t *readcommanddata = edgex_command_read_command(
+      svc->logger,
+      &svc->config.endpoints,
+      svc->secretstore,
+      devname,
+      cmdname,
+      false,
+      true,
+      err
+  );
+  if (err->code)
+  {
+    iot_log_error (svc->logger, "Failed read command for %s device %s resource %s. Reason: %s",
+      device ? "internal" : "external",
+      devname,
+      cmdname,
+      err->reason);
+      *nreadings=0;
+      cmdreadings=NULL;
+      return;
+  }
+
+  iot_data_t *responseEventMap=iot_data_string_map_get_map(readcommanddata,"event");
+  cmdreadings->origin=iot_data_string_map_get_ui64(responseEventMap,"origin",0u);
+  cmdreadings->value=iot_data_string_map_get_vector(responseEventMap,"readings");
+  *resulttotal=0;
+  if (cmdreadings->value!=NULL)
+  {
+      *resulttotal=iot_data_vector_size(cmdreadings->value);
+  }
+}
+
+void devsdk_devicecorecommand_populate(const iot_data_t *map,uint32_t *nc,devsdk_devicecorecommand **dcc)
+{
+  if (map==NULL) return;
+
+  devsdk_devicecorecommand *d=*dcc;
+
+  d->deviceName=iot_data_string_map_get_string(map,"deviceName");
+  d->profileName=iot_data_string_map_get_string(map,"profileName");
+  d->corecommands=NULL;
+  d->next=NULL;
+
+  iot_data_vector_iter_t viter;
+  iot_data_vector_iter(iot_data_string_map_get_vector(map,"coreCommands"),&viter);
+  devsdk_corecommand *newcc=NULL;
+  devsdk_corecommand **ccend=&d->corecommands;
+  while (iot_data_vector_iter_next(&viter))
+  {
+    newcc = malloc(sizeof(devsdk_corecommand));
+    memset(newcc,0,sizeof(devsdk_corecommand));
+    devsdk_corecommand_populate(iot_data_vector_iter_value(&viter),&newcc);
+    *ccend=newcc;
+    ccend=&newcc->next;
+    ++(*nc);
+  }
+}
+
+void devsdk_corecommand_populate(const iot_data_t *map,devsdk_corecommand **cc)
+{
+  if (map==NULL) return;
+
+  devsdk_corecommand *c=*cc;
+
+  c->name=iot_data_string_map_get_string(map,"name");
+  c->get=iot_data_string_map_get_bool(map,"get",false);
+  c->set=iot_data_string_map_get_bool(map,"set",false);
+  c->path=iot_data_string_map_get_string(map,"path");
+  c->url=iot_data_string_map_get_string(map,"url");
+  c->parameters=iot_data_string_map_get_pointer(map,"parameters");
+  c->next=NULL;
+}
+
+void devsdk_corecommand_free(devsdk_corecommand *c)
+{
+  free(c->name);
+  free(c->path);
+  free(c->url);
+  iot_data_free(c->parameters);
+  c->next=NULL;
+}
+
+void devsdk_devicecorecommand_free(devsdk_devicecorecommand *dcc)
+{
+  if (dcc->next) devsdk_devicecorecommand_free(dcc->next);
+  free(dcc->deviceName);
+  free(dcc->profileName);
+  devsdk_corecommand *ccs=dcc->corecommands;
+  devsdk_corecommand *nextcc=NULL;
+  if (ccs)
+  {
+    nextcc=ccs->next;
+    devsdk_corecommand_free(ccs);
+    ccs=nextcc;
+  }
+}
+
+/** internal edgex access functions  **/
+
+void edgex_command_write_command
+(
+  iot_logger_t *lc,
+  edgex_service_endpoints *endpoints,
+  edgex_secret_provider_t *secretprovider,
+  const char *devicename,
+  const char *resourcename,
+  const iot_data_t *cmd,
+  devsdk_error *err
+)
+{
+  edgex_ctx ctx;
+  char url[URL_BUF_SIZE];
+
+  memset (&ctx, 0, sizeof (edgex_ctx));
+  char *json = edgex_command_write (resourcename, cmd);
+
+  snprintf (url, URL_BUF_SIZE - 1, "http://%s:%u/api/" EDGEX_API_VERSION "/device/name/%s/%s", endpoints->command.host, endpoints->command.port, devicename, resourcename);
+
+  iot_data_t *jwt_data = edgex_secrets_request_jwt (secretprovider);
+  ctx.jwt_token = iot_data_string(jwt_data);
+
+  edgex_http_put (lc, &ctx, url, json, edgex_http_write_cb, err);
+
+  iot_data_free(jwt_data);
+  ctx.jwt_token = NULL;
+
+  json_free_serialized_string (json);
+  free (ctx.buff);
+}
+
+iot_data_t *edgex_command_read_command
+(
+  iot_logger_t * lc,
+  edgex_service_endpoints * endpoints,
+  edgex_secret_provider_t * secretprovider,
+  const char * devicename,
+  const char * commandname,
+  bool pusheventflag,
+  bool returneventflag,
+  devsdk_error * err
+)
+{
+  iot_data_t *result=NULL;
+  edgex_ctx ctx;
+  char url[URL_BUF_SIZE];
+
+  memset (&ctx, 0, sizeof (edgex_ctx));
+
+  // this is ugly and needs to be refactored, or added as a function to edgex-rest.h/c
+  const char * querytrue="true\0";
+  const char * queryfalse="false\0";
+  const char * pushevent=queryfalse;
+  const char * returnevent=queryfalse;
+  if (pusheventflag) {
+    pushevent=querytrue;
+  }
+  if (returneventflag){
+    returnevent=querytrue;
+  }
+
+  snprintf (url, URL_BUF_SIZE - 1, "http://%s:%u/api/" EDGEX_API_VERSION "/device/name/%s/%s?ds-pushevent=%s&ds-returnevent=%s",
+            endpoints->command.host, endpoints->command.port, devicename, commandname,pushevent,returnevent);
+
+  iot_data_t *jwt_data = edgex_secrets_request_jwt (secretprovider);
+  ctx.jwt_token = iot_data_string(jwt_data);
+
+  edgex_http_get (lc, &ctx, url, edgex_http_write_cb, err);
+
+  iot_data_free(jwt_data);
+  ctx.jwt_token = NULL;
+
+  if (err->code == 0)
+  {
+    result = iot_data_from_json (ctx.buff);
+  }
+  free (ctx.buff);
+
+  return result;
+}
+
+iot_data_t *edgex_command_get_device_commands
+(
+  iot_logger_t * lc,
+  edgex_service_endpoints * endpoints,
+  edgex_secret_provider_t * secretprovider,
+  const char * devicename,
+  devsdk_error * err
+)
+{
+  iot_data_t *result=NULL;
+  edgex_ctx ctx;
+  char url[URL_BUF_SIZE];
+
+  memset (&ctx, 0, sizeof (edgex_ctx));
+
+  snprintf (url, URL_BUF_SIZE - 1, "http://%s:%u/api/" EDGEX_API_VERSION "/device/name/%s",
+            endpoints->command.host, endpoints->command.port, devicename);
+
+  iot_data_t *jwt_data = edgex_secrets_request_jwt (secretprovider);
+  ctx.jwt_token = iot_data_string(jwt_data);
+
+  edgex_http_get (lc, &ctx, url, edgex_http_write_cb, err);
+
+  iot_data_free(jwt_data);
+  ctx.jwt_token = NULL;
+
+  if (err->code == 0)
+  {
+    result = iot_data_from_json (ctx.buff);
+  }
+  free (ctx.buff);
+
+  return result;
+}
+
+iot_data_t *edgex_command_get_all_commands
+(
+  iot_logger_t * lc,
+  edgex_service_endpoints * endpoints,
+  edgex_secret_provider_t * secretprovider,
+  int offset,
+  int limit,
+  devsdk_error * err
+)
+{
+  iot_data_t *result=NULL;
+  edgex_ctx ctx;
+  char url[URL_BUF_SIZE];
+
+  memset (&ctx, 0, sizeof (edgex_ctx));
+
+  snprintf (url, URL_BUF_SIZE - 1, "http://%s:%u/api/" EDGEX_API_VERSION "/device/all?limit=%d&offset=%d",
+            endpoints->command.host, endpoints->command.port, limit,offset);
+
+  iot_data_t *jwt_data = edgex_secrets_request_jwt (secretprovider);
+  ctx.jwt_token = iot_data_string(jwt_data);
+
+  edgex_http_get (lc, &ctx, url, edgex_http_write_cb, err);
+
+  iot_data_free(jwt_data);
+  ctx.jwt_token = NULL;
+
+  if (err->code == 0)
+  {
+    result = iot_data_from_json (ctx.buff);
+  }
+  free (ctx.buff);
+
+  return result;
+}

--- a/src/c/command.c
+++ b/src/c/command.c
@@ -120,7 +120,6 @@ void devsdk_send_command (devsdk_service_t *svc, const char *devname, const char
     if (result != 0) *err = EDGEX_HTTP_ERROR;
 
     iot_data_free(request);
-    //free(json);
   }
   else
   {
@@ -213,7 +212,6 @@ void devsdk_devicecorecommand_populate(const iot_data_t *map,uint32_t *nc, devsd
   d->deviceName=strdup(iot_data_string_map_get_string(map,"deviceName"));
   d->profileName=strdup(iot_data_string_map_get_string(map,"profileName"));
   d->corecommands=NULL;
-  d->next=NULL;
 
   *nc=0;
   iot_data_vector_iter_t viter;

--- a/src/c/command.c
+++ b/src/c/command.c
@@ -21,11 +21,10 @@
 
 /** devsdk api functions, defined in devsdk.h **/
 
-void devsdk_get_commands(devsdk_service_t *svc, int offset, int limit, uint32_t *ncommands, const devsdk_devicecorecommand **commands, devsdk_error *err)
+void devsdk_get_commands(devsdk_service_t *svc, int offset, int limit, uint32_t *ncommands, devsdk_devicecorecommand **commands, devsdk_error *err)
 {
   *err = EDGEX_OK;
-  devsdk_devicecorecommand *cmds=*commands;
-  iot_data_t *device_commands=NULL;
+
   iot_data_t *response_map=edgex_command_get_all_commands
   (
     svc->logger,
@@ -39,43 +38,38 @@ void devsdk_get_commands(devsdk_service_t *svc, int offset, int limit, uint32_t 
     iot_log_error (svc->logger, "Failed to get commands. Reason: %s",
       err->reason);
       *ncommands=0;
-      memset(cmds,0,sizeof(devsdk_devicecorecommand));
       return;
   }
 
-  device_commands=iot_data_string_map_get_vector(response_map,"deviceCoreCommands");
+  const iot_data_t *device_commands=iot_data_string_map_get_vector(response_map,"deviceCoreCommands");
   if (!device_commands)
   {
     iot_log_error (svc->logger, "Failed to get commands. Can not read 'deviceCoreCommands'");
     *ncommands=0;
-    memset(cmds,0,sizeof(devsdk_devicecorecommand));
     return;
   }
 
   iot_data_vector_iter_t viter;
   iot_data_vector_iter(device_commands,&viter);
-  devsdk_devicecorecommand *newcc=cmds;
-  devsdk_devicecorecommand **ccend=&cmds->next;
   while (iot_data_vector_iter_next(&viter))
   {
-    if (!newcc)
+    devsdk_devicecorecommand_populate(iot_data_vector_iter_value(&viter),ncommands,commands);
+    if (*commands!=NULL)
     {
-      newcc = malloc(sizeof(devsdk_corecommand));
-      memset(cmds,0,sizeof(devsdk_devicecorecommand));
-      *ccend=newcc;
+      commands=&(*commands)->next;
     }
-    devsdk_devicecorecommand_populate(iot_data_vector_iter_value(&viter),ncommands,&newcc);
-    ccend=&newcc->next;
-    newcc=NULL;
+  }
+  if (response_map)
+  {
+    iot_data_free(response_map);
   }
 }
 
-void devsdk_get_commands_by_name(devsdk_service_t *svc, const char *devname, uint32_t *ncommands, const devsdk_devicecorecommand **commands, devsdk_error *err)
+void devsdk_get_commands_by_name(devsdk_service_t *svc, const char *devname, uint32_t *ncommands, devsdk_devicecorecommand **commands, devsdk_error *err)
 {
   *err = EDGEX_OK;
-  devsdk_devicecorecommand *cmdparse=*commands;
-  iot_data_t *device_commands=NULL;
-  iot_data_t *map=edgex_command_get_device_commands
+  const iot_data_t *device_commands=NULL;
+  iot_data_t *response_map=edgex_command_get_device_commands
   (
     svc->logger,
     &svc->config.endpoints,
@@ -88,19 +82,21 @@ void devsdk_get_commands_by_name(devsdk_service_t *svc, const char *devname, uin
       devname,
       err->reason);
       *ncommands=0;
-      cmdparse=NULL;
+      *commands=NULL;
       return;
   }
 
-  device_commands=iot_data_string_map_get_map(map,"deviceCoreCommand");
+  device_commands=iot_data_string_map_get_map(response_map,"deviceCoreCommand");
   if (!device_commands)
   {
     iot_log_error (svc->logger, "Failed to get commands for device %s. Reason: core-command invalid map",devname);
     *ncommands=0;
-    memset(cmdparse,0,sizeof(devsdk_devicecorecommand));
     return;
   }
-  devsdk_devicecorecommand_populate(device_commands,ncommands,&cmdparse);
+  devsdk_devicecorecommand_populate(device_commands,ncommands,commands);
+  if (response_map){
+    iot_data_free(response_map);
+  }
 }
 
 void devsdk_send_command (devsdk_service_t *svc, const char *devname, const char *resname, const iot_data_t *cmd, devsdk_error *err)
@@ -156,7 +152,7 @@ void devsdk_read_command (
   bool pushevent,
   bool returnevent,
   uint32_t **nreadings,
-  const devsdk_commandresult **readings,
+  devsdk_commandresult **readings,
   devsdk_error *err
 )
 {
@@ -184,29 +180,43 @@ void devsdk_read_command (
       devname,
       cmdname,
       err->reason);
-      *nreadings=0;
-      cmdreadings=NULL;
-      return;
+
+    if (readcommanddata) {
+      free(readcommanddata);
+    }
+    *nreadings=0;
+    cmdreadings=NULL;
+    return;
   }
 
-  iot_data_t *responseEventMap=iot_data_string_map_get_map(readcommanddata,"event");
+  const iot_data_t *responseEventMap=iot_data_string_map_get_map(readcommanddata,"event");
   cmdreadings->origin=iot_data_string_map_get_ui64(responseEventMap,"origin",0u);
-  cmdreadings->value=iot_data_string_map_get_vector(responseEventMap,"readings");
+  cmdreadings->value=iot_data_copy(iot_data_string_map_get_vector(responseEventMap,"readings"));
   *resulttotal=0;
   if (cmdreadings->value!=NULL)
   {
       *resulttotal=iot_data_vector_size(cmdreadings->value);
   }
+  if (readcommanddata) {
+    iot_data_free(readcommanddata);
+  }
 }
 
-void devsdk_devicecorecommand_populate(const iot_data_t *map,uint32_t *nc,devsdk_devicecorecommand **dcc)
+void devsdk_devicecorecommand_populate(const iot_data_t *map,uint32_t *nc, devsdk_devicecorecommand **dcc)
 {
   if (map==NULL) return;
 
+  *dcc=malloc(sizeof(devsdk_devicecorecommand));
+  memset(*dcc,0,sizeof(devsdk_devicecorecommand));
+
   devsdk_devicecorecommand *d=*dcc;
 
-  d->deviceName=iot_data_string_map_get_string(map,"deviceName");
-  d->profileName=iot_data_string_map_get_string(map,"profileName");
+  d->deviceName=malloc(strlen(iot_data_string_map_get_string(map,"deviceName"))+1);
+  strncpy(d->deviceName,iot_data_string_map_get_string(map,"deviceName"),strlen(iot_data_string_map_get_string(map,"deviceName"))+1);
+
+  d->profileName=malloc(strlen(iot_data_string_map_get_string(map,"profileName"))+1);
+  strncpy(d->profileName,iot_data_string_map_get_string(map,"profileName"),strlen(iot_data_string_map_get_string(map,"profileName"))+1);
+
   d->corecommands=NULL;
   d->next=NULL;
 
@@ -216,8 +226,6 @@ void devsdk_devicecorecommand_populate(const iot_data_t *map,uint32_t *nc,devsdk
   devsdk_corecommand **ccend=&d->corecommands;
   while (iot_data_vector_iter_next(&viter))
   {
-    newcc = malloc(sizeof(devsdk_corecommand));
-    memset(newcc,0,sizeof(devsdk_corecommand));
     devsdk_corecommand_populate(iot_data_vector_iter_value(&viter),&newcc);
     *ccend=newcc;
     ccend=&newcc->next;
@@ -229,14 +237,24 @@ void devsdk_corecommand_populate(const iot_data_t *map,devsdk_corecommand **cc)
 {
   if (map==NULL) return;
 
+  *cc=malloc(sizeof(devsdk_corecommand));
+  memset(*cc,0,sizeof(devsdk_corecommand));
+
   devsdk_corecommand *c=*cc;
 
-  c->name=iot_data_string_map_get_string(map,"name");
+  c->name=malloc(strlen(iot_data_string_map_get_string(map,"name"))+1);
+  strncpy(c->name,iot_data_string_map_get_string(map,"name"),strlen(iot_data_string_map_get_string(map,"name"))+1);
+
   c->get=iot_data_string_map_get_bool(map,"get",false);
   c->set=iot_data_string_map_get_bool(map,"set",false);
-  c->path=iot_data_string_map_get_string(map,"path");
-  c->url=iot_data_string_map_get_string(map,"url");
-  c->parameters=iot_data_string_map_get_pointer(map,"parameters");
+
+  c->path=malloc(strlen(iot_data_string_map_get_string(map,"path"))+1);
+  strncpy(c->path,iot_data_string_map_get_string(map,"path"),strlen(iot_data_string_map_get_string(map,"path"))+1);
+
+  c->url=malloc(strlen(iot_data_string_map_get_string(map,"url"))+1);
+  strncpy(c->url,iot_data_string_map_get_string(map,"url"),strlen(iot_data_string_map_get_string(map,"url"))+1);
+
+  c->parameters=iot_data_copy(iot_data_string_map_get_pointer(map,"parameters"));
   c->next=NULL;
 }
 
@@ -247,21 +265,26 @@ void devsdk_corecommand_free(devsdk_corecommand *c)
   free(c->url);
   iot_data_free(c->parameters);
   c->next=NULL;
+  free(c);
 }
 
 void devsdk_devicecorecommand_free(devsdk_devicecorecommand *dcc)
 {
-  if (dcc->next) devsdk_devicecorecommand_free(dcc->next);
+  if (dcc->next)
+  {
+    devsdk_devicecorecommand_free(dcc->next);
+  }
   free(dcc->deviceName);
   free(dcc->profileName);
   devsdk_corecommand *ccs=dcc->corecommands;
   devsdk_corecommand *nextcc=NULL;
-  if (ccs)
+  while (ccs)
   {
     nextcc=ccs->next;
     devsdk_corecommand_free(ccs);
     ccs=nextcc;
   }
+  free(dcc);
 }
 
 /** internal edgex access functions  **/

--- a/src/c/command.c
+++ b/src/c/command.c
@@ -19,9 +19,10 @@
 
 #include "edgex/devices.h"
 
-/** devsdk api functions, defined in devsdk.h **/
+#define BOOL_FMT(x) ((x) ? "true" : "false")
 
-void devsdk_get_commands(devsdk_service_t *svc, int offset, int limit, uint32_t *ncommands, devsdk_devicecorecommand **commands, devsdk_error *err)
+/** devsdk api functions, defined in devsdk.h **/
+void devsdk_get_commands(devsdk_service_t *svc, int offset, int limit, uint32_t *ncommands, iot_data_t **commands, devsdk_error *err)
 {
   *err = EDGEX_OK;
 
@@ -37,37 +38,41 @@ void devsdk_get_commands(devsdk_service_t *svc, int offset, int limit, uint32_t 
   if (err->code){
     iot_log_error (svc->logger, "Failed to get commands. Reason: %s",
       err->reason);
-      *ncommands=0;
+      *commands=NULL;
       return;
   }
 
-  const iot_data_t *device_commands=iot_data_string_map_get_vector(response_map,"deviceCoreCommands");
-  if (!device_commands)
+  const iot_data_t *src_dev_commands=iot_data_string_map_get_vector(response_map,"deviceCoreCommands");
+  if (!src_dev_commands)
   {
     iot_log_error (svc->logger, "Failed to get commands. Can not read 'deviceCoreCommands'");
-    *ncommands=0;
+    *commands=NULL;
     return;
   }
 
+  uint32_t ncc=0,i=0;
+  *commands=iot_data_alloc_vector(iot_data_vector_size(src_dev_commands));
+  iot_data_t *devcommand_vector=*commands;
+  devsdk_devicecorecommand *newdcc=NULL;
   iot_data_vector_iter_t viter;
-  iot_data_vector_iter(device_commands,&viter);
+  iot_data_vector_iter(src_dev_commands,&viter);
   while (iot_data_vector_iter_next(&viter))
   {
-    devsdk_devicecorecommand_populate(iot_data_vector_iter_value(&viter),ncommands,commands);
-    if (*commands!=NULL)
-    {
-      commands=&(*commands)->next;
-    }
+    ncc=0;
+    devsdk_devicecorecommand_populate(iot_data_vector_iter_value(&viter),&ncc,&newdcc);
+    iot_data_t *dccptr=iot_data_alloc_pointer(newdcc,devsdk_devicecorecommand_free);
+    iot_data_vector_add(devcommand_vector,i,dccptr);
+    (*ncommands)+=ncc;
+    ++i;
   }
-  if (response_map)
-  {
-    iot_data_free(response_map);
-  }
+  iot_data_free(response_map);
 }
 
 void devsdk_get_commands_by_name(devsdk_service_t *svc, const char *devname, uint32_t *ncommands, devsdk_devicecorecommand **commands, devsdk_error *err)
 {
   *err = EDGEX_OK;
+  *ncommands=0;
+
   const iot_data_t *device_commands=NULL;
   iot_data_t *response_map=edgex_command_get_device_commands
   (
@@ -81,7 +86,6 @@ void devsdk_get_commands_by_name(devsdk_service_t *svc, const char *devname, uin
     iot_log_error (svc->logger, "Failed to get commands for device %s. Reason: %s",
       devname,
       err->reason);
-      *ncommands=0;
       *commands=NULL;
       return;
   }
@@ -90,13 +94,10 @@ void devsdk_get_commands_by_name(devsdk_service_t *svc, const char *devname, uin
   if (!device_commands)
   {
     iot_log_error (svc->logger, "Failed to get commands for device %s. Reason: core-command invalid map",devname);
-    *ncommands=0;
     return;
   }
   devsdk_devicecorecommand_populate(device_commands,ncommands,commands);
-  if (response_map){
-    iot_data_free(response_map);
-  }
+  iot_data_free(response_map);
 }
 
 void devsdk_send_command (devsdk_service_t *svc, const char *devname, const char *resname, const iot_data_t *cmd, devsdk_error *err)
@@ -111,8 +112,7 @@ void devsdk_send_command (devsdk_service_t *svc, const char *devname, const char
     iot_data_t* value;
 
     request = iot_data_alloc_map (IOT_DATA_STRING);
-    char* json = iot_data_to_json(cmd);
-    value = (iot_data_type(cmd) == IOT_DATA_STRING) ? iot_data_copy(cmd) : iot_data_alloc_string(json, IOT_DATA_REF);
+    value = (iot_data_type(cmd) == IOT_DATA_STRING) ? iot_data_add_ref (cmd) : iot_data_alloc_string (iot_data_to_json (cmd), IOT_DATA_TAKE);
 
     iot_data_string_map_add(request, resname, value);
 
@@ -120,7 +120,7 @@ void devsdk_send_command (devsdk_service_t *svc, const char *devname, const char
     if (result != 0) *err = EDGEX_HTTP_ERROR;
 
     iot_data_free(request);
-    free(json);
+    //free(json);
   }
   else
   {
@@ -206,29 +206,29 @@ void devsdk_devicecorecommand_populate(const iot_data_t *map,uint32_t *nc, devsd
 {
   if (map==NULL) return;
 
-  *dcc=malloc(sizeof(devsdk_devicecorecommand));
-  memset(*dcc,0,sizeof(devsdk_devicecorecommand));
+  *dcc=calloc(1,sizeof(devsdk_devicecorecommand));
 
   devsdk_devicecorecommand *d=*dcc;
 
-  d->deviceName=malloc(strlen(iot_data_string_map_get_string(map,"deviceName"))+1);
-  strncpy(d->deviceName,iot_data_string_map_get_string(map,"deviceName"),strlen(iot_data_string_map_get_string(map,"deviceName"))+1);
-
-  d->profileName=malloc(strlen(iot_data_string_map_get_string(map,"profileName"))+1);
-  strncpy(d->profileName,iot_data_string_map_get_string(map,"profileName"),strlen(iot_data_string_map_get_string(map,"profileName"))+1);
-
+  d->deviceName=strdup(iot_data_string_map_get_string(map,"deviceName"));
+  d->profileName=strdup(iot_data_string_map_get_string(map,"profileName"));
   d->corecommands=NULL;
   d->next=NULL;
 
+  *nc=0;
   iot_data_vector_iter_t viter;
-  iot_data_vector_iter(iot_data_string_map_get_vector(map,"coreCommands"),&viter);
+  iot_data_t* cc_src_vector=iot_data_string_map_get_vector(map,"coreCommands");
+  iot_data_vector_iter(cc_src_vector,&viter);
+  // alloc an iot_data_vector at vector or list
+  d->corecommands=iot_data_alloc_vector(iot_data_vector_size(cc_src_vector));
   devsdk_corecommand *newcc=NULL;
-  devsdk_corecommand **ccend=&d->corecommands;
   while (iot_data_vector_iter_next(&viter))
   {
     devsdk_corecommand_populate(iot_data_vector_iter_value(&viter),&newcc);
-    *ccend=newcc;
-    ccend=&newcc->next;
+    // turn into an iot_data_pointer
+    iot_data_t *newcc_ptr=iot_data_alloc_pointer (newcc, devsdk_corecommand_free);
+    // add to the vector
+    iot_data_vector_add(d->corecommands,*nc,newcc_ptr);
     ++(*nc);
   }
 }
@@ -237,53 +237,34 @@ void devsdk_corecommand_populate(const iot_data_t *map,devsdk_corecommand **cc)
 {
   if (map==NULL) return;
 
-  *cc=malloc(sizeof(devsdk_corecommand));
-  memset(*cc,0,sizeof(devsdk_corecommand));
+  *cc=calloc(1,sizeof(devsdk_corecommand));
 
   devsdk_corecommand *c=*cc;
 
-  c->name=malloc(strlen(iot_data_string_map_get_string(map,"name"))+1);
-  strncpy(c->name,iot_data_string_map_get_string(map,"name"),strlen(iot_data_string_map_get_string(map,"name"))+1);
-
+  c->name=strdup(iot_data_string_map_get_string(map,"name"));
   c->get=iot_data_string_map_get_bool(map,"get",false);
   c->set=iot_data_string_map_get_bool(map,"set",false);
-
-  c->path=malloc(strlen(iot_data_string_map_get_string(map,"path"))+1);
-  strncpy(c->path,iot_data_string_map_get_string(map,"path"),strlen(iot_data_string_map_get_string(map,"path"))+1);
-
-  c->url=malloc(strlen(iot_data_string_map_get_string(map,"url"))+1);
-  strncpy(c->url,iot_data_string_map_get_string(map,"url"),strlen(iot_data_string_map_get_string(map,"url"))+1);
-
+  c->path=strdup(iot_data_string_map_get_string(map,"path"));
+  c->url=strdup(iot_data_string_map_get_string(map,"url"));
   c->parameters=iot_data_copy(iot_data_string_map_get_pointer(map,"parameters"));
-  c->next=NULL;
 }
 
-void devsdk_corecommand_free(devsdk_corecommand *c)
+void devsdk_corecommand_free(void *v)
 {
+  devsdk_corecommand *c=(devsdk_corecommand *)v;
   free(c->name);
   free(c->path);
   free(c->url);
   iot_data_free(c->parameters);
-  c->next=NULL;
   free(c);
 }
 
-void devsdk_devicecorecommand_free(devsdk_devicecorecommand *dcc)
+void devsdk_devicecorecommand_free(void *v)
 {
-  if (dcc->next)
-  {
-    devsdk_devicecorecommand_free(dcc->next);
-  }
+  devsdk_devicecorecommand *dcc=(devsdk_devicecorecommand *)v;
   free(dcc->deviceName);
   free(dcc->profileName);
-  devsdk_corecommand *ccs=dcc->corecommands;
-  devsdk_corecommand *nextcc=NULL;
-  while (ccs)
-  {
-    nextcc=ccs->next;
-    devsdk_corecommand_free(ccs);
-    ccs=nextcc;
-  }
+  iot_data_free(dcc->corecommands);
   free(dcc);
 }
 
@@ -338,20 +319,8 @@ iot_data_t *edgex_command_read_command
 
   memset (&ctx, 0, sizeof (edgex_ctx));
 
-  // this is ugly and needs to be refactored, or added as a function to edgex-rest.h/c
-  const char * querytrue="true\0";
-  const char * queryfalse="false\0";
-  const char * pushevent=queryfalse;
-  const char * returnevent=queryfalse;
-  if (pusheventflag) {
-    pushevent=querytrue;
-  }
-  if (returneventflag){
-    returnevent=querytrue;
-  }
-
   snprintf (url, URL_BUF_SIZE - 1, "http://%s:%u/api/" EDGEX_API_VERSION "/device/name/%s/%s?ds-pushevent=%s&ds-returnevent=%s",
-            endpoints->command.host, endpoints->command.port, devicename, commandname,pushevent,returnevent);
+            endpoints->command.host, endpoints->command.port, devicename, commandname,BOOL_FMT(pusheventflag),BOOL_FMT(returneventflag));
 
   iot_data_t *jwt_data = edgex_secrets_request_jwt (secretprovider);
   ctx.jwt_token = iot_data_string(jwt_data);

--- a/src/c/command.h
+++ b/src/c/command.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024
+ * Eaton Corp.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#ifndef _EDGEX_COMMAND_H_
+#define _EDGEX_COMMAND_H_ 1
+
+#include "device.h"
+#include "devsdk/devsdk.h"
+#include "devsdk/devsdk-base.h"
+#include "iot/logger.h"
+#include "devmap.h"
+#include "parson.h"
+#include "secrets.h"
+
+typedef struct edgex_service_endpoints edgex_service_endpoints;
+
+void devsdk_devicecorecommand_populate(const iot_data_t *map,uint32_t *nc,devsdk_devicecorecommand **dcc);
+
+void devsdk_corecommand_populate(const iot_data_t *map,devsdk_corecommand **cc);
+
+void edgex_command_write_command
+(
+  iot_logger_t * lc,
+  edgex_service_endpoints * endpoints,
+  edgex_secret_provider_t * secretprovider,
+  const char * devicename,
+  const char * resourcename,
+  const iot_data_t * cmd,
+  devsdk_error * err
+);
+
+iot_data_t *edgex_command_read_command
+(
+  iot_logger_t * lc,
+  edgex_service_endpoints * endpoints,
+  edgex_secret_provider_t * secretprovider,
+  const char * devicename,
+  const char * commandname,
+  bool pushevent,
+  bool returnevent,
+  devsdk_error * err
+);
+
+iot_data_t *edgex_command_get_device_commands
+(
+  iot_logger_t * lc,
+  edgex_service_endpoints * endpoints,
+  edgex_secret_provider_t * secretprovider,
+  const char * devicename,
+  devsdk_error * err
+);
+
+iot_data_t *edgex_command_get_all_commands
+(
+  iot_logger_t * lc,
+  edgex_service_endpoints * endpoints,
+  edgex_secret_provider_t * secretprovider,
+  int offset,
+  int limit,
+  devsdk_error * err
+);
+
+#endif

--- a/src/c/command.h
+++ b/src/c/command.h
@@ -23,6 +23,10 @@ void devsdk_devicecorecommand_populate(const iot_data_t *map,uint32_t *nc,devsdk
 
 void devsdk_corecommand_populate(const iot_data_t *map,devsdk_corecommand **cc);
 
+void devsdk_corecommand_free(devsdk_corecommand *c);
+
+void devsdk_devicecorecommand_free(devsdk_devicecorecommand *dcc);
+
 void edgex_command_write_command
 (
   iot_logger_t * lc,

--- a/src/c/command.h
+++ b/src/c/command.h
@@ -23,9 +23,9 @@ void devsdk_devicecorecommand_populate(const iot_data_t *map,uint32_t *nc,devsdk
 
 void devsdk_corecommand_populate(const iot_data_t *map,devsdk_corecommand **cc);
 
-void devsdk_corecommand_free(devsdk_corecommand *c);
+void devsdk_corecommand_free(void *v);
 
-void devsdk_devicecorecommand_free(devsdk_devicecorecommand *dcc);
+void devsdk_devicecorecommand_free(void *dcc);
 
 void edgex_command_write_command
 (

--- a/src/c/config.c
+++ b/src/c/config.c
@@ -278,8 +278,10 @@ void edgex_device_parseClients (iot_logger_t *lc, const iot_data_t *clients, edg
   if (clients)
   {
     parseClient (iot_data_string_map_get (clients, "core-metadata"), &endpoints->metadata);
+    parseClient (iot_data_string_map_get (clients, "core-command"), &endpoints->command);
   }
   checkClientOverride (lc, "CORE_METADATA", &endpoints->metadata);
+  checkClientOverride (lc, "CORE_COMMAND", &endpoints->command);
 }
 
 static void addInsecureSecretsMap (iot_data_t *confmap, const iot_data_t *config)
@@ -694,6 +696,7 @@ void edgex_device_freeConfig (devsdk_service_t *svc)
   }
 
   free (svc->config.endpoints.metadata.host);
+  free (svc->config.endpoints.command.host);
 
   iot_data_free (svc->config.sdkconf);
   iot_data_free (svc->config.driverconf);
@@ -769,6 +772,12 @@ static JSON_Value *edgex_device_config_toJson (devsdk_service_t *svc)
   json_object_set_string (mobj, "Host", svc->config.endpoints.metadata.host);
   json_object_set_uint (mobj, "Port", svc->config.endpoints.metadata.port);
   json_object_set_value (cobj, "Metadata", mval);
+
+  JSON_Value *cmdval = json_value_init_object ();
+  JSON_Object *cmdmobj = json_value_get_object (cmdval);
+  json_object_set_string (cmdmobj, "Host", svc->config.endpoints.command.host);
+  json_object_set_uint (cmdmobj, "Port", svc->config.endpoints.command.port);
+  json_object_set_value (cobj, "Command", cmdval);
 
   json_object_set_value (obj, "Clients", cval);
 

--- a/src/c/config.h
+++ b/src/c/config.h
@@ -41,6 +41,7 @@ typedef struct edgex_device_service_endpoint
 typedef struct edgex_service_endpoints
 {
   edgex_device_service_endpoint metadata;
+  edgex_device_service_endpoint command;
 } edgex_service_endpoints;
 
 typedef struct edgex_device_metricinfo

--- a/src/c/device.c
+++ b/src/c/device.c
@@ -762,7 +762,7 @@ static edgex_event_cooked *edgex_device_runget3 (devsdk_service_t *svc, edgex_de
   return result;
 }
 
-static int32_t edgex_device_v3impl (devsdk_service_t *svc, edgex_device *dev, const char *cmdname, bool isGet, const iot_data_t *req, const iot_data_t *params, iot_data_t **reply, bool *event_is_cbor)
+extern int32_t edgex_device_v3impl (devsdk_service_t *svc, edgex_device *dev, const char *cmdname, bool isGet, const iot_data_t *req, const iot_data_t *params, iot_data_t **reply, bool *event_is_cbor)
 {
   int32_t result = 0;
   const edgex_cmdinfo *cmd = edgex_deviceprofile_findcommand (svc, cmdname, dev->profile, isGet);

--- a/src/c/device.h
+++ b/src/c/device.h
@@ -17,6 +17,7 @@
 extern void edgex_device_handler_device_namev2 (void *ctx, const devsdk_http_request *req, devsdk_http_reply *reply);
 
 extern int32_t edgex_device_handler_devicev3 (void *ctx, const iot_data_t *req, const iot_data_t *pathparams, const iot_data_t *params, iot_data_t **reply, bool *event_is_cbor);
+extern int32_t edgex_device_v3impl (devsdk_service_t *svc, edgex_device *dev, const char *cmdname, bool isGet, const iot_data_t *req, const iot_data_t *params, iot_data_t **reply, bool *event_is_cbor);
 
 extern const struct edgex_cmdinfo *edgex_deviceprofile_findcommand
   (devsdk_service_t *svc, const char *name, edgex_deviceprofile *prof, bool forGet);

--- a/src/c/edgex-rest.c
+++ b/src/c/edgex-rest.c
@@ -912,6 +912,21 @@ char *edgex_updateDevLCreq_write (const char *name, uint64_t lastconnected)
   return json;
 }
 
+char *edgex_command_write (const char *resourcename, const iot_data_t *value)
+{
+  char *data;
+  char *json;
+  JSON_Value *val = json_value_init_object ();
+  JSON_Object *obj = json_value_get_object (val);
+
+  data = iot_data_to_json(value);
+  json_object_set_string (obj, resourcename, data);
+  json = json_serialize_to_string (val);
+  json_value_free (val);
+  free (data);
+
+  return json;
+}
 
 edgex_device *edgex_devices_read (iot_logger_t *lc, const char *json)
 {

--- a/src/c/edgex-rest.h
+++ b/src/c/edgex-rest.h
@@ -64,5 +64,6 @@ char *edgex_createdevicereq_write (const edgex_device *dev);
 char *edgex_updateDevOpreq_write (const char *name, edgex_device_operatingstate opstate);
 char *edgex_updateDevLCreq_write (const char *name, uint64_t lastconnected);
 
+char *edgex_command_write (const char *resourcename, const iot_data_t *value);
 
 #endif

--- a/src/c/service.c
+++ b/src/c/service.c
@@ -763,7 +763,14 @@ static void startConfigured (devsdk_service_t *svc, const devsdk_timeout *deadli
     return;
   }
 
-  *err = EDGEX_OK;
+  /* Wait for core-command to be available */
+
+  if (!ping_client (svc->logger, "core-command", &svc->config.endpoints.command, deadline, err))
+  {
+    return;
+  }
+
+ *err = EDGEX_OK;
 
   /* Register device service in metadata */
 
@@ -1177,7 +1184,7 @@ void devsdk_service_start (devsdk_service_t *svc, iot_data_t *driverdfls, devsdk
 
     if (svc->overwriteconfig)
     {
-      iot_log_info (svc->logger, "--overwrite option is set. Not geting configuration from registry.");
+      iot_log_info (svc->logger, "--overwrite option is set. Not getting configuration from registry.");
       uploadConfig = true;
     }
     else
@@ -1295,6 +1302,16 @@ void devsdk_service_start (devsdk_service_t *svc, iot_data_t *driverdfls, devsdk
       *svc->stopconfig = true;
       return;
     }
+    devsdk_registry_query_service (svc->registry, "core-command", &svc->config.endpoints.command.host, &svc->config.endpoints.command.port, &deadline, err);
+    if (err->code)
+    {
+      iot_data_free (config_file);
+      *svc->stopconfig = true;
+      return;
+    } else
+    {
+      iot_log_debug(svc->logger, "populated core-command client from registry");
+    }
   }
   else if(svc->registry && svc->remote_mode)
   {
@@ -1338,6 +1355,9 @@ void devsdk_service_start (devsdk_service_t *svc, iot_data_t *driverdfls, devsdk
   iot_log_info (svc->logger, "EdgeX device SDK for C, version " CSDK_VERSION_STR);
   iot_log_debug (svc->logger, "Service configuration follows:");
   edgex_device_dumpConfig (svc->logger, configmap);
+  iot_log_debug (svc->logger, "Service configured clients follow:");
+  iot_log_debug (svc->logger, "  metadata: %s:%d",svc->config.endpoints.metadata.host, svc->config.endpoints.metadata.port);
+  iot_log_debug (svc->logger, "   command: %s:%d",svc->config.endpoints.command.host, svc->config.endpoints.command.port);
 
   startConfigured (svc, &deadline, err);
 


### PR DESCRIPTION
Feature proposal [#441](https://github.com/edgexfoundry/device-sdk-c/issues/441)

### Add device-sdk-c API calls that mimic the device-sdk-go method to access EdgeX core command services from a device service. 

The new endpoints are ( located in devsdk.h ):

- `void devsdk_get_commands(devsdk_service_t *svc, int offset, int limit, uint32_t *ncommands, devsdk_devicecorecommand **commands, devsdk_error *err)`

- `void devsdk_get_commands_by_name(devsdk_service_t *svc, const char *devname, uint32_t *ncommands, devsdk_devicecorecommand **commands, devsdk_error *err)`

- `void devsdk_send_command (devsdk_service_t *svc, const char *devname, const char *resname, const iot_data_t *value, devsdk_error *err)`

- `void devsdk_read_command(devsdk_service_t *svc, const char *devname, const char *cmdname, bool pushevent, bool returnevent, uint32_t **nreadings, devsdk_commandresult **readings, devsdk_error *err)`

As an alternative to populating a double-pointer parameter with the results, these API endpoints could also be made to directly return a newly allocated pointer to the data structures described below.

The API functions and Internal support functions are contained in a new file `command.h/c`

### Add API data structures based on the JSON REST output to hold EdgeX Core Command client requests and responses, as well as a convenience function to free the data structures.

New data structures, populated by calls to the above API endpoints ( located in devsdk-base.h )

- devsdk_corecommand
- devsdk_devicecorecommand

Convenience function to free the data structures:

- `void devsdk_devicecorecommand_free(devsdk_devicecorecommand *)`


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)

On request, better docstrings and external documentation will be added.

## Testing Instructions

There is a current Work-in-progress core-command client example in this branch [EF-441_Provide-Core-Command-client-test-WIP](https://github.com/TysonBoer-eaton/device-sdk-c/tree/90159672fa292d13b08c4a79b63da7942fbd2b53/src/c/examples/commandclient). On request this example can be cleaned up and added to this PR.
