### PR TITLE
feat: EF572 support reading units mechanism

### DIFF
--- a/src/c/autoevent.c
+++ b/src/c/autoevent.c
@@ -131,7 +131,7 @@ static void *ae_runner (void *p)
             resdup = devsdk_commandresult_dup (results, ai->resource->nreqs);
           }
           edgex_event_cooked *event =
-            edgex_data_process_event (dev, ai->resource, results, tags, ai->svc->config.device.datatransform, ai->svc->reduced_events, iot_data_string_map_get_bool(ai->svc->config.sdkconf, "Writable/Reading/ReadingUnits", false));
+            edgex_data_process_event (dev, ai->resource, results, tags, ai->svc->config.device.datatransform, ai->svc->reduced_events, ai->svc->config.device.reading_units);
           if (event)
           {
             if (ai->svc->config.device.maxeventsize && edgex_event_cooked_size (event) > ai->svc->config.device.maxeventsize * 1024)

--- a/src/c/autoevent.c
+++ b/src/c/autoevent.c
@@ -131,7 +131,7 @@ static void *ae_runner (void *p)
             resdup = devsdk_commandresult_dup (results, ai->resource->nreqs);
           }
           edgex_event_cooked *event =
-            edgex_data_process_event (dev, ai->resource, results, tags, ai->svc->config.device.datatransform, ai->svc->reduced_events);
+            edgex_data_process_event (dev, ai->resource, results, tags, ai->svc->config.device.datatransform, ai->svc->reduced_events, ai->svc);
           if (event)
           {
             if (ai->svc->config.device.maxeventsize && edgex_event_cooked_size (event) > ai->svc->config.device.maxeventsize * 1024)

--- a/src/c/autoevent.c
+++ b/src/c/autoevent.c
@@ -131,7 +131,7 @@ static void *ae_runner (void *p)
             resdup = devsdk_commandresult_dup (results, ai->resource->nreqs);
           }
           edgex_event_cooked *event =
-            edgex_data_process_event (dev, ai->resource, results, tags, ai->svc->config.device.datatransform, ai->svc->reduced_events, ai->svc);
+            edgex_data_process_event (dev, ai->resource, results, tags, ai->svc->config.device.datatransform, ai->svc->reduced_events, iot_data_string_map_get_bool(ai->svc->config.sdkconf, "Writable/Reading/ReadingUnits", false));
           if (event)
           {
             if (ai->svc->config.device.maxeventsize && edgex_event_cooked_size (event) > ai->svc->config.device.maxeventsize * 1024)

--- a/src/c/config.c
+++ b/src/c/config.c
@@ -61,7 +61,7 @@ iot_data_t *edgex_common_config_defaults (const char *svcname)
   iot_data_string_map_add (result, "Device/Discovery/Enabled", iot_data_alloc_bool (true));
   iot_data_string_map_add (result, "Device/Discovery/Interval", iot_data_alloc_ui32 (0));
   iot_data_string_map_add (result, "Device/MaxCmdOps", iot_data_alloc_ui32 (0));
-  
+
   iot_data_string_map_add (result, DYN_PREFIX "Reading/ReadingUnits", iot_data_alloc_bool (false));
 
   iot_data_string_map_add (result, DYN_PREFIX "Telemetry/Interval", iot_data_alloc_string ("30s", IOT_DATA_REF));

--- a/src/c/config.c
+++ b/src/c/config.c
@@ -518,6 +518,7 @@ static void edgex_device_populateCommonConfigFromMap (edgex_device_config *confi
   config->device.provisionwatchersdir = iot_data_string_map_get_string (map, "Device/ProvisionWatchersDir");
   config->device.allowed_fails = iot_data_ui32 (iot_data_string_map_get (map, "Device/AllowedFails"));
   config->device.dev_downtime = iot_data_ui64 (iot_data_string_map_get (map, "Device/DeviceDownTimeout"));
+  config->device.reading_units = iot_data_bool (iot_data_string_map_get (map, DYN_PREFIX "Reading/ReadingUnits"));
 
   config->metrics.interval = iot_data_string_map_get_string (map, DYN_PREFIX "Telemetry/Interval");
   config->metrics.flags = iot_data_bool (iot_data_string_map_get (map, DYN_PREFIX "Telemetry/Metrics/EventsSent")) ? EX_METRIC_EVSENT : 0;

--- a/src/c/config.c
+++ b/src/c/config.c
@@ -61,6 +61,8 @@ iot_data_t *edgex_common_config_defaults (const char *svcname)
   iot_data_string_map_add (result, "Device/Discovery/Enabled", iot_data_alloc_bool (true));
   iot_data_string_map_add (result, "Device/Discovery/Interval", iot_data_alloc_ui32 (0));
   iot_data_string_map_add (result, "Device/MaxCmdOps", iot_data_alloc_ui32 (0));
+  //adding reading Units here
+  iot_data_string_map_add (result, DYN_PREFIX "Reading/ReadingUnits", iot_data_alloc_bool (false));
 
   iot_data_string_map_add (result, DYN_PREFIX "Telemetry/Interval", iot_data_alloc_string ("30s", IOT_DATA_REF));
   iot_data_string_map_add (result, DYN_PREFIX "Telemetry/Metrics/EventsSent", iot_data_alloc_bool (false));

--- a/src/c/config.c
+++ b/src/c/config.c
@@ -61,7 +61,7 @@ iot_data_t *edgex_common_config_defaults (const char *svcname)
   iot_data_string_map_add (result, "Device/Discovery/Enabled", iot_data_alloc_bool (true));
   iot_data_string_map_add (result, "Device/Discovery/Interval", iot_data_alloc_ui32 (0));
   iot_data_string_map_add (result, "Device/MaxCmdOps", iot_data_alloc_ui32 (0));
-  //adding reading Units here
+  
   iot_data_string_map_add (result, DYN_PREFIX "Reading/ReadingUnits", iot_data_alloc_bool (false));
 
   iot_data_string_map_add (result, DYN_PREFIX "Telemetry/Interval", iot_data_alloc_string ("30s", IOT_DATA_REF));

--- a/src/c/config.c
+++ b/src/c/config.c
@@ -620,8 +620,14 @@ void edgex_device_updateConf (void *p, const devsdk_nvpairs *config)
 
   iot_log_info (svc->logger, "Reconfiguring");
 
+  if (devsdk_nvpairs_value (config, DYN_PREFIX "Reading/ReadingUnits") == NULL)
+  {
+    iot_data_string_map_add (svc->config.sdkconf, DYN_PREFIX "Reading/ReadingUnits", iot_data_alloc_bool (false));
+  }
+
   edgex_device_overrideConfig_nvpairs (svc->config.sdkconf, config);
   edgex_device_populateConfigFromMap (&svc->config, svc->config.sdkconf);
+  svc->config.device.reading_units = iot_data_bool (iot_data_string_map_get (svc->config.sdkconf, DYN_PREFIX "Reading/ReadingUnits"));
 
   const char *lname = devsdk_nvpairs_value (config, DYN_PREFIX "LogLevel");
   if (lname)
@@ -750,6 +756,11 @@ static JSON_Value *edgex_device_config_toJson (devsdk_service_t *svc)
   json_object_set_uint (dobj, "EventQLength", svc->config.device.eventqlen);
   json_object_set_uint (dobj, "AllowedFails", svc->config.device.allowed_fails);
   json_object_set_uint (dobj, "DeviceDownTimeout", svc->config.device.dev_downtime);
+
+  JSON_Value *rval = json_value_init_object ();
+  JSON_Object *robj = json_value_get_object (rval);
+  json_object_set_boolean (robj, "ReadingUnits", svc->config.device.reading_units);
+  json_object_set_value (wobj, "Reading", rval);
 
   JSON_Value *lval = json_value_init_array ();
   JSON_Array *larr = json_value_get_array (lval);

--- a/src/c/config.h
+++ b/src/c/config.h
@@ -55,6 +55,7 @@ typedef struct edgex_device_deviceinfo
 {
   atomic_bool datatransform;
   atomic_bool discovery_enabled;
+  atomic_bool reading_units;
   _Atomic(uint32_t) discovery_interval;
   _Atomic(uint32_t) maxcmdops;
   _Atomic(uint32_t) maxeventsize;

--- a/src/c/data.c
+++ b/src/c/data.c
@@ -54,6 +54,7 @@ Reading:
   resourceName: String (name of the DeviceResource)
   profileName: String (name of the Device Profile)
   valueType: String
+  units: String (optional, present when ReadingUnits is enabled and configured)
 
 plus
 
@@ -91,7 +92,7 @@ edgex_event_cooked *edgex_data_process_event
   edgex_event_cooked *result = NULL;
   bool useCBOR = false;
   uint64_t timenow = iot_time_nsecs ();
-  
+
   for (uint32_t i = 0; i < commandinfo->nreqs; i++)
   {
     if (commandinfo->pvals[i]->type.type == IOT_DATA_BINARY)

--- a/src/c/data.c
+++ b/src/c/data.c
@@ -84,7 +84,7 @@ edgex_event_cooked *edgex_data_process_event
   iot_data_t *tags,
   bool doTransforms,
   bool reducedEvents,
-  devsdk_service_t *svc
+  bool includeUnits
 )
 {
   char *eventId;
@@ -129,12 +129,6 @@ edgex_event_cooked *edgex_data_process_event
   strcat (result->path, "/");
   strcat (result->path, commandinfo->name);
 
-  //check ReadingUnits configuration
-  bool includeUnits = false;
-  includeUnits = iot_data_string_map_get_bool(svc->config.sdkconf, "Writable/Reading/ReadingUnits", false);
-  printf("DEBUG: CHECKING REGISTRY includeUnits = %s\n", includeUnits ? "true" : "false");
-  
-
   iot_data_t *rvec = iot_data_alloc_vector (commandinfo->nreqs);
   for (uint32_t i = 0; i < commandinfo->nreqs; i++)
   {
@@ -156,18 +150,9 @@ edgex_event_cooked *edgex_data_process_event
     }
     iot_data_string_map_add (rmap, "valueType", iot_data_alloc_string (edgex_typecode_tostring (tc), IOT_DATA_REF));
     // Add units field if ReadingUnits is enabled and the device resource has units configured
-    printf("DEBUG: includeUnits = %s\n", includeUnits ? "true" : "false");
-    printf("DEBUG: commandinfo->pvals[%d]->units = %s\n", i, 
-           commandinfo->pvals[i]->units ? commandinfo->pvals[i]->units : "NULL");
-
     if (includeUnits && commandinfo->pvals[i]->units && *commandinfo->pvals[i]->units)
     {
-      printf("DEBUG: Adding units field: %s\n", commandinfo->pvals[i]->units);
       iot_data_string_map_add (rmap, "units", iot_data_alloc_string (commandinfo->pvals[i]->units, IOT_DATA_REF));
-    }
-    else
-    {
-      printf("DEBUG: NOT adding units field\n");
     }
     // Would check that reading and event origins are different.
     // But event origin will be set to "timenow" below, so we check for that instead.

--- a/src/c/data.c
+++ b/src/c/data.c
@@ -90,7 +90,7 @@ edgex_event_cooked *edgex_data_process_event
   edgex_event_cooked *result = NULL;
   bool useCBOR = false;
   uint64_t timenow = iot_time_nsecs ();
-
+  //somewhere in here implement ReadingUnits
   for (uint32_t i = 0; i < commandinfo->nreqs; i++)
   {
     if (commandinfo->pvals[i]->type.type == IOT_DATA_BINARY)
@@ -127,6 +127,16 @@ edgex_event_cooked *edgex_data_process_event
   strcat (result->path, device->name);
   strcat (result->path, "/");
   strcat (result->path, commandinfo->name);
+
+  //check ReadingUnits configuration
+  bool includeUnits = false;
+  if (device && device->devimpl && device->devimpl->service) {
+    //access the ReadingUnits configuration
+    const iot_data_t *sdkconf = device->devimpl->service->config.sdkconf;
+    if (sdkconf) {
+        includeUnits = iot_data_string_map_get_bool(sdkconf, "Writable/Reading/ReadingUnits", false);
+    }
+  }
 
   iot_data_t *rvec = iot_data_alloc_vector (commandinfo->nreqs);
   for (uint32_t i = 0; i < commandinfo->nreqs; i++)

--- a/src/c/data.c
+++ b/src/c/data.c
@@ -83,14 +83,15 @@ edgex_event_cooked *edgex_data_process_event
   devsdk_commandresult *values,
   iot_data_t *tags,
   bool doTransforms,
-  bool reducedEvents
+  bool reducedEvents,
+  devsdk_service_t *svc
 )
 {
   char *eventId;
   edgex_event_cooked *result = NULL;
   bool useCBOR = false;
   uint64_t timenow = iot_time_nsecs ();
-  //somewhere in here implement ReadingUnits
+  
   for (uint32_t i = 0; i < commandinfo->nreqs; i++)
   {
     if (commandinfo->pvals[i]->type.type == IOT_DATA_BINARY)
@@ -130,13 +131,9 @@ edgex_event_cooked *edgex_data_process_event
 
   //check ReadingUnits configuration
   bool includeUnits = false;
-  if (device && device->devimpl && device->devimpl->service) {
-    //access the ReadingUnits configuration
-    const iot_data_t *sdkconf = device->devimpl->service->config.sdkconf;
-    if (sdkconf) {
-        includeUnits = iot_data_string_map_get_bool(sdkconf, "Writable/Reading/ReadingUnits", false);
-    }
-  }
+  includeUnits = iot_data_string_map_get_bool(svc->config.sdkconf, "Writable/Reading/ReadingUnits", false);
+  printf("DEBUG: CHECKING REGISTRY includeUnits = %s\n", includeUnits ? "true" : "false");
+  
 
   iot_data_t *rvec = iot_data_alloc_vector (commandinfo->nreqs);
   for (uint32_t i = 0; i < commandinfo->nreqs; i++)
@@ -158,6 +155,20 @@ edgex_event_cooked *edgex_data_process_event
       iot_data_string_map_add (rmap, "resourceName", iot_data_alloc_string (commandinfo->reqs[i].resource->name, IOT_DATA_REF));
     }
     iot_data_string_map_add (rmap, "valueType", iot_data_alloc_string (edgex_typecode_tostring (tc), IOT_DATA_REF));
+    // Add units field if ReadingUnits is enabled and the device resource has units configured
+    printf("DEBUG: includeUnits = %s\n", includeUnits ? "true" : "false");
+    printf("DEBUG: commandinfo->pvals[%d]->units = %s\n", i, 
+           commandinfo->pvals[i]->units ? commandinfo->pvals[i]->units : "NULL");
+
+    if (includeUnits && commandinfo->pvals[i]->units && *commandinfo->pvals[i]->units)
+    {
+      printf("DEBUG: Adding units field: %s\n", commandinfo->pvals[i]->units);
+      iot_data_string_map_add (rmap, "units", iot_data_alloc_string (commandinfo->pvals[i]->units, IOT_DATA_REF));
+    }
+    else
+    {
+      printf("DEBUG: NOT adding units field\n");
+    }
     // Would check that reading and event origins are different.
     // But event origin will be set to "timenow" below, so we check for that instead.
     if ((!reducedEvents) || ((values[i].origin != 0) && (values[i].origin != timenow)))

--- a/src/c/data.h
+++ b/src/c/data.h
@@ -39,7 +39,8 @@ edgex_event_cooked *edgex_data_process_event
   devsdk_commandresult *values,
   iot_data_t *tags,
   bool doTransforms,
-  bool reducedEvents
+  bool reducedEvents,
+  devsdk_service_t *svc
 );
 
 void edgex_data_client_add_event (edgex_bus_t *bus, edgex_event_cooked *eventval, devsdk_metrics_t *metrics);

--- a/src/c/data.h
+++ b/src/c/data.h
@@ -40,7 +40,7 @@ edgex_event_cooked *edgex_data_process_event
   iot_data_t *tags,
   bool doTransforms,
   bool reducedEvents,
-  devsdk_service_t *svc
+  bool includeUnits
 );
 
 void edgex_data_client_add_event (edgex_bus_t *bus, edgex_event_cooked *eventval, devsdk_metrics_t *metrics);

--- a/src/c/device.c
+++ b/src/c/device.c
@@ -418,7 +418,7 @@ static edgex_event_cooked *edgex_device_runget2
     if (svc->userfns.gethandler (svc->userdata, dev->devimpl, cmdinfo->nreqs, cmdinfo->reqs, results, &tags, params, &e))
     {
       devsdk_error err = EDGEX_OK;
-      result = edgex_data_process_event (dev, cmdinfo, results, tags, svc->config.device.datatransform, svc->reduced_events, svc);
+      result = edgex_data_process_event (dev, cmdinfo, results, tags, svc->config.device.datatransform, svc->reduced_events, iot_data_string_map_get_bool(svc->config.sdkconf, "Writable/Reading/ReadingUnits", false));
 
       if (result)
       {
@@ -719,7 +719,7 @@ static edgex_event_cooked *edgex_device_runget3 (devsdk_service_t *svc, edgex_de
     if (svc->userfns.gethandler (svc->userdata, dev->devimpl, cmdinfo->nreqs, cmdinfo->reqs, results, &tags, params, &e))
     {
       devsdk_error err = EDGEX_OK;
-      result = edgex_data_process_event (dev, cmdinfo, results, tags, svc->config.device.datatransform, svc->reduced_events, svc);
+      result = edgex_data_process_event (dev, cmdinfo, results, tags, svc->config.device.datatransform, svc->reduced_events, iot_data_string_map_get_bool(svc->config.sdkconf, "Writable/Reading/ReadingUnits", false));
       if (result)
       {
         if (svc->config.device.updatelastconnected)

--- a/src/c/device.c
+++ b/src/c/device.c
@@ -418,7 +418,7 @@ static edgex_event_cooked *edgex_device_runget2
     if (svc->userfns.gethandler (svc->userdata, dev->devimpl, cmdinfo->nreqs, cmdinfo->reqs, results, &tags, params, &e))
     {
       devsdk_error err = EDGEX_OK;
-      result = edgex_data_process_event (dev, cmdinfo, results, tags, svc->config.device.datatransform, svc->reduced_events);
+      result = edgex_data_process_event (dev, cmdinfo, results, tags, svc->config.device.datatransform, svc->reduced_events, svc);
 
       if (result)
       {
@@ -719,7 +719,7 @@ static edgex_event_cooked *edgex_device_runget3 (devsdk_service_t *svc, edgex_de
     if (svc->userfns.gethandler (svc->userdata, dev->devimpl, cmdinfo->nreqs, cmdinfo->reqs, results, &tags, params, &e))
     {
       devsdk_error err = EDGEX_OK;
-      result = edgex_data_process_event (dev, cmdinfo, results, tags, svc->config.device.datatransform, svc->reduced_events);
+      result = edgex_data_process_event (dev, cmdinfo, results, tags, svc->config.device.datatransform, svc->reduced_events, svc);
       if (result)
       {
         if (svc->config.device.updatelastconnected)

--- a/src/c/device.c
+++ b/src/c/device.c
@@ -418,7 +418,7 @@ static edgex_event_cooked *edgex_device_runget2
     if (svc->userfns.gethandler (svc->userdata, dev->devimpl, cmdinfo->nreqs, cmdinfo->reqs, results, &tags, params, &e))
     {
       devsdk_error err = EDGEX_OK;
-      result = edgex_data_process_event (dev, cmdinfo, results, tags, svc->config.device.datatransform, svc->reduced_events, iot_data_string_map_get_bool(svc->config.sdkconf, "Writable/Reading/ReadingUnits", false));
+      result = edgex_data_process_event (dev, cmdinfo, results, tags, svc->config.device.datatransform, svc->reduced_events, svc->config.device.reading_units);
 
       if (result)
       {
@@ -719,7 +719,7 @@ static edgex_event_cooked *edgex_device_runget3 (devsdk_service_t *svc, edgex_de
     if (svc->userfns.gethandler (svc->userdata, dev->devimpl, cmdinfo->nreqs, cmdinfo->reqs, results, &tags, params, &e))
     {
       devsdk_error err = EDGEX_OK;
-      result = edgex_data_process_event (dev, cmdinfo, results, tags, svc->config.device.datatransform, svc->reduced_events, iot_data_string_map_get_bool(svc->config.sdkconf, "Writable/Reading/ReadingUnits", false));
+      result = edgex_data_process_event (dev, cmdinfo, results, tags, svc->config.device.datatransform, svc->reduced_events, svc->config.device.reading_units);
       if (result)
       {
         if (svc->config.device.updatelastconnected)

--- a/src/c/examples/random/res/configuration.yaml
+++ b/src/c/examples/random/res/configuration.yaml
@@ -1,5 +1,7 @@
 Writable:
   LogLevel: DEBUG
+  Reading:
+    ReadingUnits: true
 
 Service:
   Host: localhost

--- a/src/c/service.c
+++ b/src/c/service.c
@@ -1420,7 +1420,7 @@ void devsdk_post_readings
   if (command)
   {
     edgex_event_cooked *event = edgex_data_process_event
-      (dev, command, values, tags, svc->config.device.datatransform, svc->reduced_events, iot_data_string_map_get_bool(svc->config.sdkconf, "Writable/Reading/ReadingUnits", false));
+      (dev, command, values, tags, svc->config.device.datatransform, svc->reduced_events, svc->config.device.reading_units);
 
     if (event)
     {

--- a/src/c/service.c
+++ b/src/c/service.c
@@ -1420,7 +1420,7 @@ void devsdk_post_readings
   if (command)
   {
     edgex_event_cooked *event = edgex_data_process_event
-      (dev, command, values, tags, svc->config.device.datatransform, svc->reduced_events, svc);
+      (dev, command, values, tags, svc->config.device.datatransform, svc->reduced_events, iot_data_string_map_get_bool(svc->config.sdkconf, "Writable/Reading/ReadingUnits", false));
 
     if (event)
     {

--- a/src/c/service.c
+++ b/src/c/service.c
@@ -1400,7 +1400,7 @@ void devsdk_post_readings
   if (command)
   {
     edgex_event_cooked *event = edgex_data_process_event
-      (dev, command, values, tags, svc->config.device.datatransform, svc->reduced_events);
+      (dev, command, values, tags, svc->config.device.datatransform, svc->reduced_events, svc);
 
     if (event)
     {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)

## Testing Instructions
1. Add the ReadingUnits field to the configuration.yaml file for your example under the Writable section and set it to true.
 ```
Writable:
  LogLevel: DEBUG
  Reading:
    ReadingUnits: true
```
2. Customize a device example profile as follows (device-counter for this example):
 a. Under deviceResources, add the units field to the properties, and choose a unit
```
"deviceResources":
  [
    {
      "name": "Counter",
      "description": "A counter generating incrementing values",
      "attributes": { "register": "count01" },
      "properties": { "valueType": "Uint32", "readWrite": "RW", "units": "Kelvin" }
    }
  ]
```
3. Compile and run the example, now, within mqtt explorer or another similar tool, you should be able to see the units field populated as a property of the device.